### PR TITLE
Adds a new key config for RedBot

### DIFF
--- a/code/controllers/configuration/entries/comms.dm
+++ b/code/controllers/configuration/entries/comms.dm
@@ -38,6 +38,7 @@
 /datum/config_entry/string/medal_hub_password
 	protection = CONFIG_ENTRY_HIDDEN
 
-/datum/config_entry/string/comms_key
-
 /datum/config_entry/string/bot_ip
+
+/datum/config_entry/string/bot_key
+	protection = CONFIG_ENTRY_HIDDEN | CONFIG_ENTRY_LOCKED

--- a/config/comms.txt
+++ b/config/comms.txt
@@ -43,3 +43,7 @@
 
 ## Password for the hub page
 #MEDAL_HUB_PASSWORD defaultpass
+
+#BOT_IP 127.0.0.1:8081
+
+#BOT_KEY default_pw

--- a/config/comms.txt
+++ b/config/comms.txt
@@ -44,6 +44,10 @@
 ## Password for the hub page
 #MEDAL_HUB_PASSWORD defaultpass
 
+## Redbot configuration
+## The BOT_IP should be the IP of your Discord bot and the configured listening port of the status cog.
+## Verify the port with [p]setstatus current (where [p] is your bot's prefix)
 #BOT_IP 127.0.0.1:8081
 
+## Password/token used to verify packets to and from the Discord bot
 #BOT_KEY default_pw

--- a/monkestation/code/controllers/subsystem/redbot.dm
+++ b/monkestation/code/controllers/subsystem/redbot.dm
@@ -3,7 +3,7 @@ SUBSYSTEM_DEF(redbot)
 	flags = SS_NO_FIRE
 
 /datum/controller/subsystem/redbot/Initialize(timeofday)
-	var/comms_key = CONFIG_GET(string/comms_key)
+	var/comms_key = CONFIG_GET(string/bot_key)
 	var/bot_ip = CONFIG_GET(string/bot_ip)
 	var/round_id = GLOB.round_id
 	if(config && bot_ip)
@@ -21,7 +21,7 @@ SUBSYSTEM_DEF(redbot)
 	if(priority_type && !.)
 		send_discord_message(channel, "@here - A new [priority_type] requires/might need attention, but there are no admins online.") //Backup message should redbot be unavailable
 	var/list/data = list()
-	data["key"] = CONFIG_GET(string/comms_key)
+	data["key"] = CONFIG_GET(string/bot_key)
 	data["announce_channel"] = channel
 	data["announce"] = message
 	world.Export("http://[bot_ip]/?[list2params(data)]")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The documented subsystem did not account for the updated topic-API. This adds a new protected string config to act as an authenticating token between the game server and the Discord bot. Eventually this will be replaced and the topic-API will be fully integrated; but, this'll keep things working until then.

For the host, ensure that both the `BOT_IP` and `BOT_KEY` options are present and set within your `comms.txt` file. The IP entry should be an `IP:Port` matching your bot's settings (e.g. `127.0.0.1:8081` if the bot is on the same machine as the game server and you're using the default listening port)

## Testing Photographs and Procedure

1. Setup a local RedBot instance with the `status` cog loaded and configured
2. Configured the game server to use the following settings:
   1. `BOT_IP 127.0.0.1:8081`
   2. `BOT_KEY 5fQ3VXQaeX5tqOTXIOsUnQe5zTCgyAnx`
3. Started the game server and confirmed that there were no runtimes on init
4. Waited for the redbot subsystem to trigger and confirmed that the bot received and processed the incoming message

<details>

<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/26130695/152709825-2d3b0e18-ce3c-4c13-9d45-fcfcd23418a2.png)

</details>

## Changelog
:cl:
server: Added a bot_key entry to the communications config for RedBot
fix: Removes the erroneous comms_key datum to resolve initialization runtimes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
