### PR TITLE
Fixes plasmaman security starting without envirohelms

### DIFF
--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -110,10 +110,10 @@ GLOBAL_LIST_INIT(available_depts, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICAL, S
 	if(head)
 		if(H.dna.species.id == SPECIES_PLASMAMAN) // we REALLY don't want to delete plasmamen's helmets
 			H.equip_to_slot_or_del(new head(H),ITEM_SLOT_BACKPACK, TRUE) // also don't want to just delete the new hat, so we put the hat in their backpack instead
-		else:
+		else
 			if(H.head)
 				qdel(H.head)
-			H.equip_or_collect(new head(H),ITEM_SLOT_HEAD)
+			H.equip_to_slot_or_del(new head(H),ITEM_SLOT_HEAD)
 	//monkestation edit end
 	var/obj/item/card/id/W = H.wear_id
 	W.access |= dep_access

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -68,7 +68,7 @@ GLOBAL_LIST_INIT(available_depts, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICAL, S
 			spawn_point = locate(/obj/effect/landmark/start/depsec/supply) in GLOB.department_security_spawns
 			accessory = /obj/item/clothing/accessory/armband/cargo
 			suit = /obj/item/clothing/suit/armor/secduster/cargo //monkestation edit: add departmental sec outfits
-			head = /obj/item/clothing/head/helmet/hat/cowboy/cargo//monkestation edit: add departmental sec outfits
+			head = /obj/item/clothing/head/helmet/hat/cowboy/cargo //monkestation edit: add departmental sec outfits
 		if(SEC_DEPT_ENGINEERING)
 			ears = /obj/item/radio/headset/headset_sec/alt/department/engi
 			dep_access = list(ACCESS_CONSTRUCTION, ACCESS_ENGINE, ACCESS_ATMOSPHERICS, ACCESS_AUX_BASE)
@@ -91,8 +91,8 @@ GLOBAL_LIST_INIT(available_depts, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICAL, S
 			destination = /area/security/checkpoint/science
 			spawn_point = locate(/obj/effect/landmark/start/depsec/science) in GLOB.department_security_spawns
 			accessory = /obj/item/clothing/accessory/armband/science
-			suit = /obj/item/clothing/suit/armor/secduster/science//monkestation edit: add departmental sec outfits
-			head = /obj/item/clothing/head/helmet/hat/cowboy/science//monkestation edit: add departmental sec outfits
+			suit = /obj/item/clothing/suit/armor/secduster/science //monkestation edit: add departmental sec outfits
+			head = /obj/item/clothing/head/helmet/hat/cowboy/science //monkestation edit: add departmental sec outfits
 	if(accessory)
 		var/obj/item/clothing/under/U = H.w_uniform
 		U.attach_accessory(new accessory)
@@ -108,9 +108,12 @@ GLOBAL_LIST_INIT(available_depts, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICAL, S
 			H.equip_to_slot_or_del(new suit(H),ITEM_SLOT_OCLOTHING)
 			H.equip_to_slot_or_del(stored,ITEM_SLOT_SUITSTORE)
 	if(head)
-		if(H.head)
-			qdel(H.head)
-		H.equip_to_slot_or_del(new head(H),ITEM_SLOT_HEAD)
+		if(H.dna.species.id == SPECIES_PLASMAMAN) // we REALLY don't want to delete plasmamen's helmets
+			H.equip_to_slot_or_del(new head(H),ITEM_SLOT_BACKPACK, TRUE) // also don't want to just delete the new hat, so we put the hat in their backpack instead
+		else:
+			if(H.head)
+				qdel(H.head)
+			H.equip_or_collect(new head(H),ITEM_SLOT_HEAD)
 	//monkestation edit end
 	var/obj/item/card/id/W = H.wear_id
 	W.access |= dep_access


### PR DESCRIPTION
I'm surprised this wasn't found sooner

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

The departmental sec code didn't check if the helmet it was deleting was an envirohelm. This kills the plasmaman.
Plasmamen instead receive their departmental hat inside of their backpack.

## Why It's Good For The Game

It might be good to have plasmamen security not die on the arrivals shuttle.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/32023715/159613713-0bc0c155-5605-4a71-9482-ce6fbb10960b.png)

</details>

## Changelog

:cl:
fix: security plasmamen now keep their envirohelm, and no longer burn to death after spawning
/:cl:
