### PR TITLE
Adds PDAs and crew pinpointers to mailmen

### DIFF
--- a/monkestation/code/modules/jobs/job_types/gimmick.dm
+++ b/monkestation/code/modules/jobs/job_types/gimmick.dm
@@ -1,14 +1,19 @@
 /datum/job/gimmick/mailman
 	title = "Mailman"
 	flag = MAILMAN
+	department_head = list("Head of Personnel")
+	department_flag = CIVILIAN
+	faction = "Station"
 	outfit = /datum/outfit/job/gimmick/mailman
 	access = list(ACCESS_MAINT_TUNNELS, ACCESS_MAILSORTING, ACCESS_CARGO)
 	minimal_access = list(ACCESS_MAINT_TUNNELS, ACCESS_MAILSORTING, ACCESS_CARGO)
 	total_positions = 1
+	supervisors = "the quartermaster and the head of personnel"
 	paycheck = PAYCHECK_EASY
 	gimmick = TRUE
 	chat_color = "#8ebee6"
 	departments = DEPARTMENT_CARGO
+	rpg_title = "Courier"
 
 	species_outfits = list(
 		SPECIES_PLASMAMAN = /datum/outfit/plasmaman/mailman
@@ -23,6 +28,8 @@
 	head = /obj/item/clothing/head/mailman
 	uniform = /obj/item/clothing/under/misc/mailman
 	shoes = /obj/item/clothing/shoes/laceup
+	r_pocket = /obj/item/pda/unlicensed
+	l_pocket = /obj/item/pinpointer/crew //for tracking down those mail recipients!
 	can_be_admin_equipped = TRUE
 
 /datum/outfit/plasmaman/mailman
@@ -33,6 +40,9 @@
 	shoes = /obj/item/clothing/shoes/laceup
 	head = /obj/item/clothing/head/helmet/space/plasmaman/mailman
 	uniform = /obj/item/clothing/under/plasmaman/mailman
+	belt = /obj/item/pda/unlicensed
+	r_pocket = /obj/item/pda/unlicensed
+	l_pocket = /obj/item/pinpointer/crew
 
 	helmet_variants = list(HELMET_MK2 = /obj/item/clothing/head/helmet/space/plasmaman/mailman/mark2,
 							HELMET_PROTECTIVE = /obj/item/clothing/head/helmet/space/plasmaman/mailman/protective)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Causes mailmen to spawn with an unlicensed PDA and a crew pinpointer, to more easily communicate and track down those pesky delivery targets!  A proper manifest is slightly guarded, but a PDA can act as one in a pinch.

It also adds a few properties to the mailman definition, including the RPG title of Courier

## Why It's Good For The Game

It was kinda frustrating when you'd get a letter for someone and have NO idea where they were, only a vague hint from the envelope color!

## Changelog

:cl:
add: Mailmen now spawn with PDAs and Crew Pinpointers!  For finding their delivery targets, definitely not for stalking people.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
