### PR TITLE
Extinguisher Spills

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -243,12 +243,13 @@
 
 /obj/item/extinguisher/proc/EmptyExtinguisher(var/mob/user)
 	if(loc == user && reagents.total_volume)
-		reagents.clear_reagents()
 
 		var/turf/T = get_turf(loc)
 		if(isopenturf(T))
-			var/turf/open/theturf = T
-			theturf.MakeSlippery(TURF_WET_WATER, min_wet_time = 10 SECONDS, wet_time_to_add = 5 SECONDS)
+			//MonkeStation Edit: Empties out the chemicals inside
+			reagents.reaction(T, TOUCH)
+		reagents.clear_reagents()
+		//MonkeStatuion Edit End
 
 		user.visible_message("[user] empties out \the [src] onto the floor using the release valve.", "<span class='info'>You quietly empty out \the [src] using its release valve.</span>")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Emptying out a fire extinguisher will now cause the chemical inside to spill out, instead of just a generic wet turf.

## Why It's Good For The Game

Feels weird to have a fire extinguisher full of plasma just spill water.
closes #170 

## Changelog

:cl:
tweak: Emptying fire extinguishers now spills the chemical inside
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
