### PR TITLE
Ghosts can no longer be farted on

### DIFF
--- a/monkestation/code/modules/surgery/organs/butts.dm
+++ b/monkestation/code/modules/surgery/organs/butts.dm
@@ -174,7 +174,7 @@
 			return
 
 	//EMOTE MESSAGE/MOB TARGETED FARTS
-	for(var/mob/Targeted in Location)
+	for(var/mob/living/Targeted in Location)
 		if(Targeted != user)
 			to_chat(user,"[user] [pick(
 										"farts in [Targeted]'s face!",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Ghosts can no longer be farted on.
I am literally oppressing gamers here.

## Why It's Good For The Game

HONESTLY I FEEL BAD REMOVING THIS

closes #119 

</details>

## Changelog

:cl:
fix: You may no longer fart on ghosts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
