### PR TITLE
makes plasmacutters cost less to recharge

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -165,7 +165,7 @@
 /obj/item/gun/energy/plasmacutter/attackby(obj/item/I, mob/user)
 	var/charge_multiplier = 0 //2 = Refined stack, 1 = Ore
 	if(istype(I, /obj/item/stack/sheet/mineral/plasma))
-		charge_multiplier = 5
+		charge_multiplier = 5 // MonkeStation Edit
 	if(istype(I, /obj/item/stack/ore/plasma))
 		charge_multiplier = 3
 	if(charge_multiplier)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -173,7 +173,7 @@
 			to_chat(user, "<span class='notice'>You try to insert [I] into [src], but it's fully charged.</span>") //my cell is round and full
 			return
 		I.use(1)
-		cell.give(100*charge_multiplier)
+		cell.give(100*charge_multiplier) //MonkeStation Edit
 		to_chat(user, "<span class='notice'>You insert [I] in [src], recharging it.</span>")
 	else
 		..()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -167,7 +167,7 @@
 	if(istype(I, /obj/item/stack/sheet/mineral/plasma))
 		charge_multiplier = 5 // MonkeStation Edit
 	if(istype(I, /obj/item/stack/ore/plasma))
-		charge_multiplier = 3
+		charge_multiplier = 3 //MonkeStation Edit
 	if(charge_multiplier)
 		if(cell.charge == cell.maxcharge)
 			to_chat(user, "<span class='notice'>You try to insert [I] into [src], but it's fully charged.</span>") //my cell is round and full

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -165,15 +165,15 @@
 /obj/item/gun/energy/plasmacutter/attackby(obj/item/I, mob/user)
 	var/charge_multiplier = 0 //2 = Refined stack, 1 = Ore
 	if(istype(I, /obj/item/stack/sheet/mineral/plasma))
-		charge_multiplier = 2
+		charge_multiplier = 5
 	if(istype(I, /obj/item/stack/ore/plasma))
-		charge_multiplier = 1
+		charge_multiplier = 3
 	if(charge_multiplier)
 		if(cell.charge == cell.maxcharge)
 			to_chat(user, "<span class='notice'>You try to insert [I] into [src], but it's fully charged.</span>") //my cell is round and full
 			return
 		I.use(1)
-		cell.give(50*charge_multiplier)
+		cell.give(100*charge_multiplier)
 		to_chat(user, "<span class='notice'>You insert [I] in [src], recharging it.</span>")
 	else
 		..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

simple PR changing some numbers to make plasma cutters cost less plasma to recharge

## Why It's Good For The Game

plasma cutters currently cost a lot of plasma to recharge, this makes them actually useful by using less plasma. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->


## Changelog

:cl:
balance: Plasma Cutters require less plasma to charge

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
