### PR TITLE
Hat Stacking

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3533,6 +3533,7 @@
 #include "monkestation\code\modules\cargo\packs.dm"
 #include "monkestation\code\modules\cargo\supplypod.dm"
 #include "monkestation\code\modules\clothing\head\helmet.dm"
+#include "monkestation\code\modules\clothing\head\misc.dm"
 #include "monkestation\code\modules\clothing\head\misc_special.dm"
 #include "monkestation\code\modules\clothing\masks\breath.dm"
 #include "monkestation\code\modules\clothing\masks\miscellaneous.dm"

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -14,6 +14,8 @@
 	if(ishuman(loc) && dynamic_hair_suffix)
 		var/mob/living/carbon/human/H = loc
 		H.update_hair()
+	verbs -= /obj/item/clothing/head/verb/detach_stacked_hat	//MonkeStation Edit: Hat Stacking
+
 
 ///Special throw_impact for hats to frisbee hats at people to place them on their heads/attempt to de-hat them.
 /obj/item/clothing/head/throw_impact(atom/hit_atom, datum/thrownthing/thrownthing)
@@ -67,6 +69,18 @@
 			. += mutable_appearance('icons/effects/item_damage.dmi', "damagedhelmet")
 		if(HAS_BLOOD_DNA(src))
 			. += mutable_appearance('icons/effects/blood.dmi', "helmetblood")
+	//MonkeStation Edit: Hat Stacking
+		if(contents)
+			var/current_hat = 1
+			for(var/obj/item/clothing/head/selected_hat in contents)
+				var/head_icon = 'icons/mob/clothing/head.dmi'
+				if(selected_hat.worn_icon)
+					head_icon = selected_hat.icon
+				var/mutable_appearance/hat_adding = selected_hat.build_worn_icon(HEAD_LAYER, head_icon, FALSE, FALSE)
+				hat_adding.pixel_y = ((current_hat * 4) - 1)
+				current_hat++
+				. += hat_adding
+	//MonkeStation Edit End
 
 /obj/item/clothing/head/update_clothes_damaged_state(damaging = TRUE)
 	..()

--- a/monkestation/code/modules/clothing/head/misc.dm
+++ b/monkestation/code/modules/clothing/head/misc.dm
@@ -1,0 +1,93 @@
+#define HAT_CAP 20 //Maximum number of hats stacked upon the base hat.
+#define ADD_HAT 0
+#define REMOVE_HAT 1
+
+/obj/item/clothing/head/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/clothing/head))
+		if(contents) 					//Checking for previous hats and preventing towers that are too large
+			if(I.contents)
+				if(I.contents.len + contents.len + 1 > HAT_CAP)
+					to_chat(user,"<span class='warning'>You think that this hat tower is perfect the way it is and decide against adding another.</span>")
+					return
+				for(var/obj/item/clothing/head/hat_movement in I.contents)
+					hat_movement.name = initial(name)
+					hat_movement.desc = initial(desc)
+					hat_movement.forceMove(src)
+			var/hat_count = contents.len
+			if(hat_count + 1 > HAT_CAP)
+				to_chat(user,"<span class='warning'>You think that this hat tower is perfect the way it is and decide against adding another.</span>")
+				return
+		var/obj/item/clothing/head/new_hat = I
+		if(user.transferItemToLoc(new_hat,src)) //Moving the new hat to the base hat's contents
+			to_chat(user, "<span class='notice'>You place the [new_hat] upon the [src].</span>")
+			update_hats(ADD_HAT, user)
+	else
+		. = ..()
+
+
+/obj/item/clothing/head/verb/detach_stacked_hat()
+	set name = "Remove Stacked Hat"
+	set category = "Object"
+	set src in usr
+	if(src.contents)
+		update_hats(REMOVE_HAT,usr)
+
+/obj/item/clothing/head/proc/restore_initial() //Why can't initial() be called directly by something?
+	name = initial(name)
+	desc = initial(desc)
+
+/obj/item/clothing/head/proc/update_hats(var/hat_removal, var/mob/living/user)
+	if(hat_removal)
+		var/obj/item/clothing/head/hat_to_remove = contents[contents.len] //Get the last item in the hat and hand it to the user.
+		hat_to_remove.restore_initial()
+		hat_to_remove.verbs -= /obj/item/clothing/head/verb/detach_stacked_hat
+		user.put_in_hands(hat_to_remove)
+
+	cut_overlays()
+	if(contents)
+		var/current_hat = 1
+		for(var/obj/item/clothing/head/selected_hat in contents)
+			selected_hat.cut_overlays()
+			selected_hat.forceMove(src)
+			selected_hat.name = initial(name)
+			selected_hat.desc = initial(desc)
+			var/mutable_appearance/hat_adding = mutable_appearance(selected_hat.icon, "[initial(selected_hat.icon_state)]")
+			hat_adding.pixel_y = ((current_hat * 6) - 1)
+			current_hat++
+			add_overlay(hat_adding)
+		verbs += /obj/item/clothing/head/verb/detach_stacked_hat
+		switch(contents.len)
+			if(0)
+				name = initial(name)
+				desc = initial(desc)
+			if (1,2)
+				name = "Pile of Hats"
+				desc = "A meagre pile of hats"
+			if (3)
+				name = "Stack of Hats"
+				desc = "A decent stack of hats"
+			if(5,6)
+				name = "Towering Pillar of Hats"
+				desc = "A magnificent display of pride and wealth"
+			if(7,8)
+				name = "A Dangerous Amount of Hats"
+				desc = "A truly grand tower of hats"
+			if(9,10)
+				name = "A Lesser Hatularity"
+				desc = "A tower approaching unstable levels of hats"
+			if(11,12,13,14,15)
+				name = "A Hatularity"
+				desc = "A tower that has grown far too powerful"
+			if(16,17,18,19)
+				name = "A Greater Hatularity"
+				desc = "A monument to the madness of man"
+			if(20)
+				name = "The True Hat Tower"
+				desc = "<span class='narsiesmall'>AFTER NINE YEARS IN DEVELOPMENT, HOPEFULLY IT WILL HAVE BEEN WORTH THE WAIT</span>"
+	worn_overlays()
+	user.update_inv_head()
+
+
+#undef HAT_CAP
+#undef ADD_HAT
+#undef REMOVE_HAT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Hats may now be stacked up to 20 high with only the base hat's armor and stats used for any gameplay.
AKA: A tower of helmets only has the armor of ONE helmet.

Removal of hats is handled by an Object verb.

The cap of 20 can be modified on-compile as it is a define.

## Why It's Good For The Game

Welcome to Team Fortress 2. 
After nine years in development, hopefully it will have been worth the wait. 

To listen to a commentary node, put your crosshair over the floating commentary symbol and press your primary fire. 
To stop a commentary node, put your crosshair over the rotating node and press your primary fire again. 
Some commentary nodes may take control of the game in order to show something to you. 
In these cases, simply press your primary fire again to stop the commentary. 
In addition, your secondary fire will cycle you through all the commentary nodes in the level.

Please let me know what you think after you have had a chance to play. 
My favorite class is the Spy.

Thanks, and have fun!

## Changelog

:cl:
add: The ability to stack hats.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
