### PR TITLE
Dynamic Skeletal Access

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3548,6 +3548,7 @@
 #include "monkestation\code\modules\food_and_drinks\food\snacks_meat.dm"
 #include "monkestation\code\modules\hydroponics\plant_genes.dm"
 #include "monkestation\code\modules\hydroponics\grown\berries.dm"
+#include "monkestation\code\modules\jobs\job_types\_job.dm"
 #include "monkestation\code\modules\jobs\job_types\gimmick.dm"
 #include "monkestation\code\modules\jobs\mail_goodies\job_mail.dm"
 #include "monkestation\code\modules\language\sippins.dm"

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -505,7 +505,7 @@ SUBSYSTEM_DEF(job)
 		if(job.req_admin_notify)
 			to_chat(M, "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>")
 		if(CONFIG_GET(number/minimal_access_threshold))
-			to_chat(M, "<span class='notice'><B>As this station was initially staffed with a [CONFIG_GET(flag/jobs_have_minimal_access) ? "full crew, only your job's necessities" : "skeleton crew, additional access may"] have been added to your ID card.</B></span>")
+			to_chat(M, "<span class='notice'><B>As this station was initially staffed with a [CONFIG_GET(flag/jobs_have_minimal_access) ? "full crew, only your job's necessities" : "skeleton crew, additional access based off crew needs"] have been added to your ID card.</B></span>") //MonkeStation Edit: More descriptive
 	if(ishuman(living_mob))
 		var/mob/living/carbon/human/wageslave = living_mob
 		living_mob.add_memory("Your account ID is [wageslave.account_id].")
@@ -747,7 +747,7 @@ SUBSYSTEM_DEF(job)
 			. |= player.mind
 
 ////////////////////////////////////////
-//Keeps track of all  security members//
+//Keeps track of all security members//
 ////////////////////////////////////////
 /datum/controller/subsystem/job/proc/get_all_sec()
 	. = list()

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -239,10 +239,18 @@
 		. = src.minimal_access.Copy()
 	else
 		. = src.access.Copy()
-		//MonkeStation Edit: Lowpop Basic Access
-		. += list(	ACCESS_ENGINE, ACCESS_ENGINE_EQUIP, ACCESS_TECH_STORAGE, ACCESS_MINING, ACCESS_MINING_STATION, ACCESS_RESEARCH,
-					ACCESS_EXTERNAL_AIRLOCKS, ACCESS_CONSTRUCTION, ACCESS_MINERAL_STOREROOM, ACCESS_MEDICAL, ACCESS_CARGO, ACCESS_ROBOTICS,
-					ACCESS_SURGERY, ACCESS_CLONING, ACCESS_MECH_MEDICAL, ACCESS_MINERAL_STOREROOM, ACCESS_MAINT_TUNNELS)
+		var/list/dynamic_access = list()
+		if(!get_any_engineers())
+			dynamic_access += list(ACCESS_ENGINE, ACCESS_ENGINE_EQUIP, ACCESS_TECH_STORAGE, ACCESS_EXTERNAL_AIRLOCKS, ACCESS_CONSTRUCTION)
+		if(!get_any_scientists())
+			dynamic_access += list(ACCESS_ROBOTICS, ACCESS_RESEARCH)
+		if(!get_any_supply())
+			dynamic_access += list(ACCESS_MINING, ACCESS_MINING_STATION, ACCESS_MINERAL_STOREROOM, ACCESS_CARGO)
+		if(!get_any_medical())
+			dynamic_access += list(ACCESS_MEDICAL, ACCESS_SURGERY, ACCESS_CLONING)
+		if(!get_any_service())
+			dynamic_access += list(ACCESS_HYDROPONICS, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_JANITOR, ACCESS_MINERAL_STOREROOM)
+		. += dynamic_access
 		//MonkeStation Edit End
 
 	if(CONFIG_GET(flag/everyone_has_maint_access)) //Config has global maint access set

--- a/monkestation/code/modules/jobs/job_types/_job.dm
+++ b/monkestation/code/modules/jobs/job_types/_job.dm
@@ -1,0 +1,76 @@
+
+///////////////////////////////////////
+//Tracking Procs for every department//
+///////////////////////////////////////
+
+//////////////////////////////////////////
+//Keeps track of any engineering members//
+//////////////////////////////////////////
+
+/datum/job/proc/get_any_engineers()
+	. = list()
+	for(var/mob/living/carbon/human/player in GLOB.carbon_list)
+		if(player.mind && (player.mind.assigned_role in GLOB.engineering_positions))
+			return TRUE
+	return FALSE
+
+//////////////////////////////////////
+//Keeps track of any medical members//
+//////////////////////////////////////
+//Does not include: Geneticist, Virologist, Brig Physician
+
+/datum/job/proc/get_any_medical()
+	. = list()
+	for(var/mob/living/carbon/human/player in GLOB.carbon_list)
+		if(player.mind && (player.mind.assigned_role in list(
+			"Chief Medical Officer",
+			"Medical Doctor",
+			"Paramedic",
+			"Chemist"
+		)))
+			return TRUE
+	return FALSE
+
+//////////////////////////////////////
+//Keeps track of any science members//
+//////////////////////////////////////
+//Does not include: Exploration Crew
+
+/datum/job/proc/get_any_scientists()
+	. = list()
+	for(var/mob/living/carbon/human/player in GLOB.carbon_list)
+		if(player.mind && (player.mind.assigned_role in list(
+			"Research Director",
+			"Scientist",
+			"Roboticist")))
+			return TRUE
+	return FALSE
+
+////////////////////////////////////
+//Keeps track of any Cargo members//
+////////////////////////////////////
+//Includes mining, as cargo techs would already have access on low-pop
+
+/datum/job/proc/get_any_supply()
+	. = list()
+	for(var/mob/living/carbon/human/player in GLOB.carbon_list)
+		if(player.mind && (player.mind.assigned_role in GLOB.supply_positions))
+			return TRUE
+	return FALSE
+
+//////////////////////////////////////
+//Keeps track of any Service members//
+//////////////////////////////////////
+//Only includes Bartender, Janitor, Chef & Botanist as they would be semi-important
+
+/datum/job/proc/get_any_service()
+	. = list()
+	for(var/mob/living/carbon/human/player in GLOB.carbon_list)
+		if(player.mind && (player.mind.assigned_role in list(
+			"Bartender",
+			"Botanist",
+			"Cook",
+			"Janitor"
+			)))
+			return TRUE
+	return FALSE

--- a/monkestation/code/modules/jobs/job_types/_job.dm
+++ b/monkestation/code/modules/jobs/job_types/_job.dm
@@ -8,7 +8,6 @@
 //////////////////////////////////////////
 
 /datum/job/proc/get_any_engineers()
-	. = list()
 	for(var/mob/living/carbon/human/player in GLOB.carbon_list)
 		if(player.mind && (player.mind.assigned_role in GLOB.engineering_positions))
 			return TRUE
@@ -20,7 +19,6 @@
 //Does not include: Geneticist, Virologist, Brig Physician
 
 /datum/job/proc/get_any_medical()
-	. = list()
 	for(var/mob/living/carbon/human/player in GLOB.carbon_list)
 		if(player.mind && (player.mind.assigned_role in list(
 			"Chief Medical Officer",
@@ -37,7 +35,6 @@
 //Does not include: Exploration Crew
 
 /datum/job/proc/get_any_scientists()
-	. = list()
 	for(var/mob/living/carbon/human/player in GLOB.carbon_list)
 		if(player.mind && (player.mind.assigned_role in list(
 			"Research Director",
@@ -52,7 +49,6 @@
 //Includes mining, as cargo techs would already have access on low-pop
 
 /datum/job/proc/get_any_supply()
-	. = list()
 	for(var/mob/living/carbon/human/player in GLOB.carbon_list)
 		if(player.mind && (player.mind.assigned_role in GLOB.supply_positions))
 			return TRUE
@@ -64,7 +60,6 @@
 //Only includes Bartender, Janitor, Chef & Botanist as they would be semi-important
 
 /datum/job/proc/get_any_service()
-	. = list()
 	for(var/mob/living/carbon/human/player in GLOB.carbon_list)
 		if(player.mind && (player.mind.assigned_role in list(
 			"Bartender",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

My previous implementation of skeletal crew access was an "all or nothing" deal that seems overkill especially when you actually have crew in certain departments.

This change now makes it so you only get bonus access to a department when that specific department has nobody in it.

## Why It's Good For The Game

Only granting specific accesses will allow players to actually do the job they signed up for, rather than having the clown rush in and do it for you.
This only applies on low-pop, usually the hours people would like to learn new jobs.

## Changelog

:cl:
tweak: Skeletal Access will grant you access to areas that are unstaffed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
