### PR TITLE
Manifest Name Fix

### DIFF
--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -43,7 +43,7 @@
 	var/obj/item/paper/P = new(T)
 
 	P.name = "requisition form - #[id] ([pack.name])"
-	P.info += "<h2>[station_name()] Supply Requisition</h2>"
+	P.info += "<h2>[GLOB.station_name] Supply Requisition</h2>" //MonkeStation Edit, fixes broken manifests.
 	P.info += "<hr/>"
 	P.info += "Order #[id]<br/>"
 	P.info += "Item: [pack.name]<br/>"
@@ -60,7 +60,7 @@
 /datum/supply_order/proc/generateManifest(obj/structure/closet/crate/C, var/owner, var/packname) //generates-the-manifests.
 	var/obj/item/paper/fluff/jobs/cargo/manifest/P = new(C, id, 0)
 
-	var/station_name = (P.errors & MANIFEST_ERROR_NAME) ? new_station_name() : station_name()
+	var/station_name = (P.errors & MANIFEST_ERROR_NAME) ? new_station_name() : GLOB.station_name //MonkeStation Edit, fixes broken manifests when they aren't in error.
 
 	P.name = "shipping manifest - [packname?"#[id] ([pack.name])":"(Grouped Item Crate)"]"
 	P.info += "<h2>[command_name()] Shipping Manifest</h2>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Makes it so cargo manifests without errors will use the actual station name, rather than a generated name.

## Why It's Good For The Game

A bug fix for a minor issue is good.
Now you must play as Reads-The-Manifests.

closes #131

## Changelog

:cl:
fix: Cargo manifests now show the station name correctly, unless in error.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
