### PR TITLE
Adds comments and some items to syndie kits

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -43,7 +43,7 @@
 			new /obj/item/flashlight/emp(src) // 3 tc
 			new /obj/item/jammer(src) // 5 tc
 
-		if("guns") // 28 tc
+		if("guns") // 29 tc
 			new /obj/item/gun/ballistic/revolver(src) // 12 tc
 			new /obj/item/ammo_box/a357(src) // 2 tc
 			new /obj/item/ammo_box/a357(src) // 2 tc
@@ -51,8 +51,8 @@
 			new /obj/item/grenade/plastic/c4(src) // 1 tc
 			new /obj/item/deployablemine/traitor(src) // 4 tc
 			new /obj/item/soap/syndie(src) // 1 tc
+			new /datum/uplink_item/badass/syndiecash(src) //1 tc
 			new /obj/item/clothing/gloves/color/latex/nitrile(src) // 0 tc
-			new /obj/item/clothing/mask/gas/clown_hat(src) // 0 tc
 			new /obj/item/clothing/under/suit/black_really(src) // 0 tc
 
 		if("screwed") // 35 tc
@@ -165,7 +165,7 @@
 			new /obj/item/toy/plush/carpplushie/dehy_carp(src)
 			new /obj/item/slimepotion/slime/sentience(src)
 
-		if("mad_scientist") //who the fuck knows
+		if("mad_scientist") //at least 29 tc, the clusters are random, and the guns are really tough to price
 			new /obj/item/clothing/suit/toggle/labcoat/mad(src) // 0 tc
 			new /obj/item/clothing/shoes/jackboots(src) // 0 tc
 			new /obj/item/megaphone(src) // 0 tc (because how else are they to know you're mad?)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -4,21 +4,22 @@
 	icon_state = "syndiebox"
 	illustration = "writing_syndie"
 
+//monkestation edit begin
 /obj/item/storage/box/syndie_kit/bundle_A/PopulateContents()
 	switch (pickweight(list("recon" = 2, "bloodyspai" = 3, "stealth" = 2, "screwed" = 2, "sabotage" = 3, "guns" = 2, "murder" = 2, "implant" = 1, "hacker" = 3, "sniper" = 1, "metaops" = 1)))
-		if("recon")
+		if("recon") // ~33 tc
 			new /obj/item/clothing/glasses/thermal/xray(src) // ~8 tc?
 			new /obj/item/storage/briefcase/launchpad(src) //6 tc
 			new	/obj/item/binoculars(src) // 2 tc?
 			new /obj/item/encryptionkey/syndicate(src) // 2 tc
 			new /obj/item/storage/box/syndie_kit/space(src) //4 tc
 			new /obj/item/grenade/frag(src) // ~2 tc each?
-			new /obj/item/grenade/frag(src)
-			new /obj/item/flashlight/emp(src)
-			new /obj/item/book/granter/martial/karate(src)
+			new /obj/item/grenade/frag(src) // ~2 tc
+			new /obj/item/flashlight/emp(src) // 3 tc
+			new /obj/item/book/granter/martial/karate(src) // 4 tc
 
-		if("bloodyspai")
-			new /obj/item/clothing/under/chameleon(src) // 2 tc since it's not the full set
+		if("bloodyspai") // ~30 tc
+			new /obj/item/clothing/under/chameleon(src) // 1 tc since it's not the full set
 			new /obj/item/clothing/mask/chameleon(src) // Goes with above
 			new /obj/item/card/id/syndicate(src) // 2 tc
 			new /obj/item/clothing/shoes/chameleon/noslip(src) // 2 tc
@@ -30,93 +31,91 @@
 			new /obj/item/storage/fancy/cigarettes/cigpack_syndicate (src) // 2 tc this shit heals
 			new /obj/item/flashlight/emp(src) // 2 tc
 			new /obj/item/chameleon(src) // 7 tc
+			new /obj/item/gun/ballistic/revolver/detective(src) // <7 tc, maybe 4ish? A backup weapon for when you never really were on their side
 
-		if("stealth")
-			new /obj/item/gun/energy/kinetic_accelerator/crossbow(src)
-			new /obj/item/pen/sleepy(src)
-			new /obj/item/healthanalyzer/rad_laser(src)
-			new /obj/item/chameleon(src)
-			new /obj/item/soap/syndie(src)
-			new /obj/item/clothing/glasses/thermal/syndi(src)
-			new /obj/item/flashlight/emp(src)
-			new /obj/item/jammer(src)
+		if("stealth") // 39 tc
+			new /obj/item/gun/energy/kinetic_accelerator/crossbow(src) // 12 tc
+			new /obj/item/pen/sleepy(src) // 5 tc
+			new /obj/item/healthanalyzer/rad_laser(src) // 3 tc
+			new /obj/item/chameleon(src) // 7 tc
+			new /obj/item/soap/syndie(src) // 1 tc
+			new /obj/item/clothing/glasses/thermal/syndi(src) // 3 tc
+			new /obj/item/flashlight/emp(src) // 3 tc
+			new /obj/item/jammer(src) // 5 tc
 
-		if("guns")
-			new /obj/item/gun/ballistic/revolver(src)
-			new /obj/item/ammo_box/a357(src)
-			new /obj/item/ammo_box/a357(src)
-			new /obj/item/card/emag(src)
-			new /obj/item/grenade/plastic/c4(src)
-			new /obj/item/clothing/gloves/color/latex/nitrile(src)
-			new /obj/item/clothing/mask/gas/clown_hat(src)
-			new /obj/item/clothing/under/suit/black_really(src)
+		if("guns") // 28 tc
+			new /obj/item/gun/ballistic/revolver(src) // 12 tc
+			new /obj/item/ammo_box/a357(src) // 2 tc
+			new /obj/item/ammo_box/a357(src) // 2 tc
+			new /obj/item/card/emag(src) // 6 tc
+			new /obj/item/grenade/plastic/c4(src) // 1 tc
+			new /obj/item/deployablemine/traitor(src) // 4 tc
+			new /obj/item/soap/syndie(src) // 1 tc
+			new /obj/item/clothing/gloves/color/latex/nitrile(src) // 0 tc
+			new /obj/item/clothing/mask/gas/clown_hat(src) // 0 tc
+			new /obj/item/clothing/under/suit/black_really(src) // 0 tc
 
-		if("screwed")
-			new /obj/item/sbeacondrop/bomb(src)
-			new /obj/item/grenade/syndieminibomb(src)
-			new /obj/item/sbeacondrop/powersink(src)
-			new /obj/item/clothing/suit/space/syndicate/black/red(src)
-			new /obj/item/clothing/head/helmet/space/syndicate/black/red(src)
-			new /obj/item/encryptionkey/syndicate(src)
-			new /obj/item/pen/edagger(src)
+		if("screwed") // 35 tc
+			new /obj/item/sbeacondrop/bomb(src) // 12 tc
+			new /obj/item/grenade/syndieminibomb(src) // 5 tc
+			new /obj/item/sbeacondrop/powersink(src) // 10 tc
+			new /obj/item/clothing/suit/space/syndicate/black/red(src) // 3 tc
+			new /obj/item/clothing/head/helmet/space/syndicate/black/red(src) // with above
+			new /obj/item/encryptionkey/syndicate(src) // 2 tc
+			new /obj/item/pen/edagger(src) // 3 tc
 
-		if("murder")
-			new /obj/item/melee/transforming/energy/sword/saber(src)
-			new /obj/item/clothing/glasses/thermal/syndi(src)
-			new /obj/item/card/emag(src)
-			new /obj/item/clothing/shoes/chameleon/noslip(src)
-			new /obj/item/encryptionkey/syndicate(src)
-			new /obj/item/grenade/syndieminibomb(src)
+		if("murder") // 27 tc
+			new /obj/item/melee/transforming/energy/sword/saber(src) // 8 tc
+			new /obj/item/clothing/glasses/thermal/syndi(src) // 3 tc
+			new /obj/item/card/emag(src) // 6 tc
+			new /obj/item/clothing/shoes/chameleon/noslip(src) // 3 tc
+			new /obj/item/encryptionkey/syndicate(src) // 2 tc
+			new /obj/item/grenade/syndieminibomb(src) // 5 tc
 
-		if("implant")
-			new /obj/item/implanter/freedom(src)
-			new /obj/item/implanter/uplink/precharged(src)
-			new /obj/item/implanter/emp(src)
-			new /obj/item/implanter/adrenalin(src)
-			new /obj/item/implanter/explosive(src)
-			new /obj/item/implanter/storage(src)
+		if("implant") // ~35 tc
+			new /obj/item/implanter/freedom(src) // 4 tc
+			new /obj/item/implanter/uplink/precharged(src) // 3 tc + 10 tc in the implant
+			new /obj/item/implanter/emp(src) // <1 tc
+			new /obj/item/implanter/adrenalin(src) // 8 tc
+			new /obj/item/implanter/explosive(src) // 3 tc
+			new /obj/item/implanter/storage(src) // 7 tc
 
-		if("hacker")
-			new /obj/item/aiModule/syndicate(src)
-			new /obj/item/card/emag(src)
-			new /obj/item/encryptionkey/binary(src)
-			new /obj/item/aiModule/toyAI(src)
-			new /obj/item/multitool/ai_detect(src)
-			new /obj/item/storage/toolbox/syndicate(src)
-			new /obj/item/camera_bug(src)
-			new /obj/item/clothing/glasses/thermal/syndi(src)
-			new /obj/item/card/id/syndicate(src)
-			new /obj/item/pen/edagger(src)
+		if("hacker") // 30 tc
+			new /obj/item/aiModule/syndicate(src) // 9 tc
+			new /obj/item/card/emag(src) // 6 tc
+			new /obj/item/encryptionkey/binary(src) // 4 tc
+			new /obj/item/aiModule/toyAI(src) // 0 tc
+			new /obj/item/multitool/ai_detect(src) // 1 tc
+			new /obj/item/storage/toolbox/syndicate(src) // 1 tc
+			new /obj/item/camera_bug(src) // 1 tc
+			new /obj/item/clothing/glasses/thermal/syndi(src) // 3 tc
+			new /obj/item/card/id/syndicate(src) // 2 tc
+			new /obj/item/pen/edagger(src) // 3 tc
 
-		if("lordsingulo")
-			new /obj/item/sbeacondrop(src)
-			new /obj/item/clothing/suit/space/syndicate/black/red(src)
-			new /obj/item/clothing/head/helmet/space/syndicate/black/red(src)
-			new /obj/item/card/emag(src)
-			new /obj/item/storage/toolbox/syndicate(src)
-			new /obj/item/pen/edagger(src)
+		if("sabotage") // 35 tc
+			new /obj/item/grenade/plastic/c4 (src) // 1 tc
+			new /obj/item/grenade/plastic/c4 (src) // 1 tc
+			new /obj/item/doorCharge(src) // 4 tc
+			new /obj/item/doorCharge(src) // 4 tc
+			new /obj/item/camera_bug(src) // 1 tc
+			new /obj/item/sbeacondrop/powersink(src) // 10 tc
+			new /obj/item/cartridge/virus/syndicate(src) // 6 tc
+			new /obj/item/storage/toolbox/syndicate(src) // 1 tc
+			new /obj/item/pizzabox/bomb(src) // 3 tc
+			new /obj/item/storage/box/syndie_kit/emp(src) // 4 tc
 
-		if("sabotage")
-			new /obj/item/grenade/plastic/c4 (src)
-			new /obj/item/grenade/plastic/c4 (src)
-			new /obj/item/doorCharge(src)
-			new /obj/item/doorCharge(src)
-			new /obj/item/camera_bug(src)
-			new /obj/item/sbeacondrop/powersink(src)
-			new /obj/item/cartridge/virus/syndicate(src)
-			new /obj/item/storage/toolbox/syndicate(src) //To actually get to those places
-			new /obj/item/pizzabox/bomb(src)
-			new /obj/item/storage/box/syndie_kit/emp(src)
+		if("sniper") // 31 tc, no silencer because getting killed without ANY indicator on what killed you sucks
+			new /obj/item/gun/ballistic/automatic/sniper_rifle(src) // 16 tc
+			new /obj/item/ammo_box/magazine/sniper_rounds/penetrator(src) // 5 tc
+			new /obj/item/clothing/glasses/thermal/syndi(src) // 3 tc
+			new /obj/item/chameleon(src) // 7 tc
+			new /obj/item/clothing/suit/hooded/wintercoat/medical(src) // 0 tc WHITE DEATH
+			new /obj/item/clothing/shoes/winterboots(src) // 0 tc
+			new /obj/item/clothing/gloves/color/white(src) // 0 tc
+			new /obj/item/reagent_containers/food/drinks/bottle/vodka(src) // 0 tc
+			new /obj/item/storage/pill_bottle/stimulant(src) // <1 tc ephedrine/antihol/coffee, not quite amphetamines!
 
-		if("sniper") //This shit is unique so can't really balance it around tc, also no silencer because getting killed without ANY indicator on what killed you sucks
-			new /obj/item/gun/ballistic/automatic/sniper_rifle(src) // 12 tc
-			new /obj/item/ammo_box/magazine/sniper_rounds/penetrator(src)
-			new /obj/item/clothing/glasses/thermal/syndi(src)
-			new /obj/item/clothing/gloves/color/latex/nitrile(src)
-			new /obj/item/clothing/mask/gas/clown_hat(src)
-			new /obj/item/clothing/under/suit/black_really(src)
-
-		if("metaops")
+		if("metaops") // 30 tc
 			new /obj/item/clothing/suit/space/hardsuit/syndi(src) // 8 tc
 			new /obj/item/gun/ballistic/shotgun/bulldog/unrestricted(src) // 8 tc
 			new /obj/item/implanter/explosive(src) // 2 tc
@@ -128,34 +127,34 @@
 
 /obj/item/storage/box/syndie_kit/bundle_B/PopulateContents()
 	switch (pickweight(list( "bond" = 2, "ninja" = 1, "darklord" = 1, "white_whale_holy_grail" = 2, "mad_scientist" = 2, "bee" = 2, "mr_freeze" = 2)))
-		if("bond")
-			new /obj/item/gun/ballistic/automatic/pistol(src)
-			new /obj/item/suppressor(src)
-			new /obj/item/ammo_box/magazine/m10mm(src)
-			new /obj/item/ammo_box/magazine/m10mm/ap(src)
-			new /obj/item/ammo_box/magazine/m10mm/hp(src)
-			new /obj/item/clothing/under/chameleon(src)
-			new /obj/item/card/id/syndicate(src)
-			new /obj/item/reagent_containers/hypospray/medipen/stimulants(src)
-			new /obj/item/reagent_containers/glass/rag(src)
-			new /obj/item/encryptionkey/syndicate(src)
+		if("bond") // ~25 tc
+			new /obj/item/gun/ballistic/automatic/pistol(src) // 7 tc
+			new /obj/item/suppressor(src) // 2 tc
+			new /obj/item/ammo_box/magazine/m10mm(src) // 1 tc
+			new /obj/item/ammo_box/magazine/m10mm/ap(src) // 2 tc
+			new /obj/item/ammo_box/magazine/m10mm/hp(src) // 3 tc
+			new /obj/item/clothing/under/chameleon(src) // ~1 tc
+			new /obj/item/card/id/syndicate(src) // 2 tc
+			new /obj/item/reagent_containers/hypospray/medipen/stimulants(src) // 5 tc
+			new /obj/item/reagent_containers/glass/rag(src) // 0 tc
+			new /obj/item/encryptionkey/syndicate(src) // 2 tc
 
-		if("ninja")
-			new /obj/item/katana(src) // Unique , hard to tell how much tc this is worth. 8 tc?
+		if("ninja") // 29 tc
+			new /obj/item/katana(src) // Based on the esword price it'd be around 8 tc
 			new /obj/item/implanter/adrenalin(src) // 8 tc
 			for(var/i in 1 to 6)
-				new /obj/item/throwing_star(src) // ~5 tc for all 6
-			new /obj/item/storage/belt/chameleon(src) // Unique but worth at least 2 tc
+				new /obj/item/throwing_star(src) // 3 tc (normal box is 5 + 2 bolas)
+			new /obj/item/storage/belt/chameleon(src) // ~1 tc
 			new /obj/item/card/id/syndicate(src) // 2 tc
 			new /obj/item/chameleon(src) // 7 tc
 
-		if("darklord")
-			new /obj/item/dualsaber(src)
-			new /obj/item/dnainjector/telemut/darkbundle(src)
-			new /obj/item/clothing/suit/hooded/chaplain_hoodie(src)
-			new /obj/item/card/id/syndicate(src)
-			new /obj/item/clothing/shoes/chameleon/noslip(src) //because slipping while being a dark lord sucks
-			new /obj/item/book/granter/spell/summonitem(src)
+		if("darklord") // 23 tc + tk + summon item so at least 30
+			new /obj/item/dualsaber(src) // 18 tc
+			new /obj/item/dnainjector/telemut/darkbundle(src) // telekinesis ?? tc
+			new /obj/item/clothing/suit/hooded/chaplain_hoodie(src) // 0 tc
+			new /obj/item/card/id/syndicate(src) // 2 tc
+			new /obj/item/clothing/shoes/chameleon/noslip(src) // 3 tc
+			new /obj/item/book/granter/spell/summonitem(src) // wizard spell ?? tc
 
 		if("white_whale_holy_grail") //Unique items that don't appear anywhere else
 			new /obj/item/pneumatic_cannon/speargun(src)
@@ -166,7 +165,7 @@
 			new /obj/item/toy/plush/carpplushie/dehy_carp(src)
 			new /obj/item/slimepotion/slime/sentience(src)
 
-		if("mad_scientist")
+		if("mad_scientist") //who the fuck knows
 			new /obj/item/clothing/suit/toggle/labcoat/mad(src) // 0 tc
 			new /obj/item/clothing/shoes/jackboots(src) // 0 tc
 			new /obj/item/megaphone(src) // 0 tc (because how else are they to know you're mad?)
@@ -178,33 +177,34 @@
 			new /obj/item/assembly/signaler(src) // 0 tc
 			new /obj/item/assembly/signaler(src) // 0 tc
 			new /obj/item/storage/toolbox/syndicate(src) // 1 tc
-			new /obj/item/pen/edagger(src)
+			new /obj/item/pen/edagger(src) // 3 tc
 			new /obj/item/gun/energy/wormhole_projector(src) //mooorttyyyy
 			new /obj/item/gun/energy/decloner/unrestricted(src)
 
-		if("bee")
+		if("bee") // probably around 30?
 			new /obj/item/paper/fluff/bee_objectives(src) // 0 tc (motivation)
 			new /obj/item/clothing/suit/hooded/bee_costume/syndie(src) // 0 tc
 			new /obj/item/clothing/mask/rat/bee(src) // 0 tc
 			new /obj/item/storage/belt/fannypack/yellow(src) // 0 tc
-			new /obj/item/storage/box/syndie_kit/bee_grenades(src) // 15 tc
+			new /obj/item/storage/box/syndie_kit/bee_grenades(src) // 16 tc
 			new /obj/item/reagent_containers/glass/bottle/beesease(src) // 10 tc?
 			new /obj/item/gun/chem/bee(src) //priceless
 
-		if("mr_freeze")
-			new /obj/item/clothing/glasses/cold(src)
-			new /obj/item/clothing/gloves/color/black(src)
-			new /obj/item/clothing/mask/chameleon(src)
-			new /obj/item/clothing/suit/hooded/wintercoat(src)
-			new /obj/item/clothing/shoes/winterboots(src)
-			new /obj/item/grenade/gluon(src)
+		if("mr_freeze") //hard to say
+			new /obj/item/clothing/glasses/cold(src) // 0 tc
+			new /obj/item/clothing/gloves/color/black(src) // 0 tc
+			new /obj/item/clothing/mask/chameleon(src) // <1 tc
+			new /obj/item/clothing/suit/hooded/wintercoat(src) // 0 tc
+			new /obj/item/clothing/shoes/winterboots(src) // 0 tc
+			new /obj/item/grenade/gluon(src) // part of grenadier's belt, ~1 tc each?
 			new /obj/item/grenade/gluon(src)
 			new /obj/item/grenade/gluon(src)
 			new /obj/item/grenade/gluon(src)
 			new /obj/item/dnainjector/geladikinesis(src)
 			new /obj/item/dnainjector/cryokinesis(src)
 			new /obj/item/gun/energy/temperature/pin(src)
-			new /obj/item/melee/transforming/energy/sword/saber/blue(src) //see see it fits the theme bc its blue and ice is blue
+			new /obj/item/melee/transforming/energy/sword/saber/blue(src) // 8 tc //see see it fits the theme bc its blue and ice is blue
+//monkestation end
 
 /obj/item/storage/box/syndie_kit/contract_kit
 	name = "Contract Kit"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -51,7 +51,7 @@
 			new /obj/item/grenade/plastic/c4(src) // 1 tc
 			new /obj/item/deployablemine/traitor(src) // 4 tc
 			new /obj/item/soap/syndie(src) // 1 tc
-			new /datum/uplink_item/badass/syndiecash(src) //1 tc
+			new /obj/item/storage/secure/briefcase/syndie(src) //1 tc
 			new /obj/item/clothing/gloves/color/latex/nitrile(src) // 0 tc
 			new /obj/item/clothing/under/suit/black_really(src) // 0 tc
 

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -972,13 +972,6 @@
 			<ul class="changes bgimages16">
 				<li class="code_imp">remove incorrect lazylen usage</li>
 			</ul>
-
-			<h2 class="date">23 December 2021</h2>
-			<h3 class="author">zeskorion updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">regenerative extracts now have correct descriptions</li>
-				<li class="bugfix">light pink regen core has been nerfed as well</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This PR goes through the random syndie-kits you can buy for 20tc as a traitor.  I added comments with the prices of every item, as well as a total, which lets you see that they generally aim at around 30tc value.  This falls apart a bit with the gimmick kits but that's kind of the nature of them.  A couple particularly lackluster kits I added a little to in order to give them a bit more bang for their buck and lessen the feeling of being "screwed".

Specifically:
"bloodyspai" - a TF2 reference, I gave it the detective revolver, it was on the low side, but adding the 357 would have been gross overkill.  The spy does have a revolver and who knows this could be handy in a pinch!  It can also be very dramatic with all the other stealth gear.
"guns" - this one is a Hitman reference that was also on the low side.  I gave it an exploding rubber duck which seemed incredibly fitting, and a bar of syndie soap which is also conducive to shenanigans.
"lordsingulo" - this was actually already disabled from the roll, so I removed it entirely, RIP, perhaps you shall return one day.
"implants" - no change, as I finally realized the uplink implant actually has 10tc preloaded so this is actually a super good kit!
"bond" - this feels alright, bond isn't really about stealth or hacking, just smooth talking and a gun.  But he always has some random gadgets, so now he gets some raw tc to buy some extra small toys!
"sniper" - this is the biggest change, reflavored from being hitman but with a gun, to "White Death", with white snow gear, vodka, stimulants (of the hobo variety, ephedrine/coffee/antihol), and a chameleon projector.  Welcome our new source of Finnish memes!  The chameleon projector adds the perfect touch I think, complementing the sniper and also giving the kit some use outside the rifle itself.


## Why It's Good For The Game

Makes the random crates less of a raw gamble, and more of a reward for being able to adapt to different playstyles and toolkits.  Being screwed over by a bad loadout you can't use feels bad.  Having a loadout that has some useful stuff but really shines if you're flexible enough to lean into it just right is great.  Generally, people can pick the syndie kit more confidently.  Syndie kits are for when you want a synergistic loadout given to you.  The gimmick bundles are when you're ok with getting screwed over for memes!

## Changelog

:cl:
tweak: added a couple items to random syndie-kits, you may find a couple new toys along the less impressive kits!
tweak: reworked the sniper syndie-kit to be a bit more Finnish, and added a chameleon projector so you can line up the shot in peace
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
