### PR TITLE
Fixes Mailbags

### DIFF
--- a/monkestation/code/game/objects/items/mail.dm
+++ b/monkestation/code/game/objects/items/mail.dm
@@ -320,14 +320,11 @@
 /obj/item/storage/bag/mail/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/storage = GetComponent(/datum/component/storage)
-	storage.max_w_class = WEIGHT_CLASS_NORMAL
-	storage.max_combined_w_class = 42
-	storage.max_items = 21
+	storage.max_w_class = WEIGHT_CLASS_SMALL
+	storage.max_combined_w_class = 30
+	storage.max_items = 30
 	storage.display_numerical_stacking = FALSE
-	storage.can_hold = list(
-		/obj/item/mail,
-		/obj/item/smallDelivery,
-		/obj/item/paper)
+	storage.can_hold = typecacheof(list(/obj/item/mail, /obj/item/smallDelivery, /obj/item/paper))
 
 /obj/item/paper/fluff/junkmail_redpill
 	name = "smudged paper"


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Mailbags will now actually hold 15 pieces of mail. Didn't have the typecache set up properly.

## Why It's Good For The Game

FIRST OF MANY BUGFIXES!

closes #93
## Changelog

:cl:
fix: Mailbags hold letters finally, get out there and deliver!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
