### PR TITLE
Bureaucracy Event Changes

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -125,23 +125,17 @@
 /datum/station_trait/overflow_job_bureacracy
 	name = "Overflow bureacracy mistake"
 	trait_type = STATION_TRAIT_NEGATIVE
-	weight = 5
+	weight = 10 //MonkeStation Edit: More errors
 	show_in_report = TRUE
-	var/list/jobs_to_use = list("Clown", "Bartender", "Cook", "Botanist", "Cargo Technician", "Mime", "Janitor")
 	var/chosen_job
 
 /datum/station_trait/overflow_job_bureacracy/New()
 	. = ..()
-	chosen_job = pick(jobs_to_use)
-	RegisterSignal(SSjob, COMSIG_SUBSYSTEM_POST_INITIALIZE, .proc/set_overflow_job_override)
+	chosen_job = pick(get_all_jobs()) //MonkeStation Edit: All jobs possible. I await Captain Station. Oh yes.
+	SSjob.set_overflow_role(chosen_job)
 
 /datum/station_trait/overflow_job_bureacracy/get_report()
 	return "[name] - It seems for some reason we put out the wrong job-listing for the overflow role this shift...I hope you like [chosen_job]s."
-
-/datum/station_trait/overflow_job_bureacracy/proc/set_overflow_job_override(datum/source, new_overflow_role)
-	SIGNAL_HANDLER
-
-	SSjob.set_overflow_role(chosen_job)
 
 /datum/station_trait/slow_shuttle
 	name = "Slow Shuttle"

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -380,7 +380,9 @@
 				// Medical
 				"Chief Medical Officer", "Medical Doctor", "Chemist", "Geneticist", "Virologist", "Paramedic", "Psychiatrist",
 				// Security
-				"Head of Security", "Warden", "Detective", "Security Officer", "Brig Physician", "Deputy")
+				"Head of Security", "Warden", "Detective", "Security Officer", "Brig Physician", "Deputy",
+				//MonkeStation Edit: Gimmick Jobs
+				"Barber", "Stage Magician", "Debtor", "Psychiatrist", "VIP", "Mailman")
 				// Each job is supposed to be in their department due to the HoP console.
 
 /proc/get_all_job_icons() //We need their HUD icons, but we don't want to give these jobs to people from the job list of HoP console.

--- a/code/modules/jobs/job_types/gimmick.dm
+++ b/code/modules/jobs/job_types/gimmick.dm
@@ -20,7 +20,7 @@
 	departments = DEPARTMENT_SERVICE
 	rpg_title = "Peasant"
 
-	allow_bureaucratic_error = FALSE
+	//MonkeStation Edit: Gimmick Overflow
 	outfit = /datum/outfit/job/gimmick
 
 /datum/outfit/job/gimmick


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Makes the negative station trait more common.

Makes it so any job may be used, rather than a select few.

Allows Gimmick jobs to be part of the error.

## Why It's Good For The Game

The Bureaucracy Error event is a fun idea, just needs a bit more capability to stir up a round.

## Changelog

:cl:
tweak: All jobs may rarely appear as overflow jobs. Hail Captain Station.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
