### PR TITLE
Extra Sticker Removal Methods

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -82,6 +82,13 @@
 	else
 		ExtinguishMob()
 		return TRUE //mob was put out, on_fire = FALSE via ExtinguishMob(), no need to update everything down the chain.
+	//MonkeStation Edit Start: Fire removes Stickers
+	for(var/obj/item/stickable/dummy_holder/dummy_stickable in vis_contents)
+		visible_message("<span class='notice'>[name]'s stickers burn up!</span>")
+		for(var/obj/item/stickable/dropping in dummy_stickable.contents)
+			qdel(dropping)
+		vis_contents -= dummy_stickable
+	//MonkeStation Edit End
 	var/datum/gas_mixture/G = loc.return_air() // Check if we're standing in an oxygenless environment
 	if(G.get_moles(GAS_O2) < 1)
 		ExtinguishMob() //If there's no oxygen in the tile we're on, put out the fire

--- a/monkestation/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/monkestation/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -18,9 +18,6 @@
 /datum/reagent/mutationtoxin/apid
 	can_synth = TRUE
 
-/datum/reagent/mutationtoxin/squid
-	can_synth = TRUE
-
 /datum/reagent/mutationtoxin/skeleton
 	can_synth = TRUE //Roundstart species
 
@@ -178,3 +175,29 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/effected = M
 		effected.emote("fart")
+
+//Acetone Sticker Removal
+/datum/reagent/acetone/reaction_mob(mob/living/M, method, reac_volume, show_message, touch_protection)
+	. = ..()
+	for(var/obj/item/stickable/dummy_holder/dummy_stickable in M.vis_contents)
+		M.visible_message("<span class='notice'>[M]'s stickers slide off!</span>")
+		for(var/obj/item/stickable/dropping in dummy_stickable.contents)
+			dropping.forceMove(get_turf(M))
+		M.vis_contents -= dummy_stickable
+
+
+/datum/reagent/acetone/reaction_obj(obj/O, volume)
+	. = ..()
+	for(var/obj/item/stickable/dummy_holder/dummy_stickable in O.vis_contents)
+		O.visible_message("<span class='notice'>The stickers slide right off of [O]!</span>")
+		for(var/obj/item/stickable/dropping in dummy_stickable.contents)
+			dropping.forceMove(get_turf(O))
+		O.vis_contents -= dummy_stickable
+
+/datum/reagent/acetone/reaction_turf(turf/T, volume)
+	. = ..()
+	for(var/obj/item/stickable/dummy_holder/dummy_stickable in T.vis_contents)
+		T.visible_message("<span class='notice'>The stickers attached to [T] lose their grip and fall off!</span>")
+		for(var/obj/item/stickable/dropping in dummy_stickable.contents)
+			dropping.forceMove(get_turf(T))
+		T.vis_contents -= dummy_stickable

--- a/monkestation/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/monkestation/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -179,11 +179,12 @@
 //Acetone Sticker Removal
 /datum/reagent/acetone/reaction_mob(mob/living/M, method, reac_volume, show_message, touch_protection)
 	. = ..()
-	for(var/obj/item/stickable/dummy_holder/dummy_stickable in M.vis_contents)
-		M.visible_message("<span class='notice'>[M]'s stickers slide off!</span>")
-		for(var/obj/item/stickable/dropping in dummy_stickable.contents)
-			dropping.forceMove(get_turf(M))
-		M.vis_contents -= dummy_stickable
+	if(method == TOUCH || VAPOR)
+		for(var/obj/item/stickable/dummy_holder/dummy_stickable in M.vis_contents)
+			M.visible_message("<span class='notice'>[M]'s stickers slide off!</span>")
+			for(var/obj/item/stickable/dropping in dummy_stickable.contents)
+				dropping.forceMove(get_turf(M))
+			M.vis_contents -= dummy_stickable
 
 
 /datum/reagent/acetone/reaction_obj(obj/O, volume)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Allows Acetone to remove stickers from Objects, Mobs and Turfs (Likely only flooring)

Causes stickers to burn off and get destroyed when a mob/living is burning.

## Why It's Good For The Game

More methods for sticker removal are nice.

## Changelog

:cl:
add: Acetone now removes stickers
add: Fire now destroys stickers on mobs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
