### PR TITLE
Surgery Restriction Removal

### DIFF
--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -15,9 +15,6 @@
 	if(istype(tool, /obj/item/organ_storage) && istype(tool.contents[1], /obj/item/bodypart))
 		tool = tool.contents[1]
 	var/obj/item/bodypart/aug = tool
-	if(IS_ORGANIC_LIMB(aug))
-		to_chat(user, "<span class='warning'>That's not an augment, silly!</span>")
-		return -1
 	if(aug.body_zone != target_zone)
 		to_chat(user, "<span class='warning'>[tool] isn't the right type for [parse_zone(target_zone)].</span>")
 		return -1

--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -33,21 +33,14 @@
 		tool = I
 	if(istype(tool, /obj/item/bodypart))
 		var/obj/item/bodypart/BP = tool
-		if(ismonkey(target))// monkey patient only accept organic monkey limbs
-			if(!IS_ORGANIC_LIMB(BP) || BP.animal_origin != MONKEY_BODYPART)
-				to_chat(user, "<span class='warning'>[BP] doesn't match the patient's morphology.</span>")
-				return -1
+		//MonkeStation Edit: Monkey limbs attach to humans and vice-reversa.
 		if(IS_ORGANIC_LIMB(BP))
 			organ_rejection_dam = 10
-			if(ishuman(target))
-				if(BP.animal_origin)
-					to_chat(user, "<span class='warning'>[BP] doesn't match the patient's morphology.</span>")
-					return -1
-				var/mob/living/carbon/human/H = target
-				if(H.dna.species.id != BP.limb_id)
-					organ_rejection_dam = 30
+			var/mob/living/carbon/human/H = target
+			if(H.dna.species.id != BP.limb_id)
+				organ_rejection_dam = 30
 
-		if(target_zone == BP.body_zone) //so we can't replace a leg with an arm, or a human arm with a monkey arm.
+		if(target_zone == BP.body_zone) //MonkeStation Edit: so we CAN replace a human arm with a monkey arm
 			display_results(user, target, "<span class ='notice'>You begin to replace [target]'s [parse_zone(target_zone)] with [tool]...</span>",
 				"[user] begins to replace [target]'s [parse_zone(target_zone)] with [tool].",
 				"[user] begins to replace [target]'s [parse_zone(target_zone)].")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

You may now attach monkey limbs to humans and human limbs to monkeys.

## Why It's Good For The Game

With an incoming monkey species, we need to blur the lines between "human" and monkey a bit so that we don't need to overhaul surgery entirely for one species.

It also will allow AMAZINGLY cursed limb combinations now.

Every cigarette takes 17 minutes off your life.
Every slice of bacon takes nine minutes off your life.
If you smoke and eat bacon fast enough, you can go back in time.

## Changelog

:cl:
add: You may now attach monkey limbs to humans and human limbs to monkeys.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
