### PR TITLE
make dizziness use screen_shake, add additional override

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -440,7 +440,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 
 	//Dizziness
 	if(dizziness)
-		shake_camera(src, dizziness/10, 1, 8)
+		shake_camera(src, 8, 1, 8)
 		dizziness = max(dizziness - restingpwr, 0)
 	if(drowsyness)
 		drowsyness = max(drowsyness - restingpwr, 0)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -440,28 +440,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 
 	//Dizziness
 	if(dizziness)
-		var/client/C = client
-		var/temp_x
-		var/temp_y
-		var/saved_dizz = dizziness
-		if(C)
-			var/amplitude = dizziness * world.time * 0.00035
-			spawn(0)
-				if(C)
-					temp_x = amplitude * sin(saved_dizz  * world.time * 0.5)
-					temp_y = amplitude * cos(saved_dizz  * world.time * 2)
-					if(temp_x > 128) // add a cap to this shit
-						temp_x = 128
-					if(temp_y > 128)
-						temp_y = 128
-					animate(C, QUAD_EASING, pixel_x = temp_x)
-					sleep(3)
-					animate(C, QUAD_EASING, pixel_y = temp_y)
-					sleep(3)
-					animate(C, QUAD_EASING, pixel_x = 0, pixel_y = 0)
-					if(C)
-						C.pixel_x = 0
-						C.pixel_y = 0
+		shake_camera(src, dizziness/10, 1, 8)
 		dizziness = max(dizziness - restingpwr, 0)
 	if(drowsyness)
 		drowsyness = max(drowsyness - restingpwr, 0)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -256,7 +256,7 @@
 	return sanitize(.)
 
 ///Shake the camera of the person viewing the mob SO REAL!
-/proc/shake_camera(mob/M, duration, strength=1)
+/proc/shake_camera(mob/M, duration, strength=1, time=1) //monkestation edit: add time argument for more proc usage
 	if(!M || !M.client || duration < 1)
 		return
 	var/client/C = M.client
@@ -267,10 +267,10 @@
 
 	for(var/i in 0 to duration-1)
 		if (i == 0)
-			animate(C, pixel_x=rand(min,max), pixel_y=rand(min,max), time=1)
+			animate(C, pixel_x=rand(min,max), pixel_y=rand(min,max), time)
 		else
-			animate(pixel_x=rand(min,max), pixel_y=rand(min,max), time=1)
-	animate(pixel_x=oldx, pixel_y=oldy, time=1)
+			animate(pixel_x=rand(min,max), pixel_y=rand(min,max), time)
+	animate(pixel_x=oldx, pixel_y=oldy, time)
 
 
 ///Find if the message has the real name of any user mob in the mob_list


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
see title, will add picture soon(tm)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
My original "fix" didn't work the same way server side.  This approach uses the screen_shake() proc to drive dizziness.  Moreover, it now has a static effect that doesn't increase in severity; higher dizziness only means longer duration.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
Also put closed issues under this tag, if any. Format is as follows(must be lowercase):
closes #123456789
-->

## Testing Photographs and Procedure
<!--
Include any screenshots, videos, etc. of you testing your code with it successfully functioning.
Ideally testing should cover:
Intended use cases(IE: if you are making a shotgun, test it as you intend for it to be used.)
Potential edge cases(IE: try loading different ammo than you designed for into the shotgun.)
Please include the steps you went through for the testing(videos are exempt so long as we can see everything being done in frame). Said steps can also help us help you with any issues you encounter during development.
Pulls from Upstream are generally exempt from this.
-->
<details>

<summary>Screenshots&Videos</summary>

Put screenshots and Videos documenting testing and execution of intended behaviors here

</details>

## Changelog

:cl:
tweak: dizziness effect
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
