### PR TITLE
Larry Changes

### DIFF
--- a/code/datums/components/larryknife.dm
+++ b/code/datums/components/larryknife.dm
@@ -6,7 +6,7 @@
 	var/static/list/default_connections = list(COMSIG_ATOM_ENTERED = .proc/knife_crossed)
 
 /datum/component/knife_attached_to_movable/Initialize(damage = 0)
-	knife_damage = damage
+	knife_damage = min(5, damage) //MonkeStation Edit: 5 damage a hit max
 	RegisterSignal(parent, COMSIG_ATOM_ENTERED, .proc/knife_crossed)
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, .proc/knife_move)
 	add_connect_loc_behalf_to_parent()

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -302,6 +302,7 @@
 	desc = "A little Larry, he looks so excited!"
 	icon_state = "larry0"
 	var/obj/item/kitchen/knife/knife //You know exactly what this is about
+	var/datum/component/knife_attached_to_movable/larry_knife //MonkeStation Edit
 
 /mob/living/simple_animal/bot/cleanbot/larry/Initialize(mapload)
 	. = ..()
@@ -387,7 +388,7 @@
 			knife = newknife
 			newknife.forceMove(src)
 			message_admins("[user] attached a [newknife.name] to [src]") //This should definitely be a notified thing.
-			AddComponent(/datum/component/knife_attached_to_movable, knife.force)
+			larry_knife = AddComponent(/datum/component/knife_attached_to_movable, knife.force) //MonkeStation Edit
 			update_icons()
 		else
 			return ..()
@@ -409,8 +410,10 @@
 
 	if(prob(50))
 		drop_part(robot_arm, Tsec)
-	if(knife && prob(50))
-		new knife(Tsec)
+	//MonkeStation Edit Start: Larry Fixes
+	if(knife)
+		qdel(larry_knife)
+	//MonkeStation Edit End
 
 	do_sparks(3, TRUE, src)
 	qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Larry now has a maximum damage of 5, since it is not a direct stab.

Removed the chance to drop the existing knife inside, which caused the Larry corpse to stay.
Undead Larrys cannot stab you anymore.

## Why It's Good For The Game

A swarm of 5 robots should not be able to put you into crit just by walking over them.
(Personally I'd rather just remove this feature entirely, it's horrid)

## Changelog

:cl:
balance: Reduced Larry's damage to 5, down from 10-20
fix: Larry no longer leaves invisible corpses that can still stab you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
