### PR TITLE
Increase of Florida Man spawn

### DIFF
--- a/monkestation/code/modules/antagonists/florida_man/florida_man_event.dm
+++ b/monkestation/code/modules/antagonists/florida_man/florida_man_event.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/florida_man
 	name = "Florida Man"
 	typepath = /datum/round_event/ghost_role/florida_man
-	weight = 5
+	weight = 14
 	max_occurrences = 3
 
 /datum/round_event/ghost_role/florida_man


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Gives Florida Man an equal chance to randomly trigger as an Abductor team.
Original weight made him rarer than a space ninja!

## Why It's Good For The Game

This is one of our unique features and is sadly too rare.
I don't consider him as deadly as some of the antagonist types out there, so the weight could be increased.

## Changelog

:cl:
tweak: Your station has been moved closer to Space Florida. Expect more visitors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
