### PR TITLE
Surgery & Abductor Fixes

### DIFF
--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -801,7 +801,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	/// Amount to inject per second
 	var/inject_am = 0.5
 
-	var/static/list/injected_reagents = list(/datum/reagent/medicine/corazone)
+	var/static/list/injected_reagents = list(/datum/reagent/medicine/corazone, /datum/reagent/space_cleaner/sterilizine, /datum/reagent/consumable/ethanol) //MonkeStation Edit: Sterilizing Abductors
 
 /obj/structure/table/optable/abductor/Initialize(mapload)
 	. = ..()
@@ -821,6 +821,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	. = PROCESS_KILL
 	for(var/mob/living/carbon/C in get_turf(src))
 		. = TRUE
+		C.drunkenness = 49 //MonkeStation Edit: UFOs don't exist, just smell the alcohol on his breath!
 		for(var/chemical in injected_reagents)
 			if(C.reagents.get_reagent_amount(chemical) < inject_am * delta_time)
 				C.reagents.add_reagent(chemical, inject_am * delta_time)

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -108,7 +108,7 @@
 
 	if(do_after(user, modded_time, target = target))
 
-		if((prob(0 + success_prob) || iscyborg(user) || HAS_TRAIT(user, TRAIT_SURGEON)) && chem_check(target) && !try_to_fail)
+		if(accept_hand || (prob(0 + success_prob) || iscyborg(user) || HAS_TRAIT(user, TRAIT_SURGEON)) && chem_check(target) && !try_to_fail)
 
 			if(success(user, target, target_zone, tool, surgery))
 				advance = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This fixes an underlying issue where any surgery with accept_hand was enabled would fail due to the "tool" not having any actual success rate defined.

This also fixes abductors having annoyingly high levels of failure rate with ANY surgery by causing their surgical table to inject sterilizer into the target.

## Why It's Good For The Game

Abductors should actually be able to do their jobs.
closes #159 

## Changelog

:cl:
fix: Surgeries that require only an open hand will actually succeed now.
fix: The Alien Federation has started actually sterilizing their subjects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
