### PR TITLE
Weeb Trait Changes

### DIFF
--- a/code/datums/diseases/advance/symptoms/clockwork.dm
+++ b/code/datums/diseases/advance/symptoms/clockwork.dm
@@ -336,20 +336,7 @@
 	icon_state = "clocktail"
 	organ_flags = ORGAN_SYNTHETIC
 	status = ORGAN_ROBOTIC
-
-/obj/item/organ/tail/clockwork/Insert(mob/living/carbon/human/H, special = 0, drop_if_replaced = TRUE)
-	..()
-	if(istype(H))
-		if(!("tail_human" in H.dna.species.mutant_bodyparts))
-			H.dna.features["tail_human"] = tail_type
-			H.dna.species.mutant_bodyparts |= "tail_human"
-		H.update_body()
-
-/obj/item/organ/tail/clockwork/Remove(mob/living/carbon/human/H,  special = 0)
-	..()
-	if(istype(H))
-		H.dna.species.mutant_bodyparts -= "tail_human"
-		H.update_body()
+	mutant_bodypart_name = "tail_human" //MonkeStation Edit: Tail Overhaul
 
 /obj/item/bodypart/l_arm/robot/clockwork
 	name = "clockwork left arm"

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -82,8 +82,6 @@
 	if(ishuman(T))
 		var/mob/living/carbon/human/H = T
 		if(HAS_TRAIT(H, TRAIT_ANIME))//monkestation edit PR 66
-			H.dna.species.start_wagging_tail(H)
-			addtimer(CALLBACK(H.dna.species, /datum/species.proc/stop_wagging_tail, H), 30)
 			description =  "<span class='nicegreen'>They want to play on the table!</span>\n"
 			mood_change = 2
 

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -789,10 +789,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	hitsound = 'sound/effects/snap.ogg'
 
 /obj/item/slapper/attack(mob/M, mob/living/carbon/human/user)
-	if(ishuman(M))
-		var/mob/living/carbon/human/L = M
-		if(L?.dna?.species)
-			L.dna.species.stop_wagging_tail(M)
 	user.do_attack_animation(M)
 	playsound(M, 'sound/weapons/slap.ogg', 50, 1, -1)
 	user.visible_message("<span class='danger'>[user] slaps [M]!</span>",

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -144,33 +144,48 @@
 /datum/emote/living/carbon/human/wag
 	key = "wag"
 	key_third_person = "wags"
-	message = "wags their tail"
+	message = "wagging their tail" //MonkeStation Edit: Toggled Wagging
 
 /datum/emote/living/carbon/human/wag/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
 	if(!.)
+//MonkeStation Edit Start: Tail Overhaul. Yes, you read that right. We here have the best god damn tails you can find. Please kill me.
+		to_chat(user, "<span class='notice'>You don't have a tail!</span>")
 		return
 	var/mob/living/carbon/human/H = user
-	if(!istype(H) || !H.dna || !H.dna.species || !H.dna.species.can_wag_tail(H))
-		return
-	if(!H.dna.species.is_wagging_tail())
-		H.dna.species.start_wagging_tail(H)
-	else
-		H.dna.species.stop_wagging_tail(H)
+	var/obj/item/organ/tail/tail_finder = H.getorganslot(ORGAN_SLOT_TAIL)
+	if(!tail_finder.wagging_mutant_name)
+		return //because certain tails literally don't have animations.
+	if(!tail_finder.wagging) //Start Wagging
+		tail_finder.wagging = TRUE
+		H.dna.species.mutant_bodyparts += tail_finder.wagging_mutant_name
+		H.dna.species.mutant_bodyparts -= tail_finder.mutant_bodypart_name
+	else //Stop wagging
+		tail_finder.wagging = FALSE
+		H.dna.species.mutant_bodyparts -= tail_finder.wagging_mutant_name
+		H.dna.species.mutant_bodyparts += tail_finder.mutant_bodypart_name
+	H.update_body()
+//MonkeStation Edit End
 
 /datum/emote/living/carbon/human/wag/can_run_emote(mob/user, status_check = TRUE , intentional)
 	if(!..())
 		return FALSE
 	var/mob/living/carbon/human/H = user
-	return H.dna && H.dna.species && H.dna.species.can_wag_tail(user)
+//MonkeStation Edit Start
+	var/obj/item/organ/tail/tail_finder = H.getorganslot(ORGAN_SLOT_TAIL)
+	return tail_finder
 
 /datum/emote/living/carbon/human/wag/select_message_type(mob/user, intentional)
 	. = ..()
 	var/mob/living/carbon/human/H = user
-	if(!H.dna || !H.dna.species)
-		return
-	if(H.dna.species.is_wagging_tail())
-		. = null
+	var/obj/item/organ/tail/tail_finder = H.getorganslot(ORGAN_SLOT_TAIL)
+	if(tail_finder)
+		switch(tail_finder.wagging)
+			if(TRUE)
+				. = "stops [message]"
+			if(FALSE)
+				. = "starts [message]"
+//MonkeStation Edit End
 
 /datum/emote/living/carbon/human/wing
 	key = "wing"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -2003,20 +2003,6 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		return TRUE
 	return FALSE
 
-////////////////
-//Tail Wagging//
-////////////////
-
-/datum/species/proc/can_wag_tail(mob/living/carbon/human/H)
-	return FALSE
-
-/datum/species/proc/is_wagging_tail(mob/living/carbon/human/H)
-	return FALSE
-
-/datum/species/proc/start_wagging_tail(mob/living/carbon/human/H)
-
-/datum/species/proc/stop_wagging_tail(mob/living/carbon/human/H)
-
 ///////////////
 //FLIGHT SHIT//
 ///////////////

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -46,38 +46,6 @@
 
 	return randname
 
-//I wag in death
-/datum/species/lizard/spec_death(gibbed, mob/living/carbon/human/H)
-	if(H)
-		stop_wagging_tail(H)
-
-/datum/species/lizard/spec_stun(mob/living/carbon/human/H,amount)
-	if(H)
-		stop_wagging_tail(H)
-	. = ..()
-
-/datum/species/lizard/can_wag_tail(mob/living/carbon/human/H)
-	return ("tail_lizard" in mutant_bodyparts) || ("waggingtail_lizard" in mutant_bodyparts)
-
-/datum/species/lizard/is_wagging_tail(mob/living/carbon/human/H)
-	return ("waggingtail_lizard" in mutant_bodyparts)
-
-/datum/species/lizard/start_wagging_tail(mob/living/carbon/human/H)
-	if("tail_lizard" in mutant_bodyparts)
-		mutant_bodyparts -= "tail_lizard"
-		mutant_bodyparts -= "spines"
-		mutant_bodyparts |= "waggingtail_lizard"
-		mutant_bodyparts |= "waggingspines"
-	H.update_body()
-
-/datum/species/lizard/stop_wagging_tail(mob/living/carbon/human/H)
-	if("waggingtail_lizard" in mutant_bodyparts)
-		mutant_bodyparts -= "waggingtail_lizard"
-		mutant_bodyparts -= "waggingspines"
-		mutant_bodyparts |= "tail_lizard"
-		mutant_bodyparts |= "spines"
-	H.update_body()
-
 /*
  Lizard subspecies: ASHWALKERS
 */

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1622,7 +1622,7 @@
 			var/mob/living/carbon/human/H = M
 			H.hair_color = pick(potential_colors)
 			H.facial_hair_color = pick(potential_colors)
-			H.update_hair()
+			H.update_body() //MonkeStation Edit: Body Update
 
 /datum/reagent/barbers_aid
 	name = "Barber's Aid"

--- a/code/modules/surgery/organs/tails.dm
+++ b/code/modules/surgery/organs/tails.dm
@@ -7,30 +7,43 @@
 	zone = BODY_ZONE_PRECISE_GROIN
 	slot = ORGAN_SLOT_TAIL
 	var/tail_type = "None"
-
-/obj/item/organ/tail/Remove(mob/living/carbon/human/H,  special = 0)
-	..()
-	if(H?.dna?.species)
-		H.dna.species.stop_wagging_tail(H)
+//MonkeStation Edit Start: Tail Overhaul
+	var/wagging = FALSE
+	var/list/mutant_bodypart_name = list() //The organ that goes under H.dna.species.mutant_bodyparts
+	var/list/wagging_mutant_name //The WAGGING state for the organ that goes under H.dna.species.mutant_bodyparts
+	//All new tails need to be added to the switch in handle_mutant_bodyparts() under species.dm
+//MonkeStation Edit End
 
 /obj/item/organ/tail/cat
 	name = "cat tail"
 	desc = "A severed cat tail. Who's wagging now?"
 	tail_type = "Cat"
+	//MonkeStation Edit Start: Tail Overhaul
+	mutant_bodypart_name = list("tail_human")
+	wagging_mutant_name = list("waggingtail_human")
+	//MonkeStation Edit End
 
-/obj/item/organ/tail/cat/Insert(mob/living/carbon/human/H, special = 0, drop_if_replaced = TRUE)
+//MonkeStation Edit Start: Tail Overhaul
+/obj/item/organ/tail/Insert(mob/living/carbon/human/H, special = 0, drop_if_replaced = TRUE)
 	..()
 	if(istype(H))
-		if(!("tail_human" in H.dna.species.mutant_bodyparts))
-			H.dna.species.mutant_bodyparts |= "tail_human"
+		if(!(mutant_bodypart_name in H.dna.species.mutant_bodyparts))
+			H.dna.species.mutant_bodyparts |= mutant_bodypart_name
+//MonkeStation Edit End
 			H.dna.features["tail_human"] = tail_type
 			H.update_body()
 
-/obj/item/organ/tail/cat/Remove(mob/living/carbon/human/H,  special = 0)
+/obj/item/organ/tail/Remove(mob/living/carbon/human/H,  special = 0)
 	..()
 	if(istype(H))
 		H.dna.features["tail_human"] = "None"
-		H.dna.species.mutant_bodyparts -= "tail_human"
+//MonkeStation Edit Start: Tail Overhaul
+		if(wagging)
+			H.dna.species.mutant_bodyparts -= wagging_mutant_name
+			wagging = FALSE
+		else
+			H.dna.species.mutant_bodyparts -= mutant_bodypart_name
+//MonkeStation Edit End
 		H.update_body()
 
 /obj/item/organ/tail/lizard
@@ -39,15 +52,15 @@
 	color = "#116611"
 	tail_type = "Smooth"
 	var/spines = "None"
+	//MonkeStation Edit Start: Tail Overhaul
+	mutant_bodypart_name = list("tail_lizard", "spines")
+	wagging_mutant_name = list("waggingtail_lizard", "waggingspines")
+	//MonkeStation Edit End
 
 /obj/item/organ/tail/lizard/Insert(mob/living/carbon/human/H, special = 0, drop_if_replaced = TRUE)
 	..()
 	if(istype(H))
 		// Checks here are necessary so it wouldn't overwrite the tail of a lizard it spawned in
-		if(!("tail_lizard" in H.dna.species.mutant_bodyparts))
-			H.dna.features["tail_lizard"] = tail_type
-			H.dna.species.mutant_bodyparts |= "tail_lizard"
-
 		if(!("spines" in H.dna.species.mutant_bodyparts))
 			H.dna.features["spines"] = spines
 			H.dna.species.mutant_bodyparts |= "spines"
@@ -56,7 +69,6 @@
 /obj/item/organ/tail/lizard/Remove(mob/living/carbon/human/H,  special = 0)
 	..()
 	if(istype(H))
-		H.dna.species.mutant_bodyparts -= "tail_lizard"
 		H.dna.species.mutant_bodyparts -= "spines"
 		color = "#" + H.dna.features["mcolor"]
 		tail_type = H.dna.features["tail_lizard"]

--- a/monkestation/code/game/objects/items/anime.dm
+++ b/monkestation/code/game/objects/items/anime.dm
@@ -7,27 +7,41 @@
 	icon_state = "coder"
 	var/obj/item/organ/ears/ears = null
 	var/obj/item/organ/tail/tail = null
+	var/food_likes
+	var/food_dislikes
+	var/list/weeb_screams
+	var/list/weeb_laughs
 
 /obj/item/anime/examine(mob/user)
 	. = ..()
 	. += "Ctrl+Click to adjust the color."
 
-/obj/item/anime/attack_self(mob/living/carbon/human/user)
-	var/old_hair_color = user.hair_color
-	user.hair_color = sanitize_hexcolor(src.color) //I guess I have to do this fuck living code
-	if(ears)
-		ears.Insert(user)
-	if(tail)
-		tail.Insert(user)
-	user.hair_color = old_hair_color
-	var/turf/location = get_turf(user)
-	user.add_splatter_floor(location)
-	var/msg = "<span class=danger>You feel the power of God and Anime flow through you! </span>"
-	to_chat(user, msg)
-	playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, 1)
-	qdel(src)
+/obj/item/anime/attack_self(mob/living/carbon/user)
+	if(ishuman(user))
+		var/mob/living/carbon/human/weeb = user
+		weeb.hair_color = sanitize_hexcolor(src.color) //I guess I have to do this fuck living code
+		if(ears)
+			ears.Insert(weeb)
+		if(tail)
+			tail.Insert(weeb)
+		if(weeb_screams)
+			weeb.alternative_screams += weeb_screams
+		if(weeb_laughs)
+			weeb.alternative_laughs += weeb_laughs
+		if(food_likes)
+			weeb.dna.species.liked_food = food_likes
+		if(food_dislikes)
+			weeb.dna.species.disliked_food = food_dislikes
+			weeb.dna.species.toxic_food = food_dislikes
+		var/turf/location = get_turf(weeb)
+		weeb.add_splatter_floor(location)
+		var/msg = "<span class=danger>You feel the power of God and Anime flow through you! </span>"
+		to_chat(weeb, msg)
+		playsound(get_turf(weeb), 'sound/weapons/circsawhit.ogg', 50, 1)
+		weeb.update_body()
+		qdel(src)
 
-/obj/item/anime/CtrlClick(mob/living/carbon/human/user)
+/obj/item/anime/CtrlClick(mob/living/carbon/user)
 	var/new_color = input(user, "Choose your anime color:", "Anime Color","#"+ears.color) as color|null
 	if(new_color)
 		src.color = new_color
@@ -40,6 +54,10 @@
 	icon_state = "cat"
 	ears = new /obj/item/organ/ears/cat
 	tail = new /obj/item/organ/tail/cat
+	food_likes = DAIRY | MEAT
+	food_dislikes = FRUIT | VEGETABLES | SUGAR
+	weeb_screams = list('monkestation/sound/voice/screams/felinid/hiss.ogg','monkestation/sound/voice/screams/felinid/merowr.ogg','monkestation/sound/voice/screams/felinid/scream_cat.ogg')
+	weeb_laughs = list('monkestation/sound/voice/laugh/felinid/cat_laugh0.ogg','monkestation/sound/voice/laugh/felinid/cat_laugh1.ogg','monkestation/sound/voice/laugh/felinid/cat_laugh2.ogg','monkestation/sound/voice/laugh/felinid/cat_laugh3.ogg')
 
 
 //ANIME TRAIT SPAWNER//

--- a/monkestation/code/game/objects/items/anime.dm
+++ b/monkestation/code/game/objects/items/anime.dm
@@ -12,14 +12,14 @@
 	var/list/weeb_screams
 	var/list/weeb_laughs
 
-/obj/item/anime/examine(mob/user)
-	. = ..()
-	. += "Ctrl+Click to adjust the color."
-
 /obj/item/anime/attack_self(mob/living/carbon/user)
 	if(ishuman(user))
 		var/mob/living/carbon/human/weeb = user
-		weeb.hair_color = sanitize_hexcolor(src.color) //I guess I have to do this fuck living code
+		var/new_color = input(user, "Choose a new hair color:", "Anime Color","#"+ears.color) as color|null
+		if(new_color) //If they DON'T pick a color, then it just defaults to their original hair color.
+			src.color = new_color
+			weeb.hair_color = sanitize_hexcolor(src.color) //I guess I have to do this fuck living code
+
 		if(ears)
 			ears.Insert(weeb)
 		if(tail)
@@ -33,19 +33,15 @@
 		if(food_dislikes)
 			weeb.dna.species.disliked_food = food_dislikes
 			weeb.dna.species.toxic_food = food_dislikes
+
 		var/turf/location = get_turf(weeb)
 		weeb.add_splatter_floor(location)
 		var/msg = "<span class=danger>You feel the power of God and Anime flow through you! </span>"
 		to_chat(weeb, msg)
-		playsound(get_turf(weeb), 'sound/weapons/circsawhit.ogg', 50, 1)
+		playsound(location, 'sound/weapons/circsawhit.ogg', 50, 1)
 		weeb.update_body()
+		weeb.update_hair()
 		qdel(src)
-
-/obj/item/anime/CtrlClick(mob/living/carbon/user)
-	var/new_color = input(user, "Choose your anime color:", "Anime Color","#"+ears.color) as color|null
-	if(new_color)
-		src.color = new_color
-	. = ..()
 
 //DERMAL IMPLANT SETS//
 /obj/item/anime/cat


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Overhauls Tails so that they work on any species they are implanted into.
Beware the plasmaman with a lizard tail.

Tail Wag emote code has been trashed and replaced with a better version that doesn't need so many snowflaked procs.

Changing your hair color with the weeb tool will update your hair color immediately.

Felinid Weebs can now eat rats and other gross objects like they had the ability to as a species.

Felinid Weebs now have their screams and laughs changed because why not.
SOMEONE forgot to delete them from the files, so I brought them back :^)

Slaps and stuns don't cause you to stop wagging your tail.

I spent too much time working on tails.

## Why It's Good For The Game

Dis pr is a tewwibwe idea and i wasted so much time wowking on taiw code, but it was so bad dat i couwdn't just weave it in dat state.
so i thought we couwd ovewhauw it fow any futuwe featuwes.
catgiwws and catgiwws(mawe) wiww enjoy it at weast?

On another note.
This is good because it allows for more potential future subspecies without needing the pain of maintaining a full species.
If you can create some catmoth abomination, this is giving the player the customization they want without requiring to create that species...or go full furry with the character customization screen. No.

## Changelog

:cl:
tweak: Anime autosurgeons now prompt you to change your hair color on usage
add: Tails can be wagged by any species
add: Felinid Weebs can eat rats without vomiting.
code: Throws out the old tail wagging code and makes it Better(tm)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
