### PR TITLE
Florida Rebalance

### DIFF
--- a/monkestation/code/modules/antagonists/florida_man/florida_man.dm
+++ b/monkestation/code/modules/antagonists/florida_man/florida_man.dm
@@ -8,18 +8,21 @@
 
 /datum/antagonist/florida_man/on_gain()
 	forge_objectives()
-	if(iscarbon(owner.current))
-		var/mob/living/carbon/floridan = owner.current
+	if(ishuman(owner.current))
+		var/mob/living/carbon/human/floridan = owner.current
 
 		//Abilities & Traits added here
 		ADD_TRAIT(floridan, TRAIT_MONKEYLIKE, SPECIES_TRAIT)
-		ADD_TRAIT(floridan, TRAIT_STUNIMMUNE, SPECIES_TRAIT)
+		ADD_TRAIT(floridan, TRAIT_CLUMSY, SPECIES_TRAIT)
+		ADD_TRAIT(floridan, TRAIT_DUMB, SPECIES_TRAIT)
 		ADD_TRAIT(floridan, TRAIT_STABLELIVER, SPECIES_TRAIT)
 		ADD_TRAIT(floridan, TRAIT_STABLEHEART, SPECIES_TRAIT)
 		ADD_TRAIT(floridan, TRAIT_TOXIMMUNE, SPECIES_TRAIT)
 		ADD_TRAIT(floridan, TRAIT_JAILBIRD, SPECIES_TRAIT)
 		ADD_TRAIT(floridan, TRAIT_IGNORESLOWDOWN, SPECIES_TRAIT)
 
+		floridan.physiology.stamina_mod = 0.25
+		floridan.physiology.stun_mod = 0.25
 		floridan.ventcrawler = 1
 		var/obj/effect/proc_holder/spell/targeted/florida_doorbuster/DB = new
 		var/obj/effect/proc_holder/spell/targeted/florida_cuff_break/CB = new

--- a/monkestation/code/modules/antagonists/florida_man/florida_man_abilities.dm
+++ b/monkestation/code/modules/antagonists/florida_man/florida_man_abilities.dm
@@ -32,7 +32,7 @@
 	name = "Break These Cuffs"
 	desc = "You CAN break those cuffs!"
 	charge_counter = 0
-	charge_max = 60 SECONDS
+	charge_max = 2 MINUTES
 	clothes_req = FALSE
 	range = -1
 	include_user = TRUE
@@ -64,7 +64,7 @@
 	name = "Sovereign Citizen"
 	desc = "Use the power of Florida to push your way through"
 	charge_counter = 0
-	charge_max = 20 SECONDS
+	charge_max = 1 MINUTES
 	clothes_req = FALSE
 	range = -1
 	include_user = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Increases the cooldown of Sovereign Citizen and Break These Cuffs.

Adds the Clumsy and Dumb trait to Florida Man.

Removes total stun immunity from Florida Man.
Gives Florida Man 75% stun resistance.

## Why It's Good For The Game
Total immunity BAD.
Great resistance GOOD.

closes #125 

## Changelog

:cl:
balance: Makes Florida Man slightly less powerful.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
