### PR TITLE
Fixes mk2 assistant envirohelm icons

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -470,8 +470,8 @@
 /obj/item/clothing/head/helmet/space/plasmaman/mark2
 	name = "Mk.II envirosuit helmet"
 	desc = "A sleek new plasmaman containment helmet, painted in classic Hazardous Orange."
-	icon_state = "assistant_openvirohelm"
-	item_state = "assistant_openvirohelm"
+	icon_state = "openvirohelm"
+	item_state = "openvirohelm"
 	visor_icon = "openvisor"
 
 /obj/item/clothing/head/helmet/space/plasmaman/security/mark2


### PR DESCRIPTION
Looks like it wanted assistant_openvirohelm... which doesn't actually exist in the files.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Makes the mkii sprite for the plasmaman envirohelm visible

## Why It's Good For The Game

Being able to see your helmet on a race that requires helmets is very convenient
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
-->
closes #108

## Testing Photographs and Procedure
<!--
Include any screenshots, videos, etc. of you testing your code with it successfully functioning.
Ideally testing should cover:
Intended use cases(IE: if you are making a shotgun, test it as you intend for it to be used.)
Potential edge cases(IE: try loading different ammo than you designed for into the shotgun.)
Please include the steps you went through for the testing(videos are exempt so long as we can see everything being done in frame). Said steps can also help us help you with any issues you encounter during development.
Pulls from Upstream are generally exempt from this.
-->
<details>

<summary>Screenshots&Videos</summary>

Put screenshots and Videos documenting testing and execution of intended behaviors here

</details>

## Changelog

:cl:
fix: fixed the MKII assistant envirohelm sprite
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
