### PR TITLE
Mons for Monke!

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -5833,8 +5833,7 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "amN" = (
-/mob/living/simple_animal/pet/dog/australianshepherd/captain,//monkestation edit
-/obj/structure/bed/dogbed/walter,
+/mob/living/simple_animal/pet/dog/australianshepherd/captain,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "amQ" = (
@@ -54420,6 +54419,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"qbL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/mob/living/carbon/monkey{
+	name = "Monsieur Stirstir";
+	unique_name = 0
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qcI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -88989,7 +89002,7 @@ aiz
 ajg
 akl
 akR
-eGg
+qbL
 alx
 amR
 anw

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -6667,8 +6667,7 @@
 	pixel_y = 32
 	},
 /obj/structure/bed/dogbed/walter,
-/mob/living/simple_animal/pet/dog/australianshepherd/captain,//monkestation edit
-/turf/open/floor/plasteel/dark,
+/mob/living/simple_animal/pet/dog/australianshepherd/captain,
 /area/security/warden)
 "bFC" = (
 /obj/structure/table/glass,
@@ -23599,6 +23598,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/upper/primary/fore)
+"fyB" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/mob/living/carbon/monkey{
+	name = "Monsieur Stirstir";
+	unique_name = 0
+	},
+/turf/open/floor/carpet/blue,
+/area/security/brig)
 "fyC" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
@@ -142804,7 +142813,7 @@ lDB
 wBl
 pCn
 roY
-kcQ
+fyB
 mNE
 eCV
 dgF

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -105894,6 +105894,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"ivs" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/mob/living/carbon/monkey{
+	name = "Monsieur Stirstir";
+	unique_name = 0
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "iwe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
@@ -168986,7 +169000,7 @@ bLl
 bNj
 bPo
 bRo
-bLl
+ivs
 bNj
 bXC
 bZL

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -23836,6 +23836,23 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/storage)
+"fsB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/mob/living/carbon/monkey{
+	name = "Monsieur Stirstir";
+	unique_name = 0
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "fsJ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 1
@@ -95870,10 +95887,7 @@
 /area/hallway/secondary/entry)
 "wzL" = (
 /obj/structure/bed/dogbed/walter,
-/mob/living/simple_animal/pet/dog/australianshepherd/captain,//monkestation edit
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
+/mob/living/simple_animal/pet/dog/australianshepherd/captain,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
@@ -135290,7 +135304,7 @@ uwz
 mdb
 uNi
 hrw
-oUo
+fsB
 kBH
 xiy
 fDh

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -102490,6 +102490,21 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/fore)
+"rpk" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/mob/living/carbon/monkey{
+	name = "Monsieur Stirstir";
+	unique_name = 0
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "rrF" = (
 /obj/machinery/door/firedoor,
 /obj/structure/door_assembly/door_assembly_ext{
@@ -126380,7 +126395,7 @@ cht
 bPE
 cLV
 cwN
-bkT
+rpk
 aiZ
 bWN
 acp

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -9719,8 +9719,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ass" = (
-/mob/living/simple_animal/pet/dog/australianshepherd/captain,//monkestation edit
-/obj/structure/bed/dogbed/walter,
+/mob/living/simple_animal/pet/dog/australianshepherd/captain,
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -30
 	},
@@ -79839,6 +79838,21 @@
 "jwW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/crew_quarters/fitness/recreation)
+"jyc" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/mob/living/carbon/monkey{
+	name = "Monsieur Stirstir";
+	head = /obj/item/clothing/head/soft/orange
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jyQ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -108810,7 +108824,7 @@ auV
 awb
 axe
 ayx
-azE
+jyc
 arN
 aCl
 aDx

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -79849,7 +79849,7 @@
 	},
 /mob/living/carbon/monkey{
 	name = "Monsieur Stirstir";
-	head = /obj/item/clothing/head/soft/orange
+	unique_name = 0
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -62386,6 +62386,17 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
 /turf/open/floor/plating,
 /area/science/mixing)
+"wPP" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/carbon/monkey{
+	name = "Monsieur Stirstir";
+	unique_name = 0
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "wQU" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable/yellow{
@@ -86754,7 +86765,7 @@ aqt
 arp
 asC
 atD
-auz
+wPP
 avA
 awJ
 ekg


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

brings Monsieur Stirstir from Goon's Cogmap 1's security imprisoned convict monkey "pet" into monkey code in one of the brig cells for each and every map in monke code, Beware the chimp who was convicted for causing many stations by NanoTrasen to blow up or be plasmaflooded..

## Why It's Good For The Game

CRIMER CHIMP ON THE FINAL APE ESCAPE!!

## Changelog

:cl:
add:adds in Monsieur Stirstir from Goon! or rather atleast our own version of him due to tg monkes being different then Goon monkes and etc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
