### PR TITLE
Wheelchair QoL

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -51,7 +51,7 @@
 		return
 	if(user == O && iscarbon(O))
 		var/mob/living/carbon/C = O
-		if(C.mobility_flags & MOBILITY_MOVE)
+		if(isliving(C)) //MonkeStation Edit: Anyone can climb
 			climb_structure(user)
 			return
 	if(!istype(O, /obj/item) || user.get_active_held_item() != O)

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -10,7 +10,7 @@
 	canmove = TRUE
 	density = FALSE		//Thought I couldn't fix this one easily, phew
 	// Run speed delay is multiplied with this for vehicle move delay.
-	var/delay_multiplier = 6.7
+	var/delay_multiplier = 3 //MonkeStation Edit: Better Speed
 
 /obj/vehicle/ridden/wheelchair/Initialize(mapload)
 	. = ..()
@@ -110,5 +110,5 @@
 /obj/vehicle/ridden/wheelchair/the_whip/driver_move(mob/living/user, direction)
 	if(istype(user))
 		var/datum/component/riding/D = GetComponent(/datum/component/riding)
-		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 6.7) / user.get_num_arms()
+		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 3) / user.get_num_arms() //MonkeStation Edit: Better Speeds
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Increases the base wheelchair speed to just under run speed.
Increases the top speed of electric wheelchairs to: FREAKIN' FAST
Allows for the wheelchair bound to climb structures.

## Why It's Good For The Game

If you've watched anyone try to move around in a wheelchair in-game, it's horrible.
There are people IRL that can go faster than that and we're spessmen that can carry a mountain of gold bars in our backpacks!


## Changelog

:cl:
tweak: Anyone that is living can climb tables
balance: Wheelchairs are faster
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
