### PR TITLE
Butt Bugfixes

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3566,6 +3566,7 @@
 #include "monkestation\code\modules\reagents\reagent_containers\medspray.dm"
 #include "monkestation\code\modules\reagents\reagent_containers\spray.dm"
 #include "monkestation\code\modules\research\designs\biogenerator_designs.dm"
+#include "monkestation\code\modules\research\designs\medical_designs.dm"
 #include "monkestation\code\modules\research\techweb\_techweb.dm"
 #include "monkestation\code\modules\surgery\organs\butts.dm"
 #include "monkestation\code\modules\uplink\uplink_items.dm"

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -2,7 +2,7 @@
 	name = "alien"
 	icon_state = "alien"
 	pass_flags = PASSTABLE
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/xeno = 5, /obj/item/stack/sheet/animalhide/xeno = 1)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/xeno = 5, /obj/item/stack/sheet/animalhide/xeno = 1, /obj/item/organ/butt/xeno = 1) //MonkeStation Edit: Xeno Butt
 	possible_a_intents = list(INTENT_HELP, INTENT_DISARM, INTENT_GRAB, INTENT_HARM)
 	limb_destroyer = 1
 	hud_type = /datum/hud/alien

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -9,7 +9,7 @@
 	mob_size = MOB_SIZE_LARGE
 	layer = LARGE_MOB_LAYER //above most mobs, but below speechbubbles
 	pressure_resistance = 200 //Because big, stompy xenos should not be blown around like paper.
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/xeno = 20, /obj/item/stack/sheet/animalhide/xeno = 3)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/xeno = 20, /obj/item/stack/sheet/animalhide/xeno = 3, /obj/item/organ/butt/xeno = 1) //MonkeStation Edit: Xeno Butt
 
 	var/alt_inhands_file = 'icons/mob/alienqueen.dmi'
 	var/game_end_timer

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -29,6 +29,7 @@
 
 /mob/living/carbon/alien/larva/create_internal_organs()
 	internal_organs += new /obj/item/organ/alien/plasmavessel/small/tiny
+	//If you came here looking for Larva ass, shame on you.
 	..()
 
 //This needs to be fixed

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -12,7 +12,7 @@
 	response_harm = "hits"
 	speed = 0
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/xeno = 4,
-							/obj/item/stack/sheet/animalhide/xeno = 1)
+							/obj/item/stack/sheet/animalhide/xeno = 1, /obj/item/organ/butt/xeno = 1) //MonkeStation Edit: Xeno Ass
 	maxHealth = 125
 	health = 125
 	obj_damage = 60
@@ -85,7 +85,7 @@
 	minimum_distance = 5
 	move_to_delay = 4
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/xeno = 4,
-							/obj/item/stack/sheet/animalhide/xeno = 1)
+							/obj/item/stack/sheet/animalhide/xeno = 1, /obj/item/organ/butt/xeno = 1) //MonkeStation Edit: Xeno Ass
 	projectiletype = /obj/item/projectile/neurotox
 	projectilesound = 'sound/weapons/pierce.ogg'
 	status_flags = 0
@@ -135,7 +135,7 @@
 	maxHealth = 400
 	health = 400
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/xeno = 10,
-							/obj/item/stack/sheet/animalhide/xeno = 2)
+							/obj/item/stack/sheet/animalhide/xeno = 2, /obj/item/organ/butt/xeno = 1) //MonkeStation Edit: Xeno Ass
 	mob_size = MOB_SIZE_LARGE
 	gold_core_spawnable = NO_SPAWN
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -211,7 +211,7 @@
 	display_name = "Basic Bluespace Theory"
 	description = "Basic studies into the mysterious alternate dimension known as bluespace."
 	prereq_ids = list("base")
-	design_ids = list("beacon", "dragnetbeacon", "xenobioconsole", "telesci_gps", "bluespace_crystal")
+	design_ids = list("beacon", "dragnetbeacon", "xenobioconsole", "telesci_gps", "bluespace_crystal", "bluespace_ass") //MonkeStation Edit: Bluespace Asses
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 

--- a/monkestation/code/modules/mob/living/carbon/human/emote.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/emote.dm
@@ -13,7 +13,7 @@
 	if(booty.cooling_down)
 		return
 	booty.cooling_down = TRUE
-	var/turf/Location
+	var/turf/Location = get_turf(ass_holder)
 
 	//BIBLEFART/
 	//This goes above all else because it's an instagib.

--- a/monkestation/code/modules/research/designs/medical_designs.dm
+++ b/monkestation/code/modules/research/designs/medical_designs.dm
@@ -1,0 +1,10 @@
+/datum/design/bluespace_ass
+	name = "Bluespace Posterior"
+	desc = "An advanced form of posterior."
+	id = "bluespace_ass"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 1700, /datum/material/glass = 1350, /datum/material/gold = 500, /datum/material/bluespace = 1000)
+	construction_time = 75
+	build_path = /obj/item/organ/butt/bluespace
+	category = list("Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE

--- a/monkestation/code/modules/surgery/organs/butts.dm
+++ b/monkestation/code/modules/surgery/organs/butts.dm
@@ -42,6 +42,7 @@
 			spawn(120)
 				Location = get_turf(user)
 				dyn_explosion(Location, 20,10)
+				cooling_down = FALSE
 		else
 			playsound(user, pick(sound_effect), 50, TRUE)
 			Location.atmos_spawn_air(atmos_gas)
@@ -162,21 +163,21 @@
 			var/turf/T = get_step(get_step(Person, NORTH), NORTH)
 			T.Beam(Person, icon_state="lightning[rand(1,12)]", time = 15)
 			Person.Paralyze(15)
-			to_chat(Person, "<span class='warning'>[Person] attempts to fart on the [Holy], uh oh.<span>")
+			Person.visible_message("<span class='warning'>[Person] attempts to fart on the [Holy], uh oh.<span>","<span class='ratvar'>What a grand and intoxicating innocence. Perish.</span>")
 			playsound(user,'sound/magic/lightningshock.ogg', 50, 1)
 			playsound(user,	'monkestation/sound/misc/dagothgod.ogg', 80)
 			Person.electrocution_animation(15)
 			spawn(15)
-				to_chat(Person,"<span class='ratvar'>What a grand and intoxicating innocence. Perish.</span>")
 				Person.gib()
 				dyn_explosion(Location, 1, 0)
 				cooling_down = FALSE
 			return
 
 	//EMOTE MESSAGE/MOB TARGETED FARTS
+	var/hit_target = FALSE
 	for(var/mob/living/Targeted in Location)
 		if(Targeted != user)
-			to_chat(user,"[user] [pick(
+			user.visible_message("[user] [pick(
 										"farts in [Targeted]'s face!",
 										"gives [Targeted] the silent but deadly treatment!",
 										"rips mad ass in [Targeted]'s mug!",
@@ -185,9 +186,10 @@
 										"poots, singing [Targeted]'s eyebrows!",
 										"humiliates [Targeted] like never before!",
 										"gets real close to [Targeted]'s face and cuts the cheese!")]")
+			hit_target = TRUE
 			break
-		else
-			user.audible_message("[pick(
+	if(!hit_target)
+		user.audible_message("[pick(
 								"rears up and lets loose a fart of tremendous magnitude!",
 								"farts!",
 								"toots.",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Fixes a number of bugs found with the ass system:

## Why It's Good For The Game

And I heard a voice in the midst of the four beasts
And I looked, and behold, a pale horse
And his name, that sat on him, was Death

And farts followed with him.

closes #148 
closes #153 


## Changelog

:cl:
fix: Fixes double messages when farting on someone.
fix: Fixes messages not appearing for players when farting.
fix: Atomic Asses now reset properly upon detonation.
fix: Superfarting on a bible will kill you properly.
add: Bluespace Asses may now be researched and built.
add: Xenomorphs can now be butchered for their ass. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
