### PR TITLE
Junk Food Reduction

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -3090,7 +3090,6 @@
 /area/security/warden)
 "agY" = (
 /obj/structure/table,
-/obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -5833,8 +5832,7 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "amN" = (
-/mob/living/simple_animal/pet/dog/australianshepherd/captain,//monkestation edit
-/obj/structure/bed/dogbed/walter,
+/mob/living/simple_animal/pet/dog/australianshepherd/captain,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "amQ" = (
@@ -15540,7 +15538,6 @@
 /area/bridge)
 "aSE" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel,
 /area/bridge)
 "aSF" = (
@@ -16493,7 +16490,6 @@
 /area/crew_quarters/kitchen)
 "aVA" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/pie/cream,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aVB" = (
@@ -18150,11 +18146,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
-"baP" = (
-/obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/carpet/royalblue,
-/area/crew_quarters/heads/captain)
 "baQ" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -19092,7 +19083,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bdX" = (
-/obj/item/storage/fancy/donut_box,
 /obj/structure/table,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
@@ -28991,11 +28981,6 @@
 	dir = 1
 	},
 /obj/structure/table,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -3;
-	pixel_y = 5
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bLg" = (
@@ -39762,11 +39747,6 @@
 /area/medical/genetics)
 "cvN" = (
 /obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cvO" = (
@@ -54689,7 +54669,6 @@
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
-/obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -57900,9 +57879,6 @@
 /area/science/misc_lab)
 "uCC" = (
 /obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 4
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
@@ -58233,11 +58209,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"vbg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/donkpockets,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
 "vbZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -58348,16 +58319,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"vkT" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "vnK" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/color/latex,
@@ -82604,7 +82565,7 @@ baS
 bbP
 baS
 bcE
-vbg
+baS
 bex
 gjl
 bgu
@@ -92881,7 +92842,7 @@ vrY
 wwp
 aZV
 bao
-baP
+bbZ
 bbZ
 bcP
 cBo
@@ -99561,7 +99522,7 @@ aTM
 aVB
 aVz
 aVz
-vkT
+kVI
 bbz
 aYV
 aYV

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -16512,10 +16512,6 @@
 /area/crew_quarters/kitchen)
 "aVE" = (
 /obj/structure/table,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/item/reagent_containers/glass/beaker{
 	pixel_x = 5
 	},
@@ -48262,10 +48258,6 @@
 /area/hydroponics/garden)
 "jac" = (
 /obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "jbf" = (
@@ -49988,10 +49980,6 @@
 /area/crew_quarters/kitchen)
 "kWa" = (
 /obj/structure/table,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/machinery/newscaster{
 	pixel_x = -30
 	},

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -6667,8 +6667,7 @@
 	pixel_y = 32
 	},
 /obj/structure/bed/dogbed/walter,
-/mob/living/simple_animal/pet/dog/australianshepherd/captain,//monkestation edit
-/turf/open/floor/plasteel/dark,
+/mob/living/simple_animal/pet/dog/australianshepherd/captain,
 /area/security/warden)
 "bFC" = (
 /obj/structure/table/glass,
@@ -8584,7 +8583,6 @@
 	dir = 8
 	},
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "cbQ" = (
@@ -10578,7 +10576,6 @@
 /area/hallway/upper/primary/fore)
 "czL" = (
 /obj/structure/rack,
-/obj/item/storage/fancy/donut_box,
 /obj/item/key/security,
 /obj/item/key/security,
 /obj/effect/turf_decal/delivery,
@@ -23541,7 +23538,6 @@
 /area/quartermaster/storage)
 "fyl" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "fym" = (
@@ -30593,8 +30589,6 @@
 /area/security/brig)
 "haF" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/spawner/lootdrop/donkpockets,
 /obj/machinery/light/small,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -57524,7 +57518,6 @@
 /area/hallway/primary/starboard)
 "nzO" = (
 /obj/structure/table/glass,
-/obj/item/storage/box/donkpockets,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -99048,7 +99041,6 @@
 /area/science/xenobiology)
 "xsL" = (
 /obj/structure/table,
-/obj/item/storage/fancy/donut_box,
 /obj/item/taperecorder,
 /obj/effect/turf_decal/tile/red{
 	dir = 1

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -5131,7 +5131,6 @@
 /area/hallway/secondary/entry)
 "ams" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/entry)
 "amu" = (
@@ -18881,7 +18880,6 @@
 "aPh" = (
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
-/obj/item/storage/box/donkpockets,
 /obj/item/clothing/head/chefhat,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -19810,10 +19808,6 @@
 /area/security/prison)
 "aQZ" = (
 /obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -2;
-	pixel_y = 5
-	},
 /turf/open/floor/plating,
 /area/security/prison)
 "aRb" = (
@@ -20528,26 +20522,6 @@
 /area/quartermaster/storage)
 "aSp" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/box/donkpockets,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"aSq" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -3;
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -26363,7 +26337,6 @@
 	id = "kitchencounter";
 	name = "Kitchen Counter Shutters"
 	},
-/obj/item/storage/fancy/donut_box,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
@@ -26532,18 +26505,12 @@
 /area/quartermaster/miningoffice)
 "bcE" = (
 /obj/structure/table,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -3;
-	pixel_y = 5
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bcF" = (
 /obj/structure/table,
-/obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
@@ -31588,7 +31555,6 @@
 /area/security/main)
 "bmo" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -36246,7 +36212,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -38602,7 +38567,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bzo" = (
@@ -44329,7 +44293,6 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel/grimy,
 /area/bridge)
 "bIP" = (
@@ -46755,7 +46718,6 @@
 /area/crew_quarters/heads/captain)
 "bMM" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "bMN" = (
@@ -47810,7 +47772,6 @@
 /area/bridge/meeting_room/council)
 "bOC" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet/royalblue,
 /area/bridge/meeting_room/council)
 "bOF" = (
@@ -50114,11 +50075,6 @@
 /area/bridge/meeting_room/council)
 "bSD" = (
 /obj/structure/table/wood,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -3;
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -50133,7 +50089,6 @@
 /area/tcommsat/computer)
 "bSE" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/donkpockets,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bSF" = (
@@ -54736,7 +54691,6 @@
 /area/engine/engineering)
 "cav" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -57054,10 +57008,6 @@
 /area/crew_quarters/heads/captain/private)
 "ceM" = (
 /obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -2;
-	pixel_y = 5
-	},
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
@@ -57917,7 +57867,6 @@
 /obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
-/obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -61318,7 +61267,6 @@
 /area/library)
 "cnS" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel/grimy,
 /area/library)
 "cnT" = (
@@ -62665,7 +62613,6 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -64053,7 +64000,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -68246,7 +68192,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet/blue,
 /area/bridge/showroom/corporate)
 "cDa" = (
@@ -77569,19 +77514,6 @@
 /area/medical/storage)
 "cYa" = (
 /obj/structure/table/wood,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/medical/medbay/central)
-"cYb" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -77674,8 +77606,6 @@
 /area/maintenance/starboard/aft)
 "cYn" = (
 /obj/structure/closet/crate,
-/obj/item/storage/box/donkpockets,
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -94400,11 +94330,6 @@
 /area/science/research)
 "dMc" = (
 /obj/structure/table/wood,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -3;
-	pixel_y = 5
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
@@ -94421,7 +94346,6 @@
 /area/science/research)
 "dMd" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/donkpockets,
 /obj/structure/sign/poster/official/report_crimes{
 	pixel_y = 32
 	},
@@ -101447,7 +101371,6 @@
 /area/chapel/office)
 "eeF" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
 /obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
@@ -101527,7 +101450,6 @@
 /area/security/checkpoint/escape)
 "eeL" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -104078,7 +104000,6 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "gfA" = (
@@ -112237,8 +112158,6 @@
 "qer" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/bot,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/item/storage/box/donkpockets,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "qeD" = (
@@ -163067,7 +162986,7 @@ azC
 aAG
 aOW
 axk
-aSq
+aSp
 aUf
 aVO
 azy
@@ -166988,7 +166907,7 @@ cIW
 cPy
 cUQ
 cPy
-cYb
+cYa
 cZN
 cZN
 ddi

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -1260,10 +1260,6 @@
 /area/space/nearstation)
 "arf" = (
 /obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -2;
-	pixel_y = 5
-	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/light/small{
 	dir = 8
@@ -6771,9 +6767,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red/tile_marquee,
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/aft)
 "bEg" = (
@@ -6787,7 +6780,6 @@
 /area/security/checkpoint/escape)
 "bEr" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/donkpockets,
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
@@ -22580,7 +22572,6 @@
 	dir = 4
 	},
 /obj/structure/table,
-/obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -27061,11 +27052,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint)
-"ghp" = (
-/obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/carpet/green,
-/area/crew_quarters/dorms)
 "ghy" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -30419,7 +30405,6 @@
 /area/hallway/primary/central)
 "gVn" = (
 /obj/structure/table,
-/obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -35756,14 +35741,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
-"igC" = (
-/obj/structure/table,
-/obj/item/storage/box/donkpockets/donkpocketpizza,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/quartermaster/miningdock)
 "igE" = (
 /obj/structure/cable/yellow,
 /obj/machinery/power/apc/auto_name/south{
@@ -43939,17 +43916,6 @@
 	dir = 1
 	},
 /area/teleporter)
-"kbS" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/table/wood,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 8
-	},
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/carpet/royalblue,
-/area/bridge/meeting_room/council)
 "kbT" = (
 /obj/machinery/light/small,
 /obj/machinery/light_switch{
@@ -55668,7 +55634,6 @@
 /area/science/robotics/lab)
 "mQG" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plasteel/sepia,
 /area/engine/break_room)
 "mQK" = (
@@ -57127,7 +57092,6 @@
 /area/engine/atmospherics_engine)
 "nly" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -59496,7 +59460,6 @@
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 31
 	},
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "nNz" = (
@@ -63256,10 +63219,6 @@
 /area/maintenance/port/central)
 "oLk" = (
 /obj/structure/table/reinforced,
-/obj/machinery/microwave{
-	pixel_x = -2;
-	pixel_y = 5
-	},
 /obj/item/radio/intercom{
 	pixel_x = -28
 	},
@@ -65208,7 +65167,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "pmi" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
@@ -71918,16 +71876,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/carpet/red,
 /area/crew_quarters/bar/atrium)
-"qRp" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchencounter";
-	name = "Kitchen Counter Shutters"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/techmaint,
-/area/crew_quarters/kitchen)
 "qRr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 8
@@ -74085,7 +74033,6 @@
 /area/bridge/showroom/corporate)
 "rpl" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "rpn" = (
@@ -79214,7 +79161,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/obj/effect/spawner/lootdrop/donkpocketsfinlandia,
 /turf/open/floor/plasteel/dark,
 /area/science/research)
 "sCR" = (
@@ -79264,11 +79210,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -3;
-	pixel_y = 5
-	},
 /turf/open/floor/plasteel/dark,
 /area/science/research)
 "sDz" = (
@@ -80326,9 +80267,6 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30
-	},
-/obj/machinery/microwave{
-	pixel_y = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -81673,7 +81611,6 @@
 /area/crew_quarters/locker)
 "tcL" = (
 /obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/donkpockets,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/red/tile_full,
 /turf/open/floor/plasteel/dark,
@@ -88369,11 +88306,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/carpet/royalblack,
 /area/bridge/showroom/corporate)
-"uFj" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/chips,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "uFn" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -92436,7 +92368,6 @@
 /area/crew_quarters/theatre/backstage)
 "vDI" = (
 /obj/structure/table/wood,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "vDT" = (
@@ -93080,7 +93011,6 @@
 	pixel_x = -4
 	},
 /obj/item/book/granter/crafting_recipe/cooking_sweets_101,
-/obj/item/storage/box/donkpockets,
 /obj/item/clothing/head/chefhat,
 /obj/structure/railing{
 	dir = 8
@@ -93880,10 +93810,6 @@
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
-	},
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_y = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
@@ -95870,10 +95796,7 @@
 /area/hallway/secondary/entry)
 "wzL" = (
 /obj/structure/bed/dogbed/walter,
-/mob/living/simple_animal/pet/dog/australianshepherd/captain,//monkestation edit
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
+/mob/living/simple_animal/pet/dog/australianshepherd/captain,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
@@ -96908,10 +96831,6 @@
 /area/science/research)
 "wLK" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/cheesiehonkers{
-	pixel_x = -4;
-	pixel_y = 4
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -98270,13 +98189,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"xcA" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/red/tile_full,
-/turf/open/floor/plasteel/dark,
-/area/security/main)
 "xcZ" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering locker room";
@@ -101585,7 +101497,6 @@
 /area/science/storage)
 "xTQ" = (
 /obj/structure/table,
-/obj/effect/spawner/lootdrop/donkpockets,
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
@@ -125001,7 +124912,7 @@ sRt
 cQU
 wPM
 ucD
-uFj
+vLs
 klM
 vJu
 wKy
@@ -126277,7 +126188,7 @@ dfs
 dfs
 qjG
 qBy
-qRp
+sSd
 vFy
 ufT
 sgs
@@ -132749,7 +132660,7 @@ uId
 uId
 xMs
 vXA
-igC
+vXA
 fKP
 wZH
 nBQ
@@ -135269,7 +135180,7 @@ oPO
 cpE
 kNC
 tcL
-xcA
+tcL
 pIQ
 qFU
 kNC
@@ -143717,7 +143628,7 @@ xsj
 cYr
 dgw
 dvr
-kbS
+dHj
 uIA
 xsj
 ekC
@@ -149413,7 +149324,7 @@ wtw
 wtw
 gEZ
 teQ
-ghp
+tAK
 tYd
 uvd
 wtw

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -4968,7 +4968,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiJ" = (
@@ -5004,7 +5003,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/item/reagent_containers/food/snacks/donut,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiL" = (
@@ -8253,10 +8251,6 @@
 	},
 /obj/structure/table,
 /obj/effect/decal/cleanable/vomit/old,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/maintenance/department/science)
 "anO" = (
@@ -9501,7 +9495,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "apQ" = (
@@ -16055,7 +16048,6 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "azC" = (
-/obj/item/storage/fancy/donut_box,
 /obj/structure/table/wood,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
@@ -23467,9 +23459,6 @@
 	dir = 8
 	},
 /obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
@@ -26407,10 +26396,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aPL" = (
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 5
-	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -26592,9 +26577,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/cmo)
 "aPW" = (
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -27159,9 +27141,6 @@
 	dir = 1
 	},
 /obj/structure/table,
-/obj/item/storage/box/donkpockets{
-	pixel_y = 5
-	},
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
@@ -30229,7 +30208,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/item/storage/fancy/donut_box,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -43918,14 +43896,6 @@
 	pixel_x = -8;
 	pixel_y = 12
 	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 6;
-	pixel_y = 6
-	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "boB" = (
@@ -44347,7 +44317,6 @@
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
-/obj/item/storage/fancy/donut_box,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchen_2";
 	name = "Hallway Hatch"
@@ -47233,7 +47202,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/storage/fancy/donut_box,
 /obj/machinery/newscaster{
 	pixel_y = -30
 	},
@@ -61508,7 +61476,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/item/storage/fancy/donut_box,
 /obj/structure/table,
 /obj/machinery/camera{
 	c_tag = "Courtroom Jury";
@@ -63698,9 +63665,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
-	},
-/obj/machinery/microwave{
-	pixel_y = 5
 	},
 /obj/structure/table,
 /obj/machinery/firealarm{
@@ -89253,7 +89217,6 @@
 	name = "Security Desk";
 	req_one_access_txt = "63"
 	},
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "cIV" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -996,10 +996,6 @@
 /area/security/prison)
 "acq" = (
 /obj/structure/table,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 2;
-	pixel_y = 1
-	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -23
@@ -1136,10 +1132,6 @@
 /area/security/execution/education)
 "acD" = (
 /obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -3711,7 +3703,6 @@
 	pixel_x = -22
 	},
 /obj/structure/rack,
-/obj/item/storage/fancy/donut_box,
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/beacon/nettingportal,
@@ -8532,7 +8523,6 @@
 /obj/structure/table,
 /obj/item/folder/red,
 /obj/item/pen,
-/obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plasteel,
 /area/security/main)
 "apZ" = (
@@ -14372,12 +14362,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
-"aBY" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/donkpockets,
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
 "aBZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/corner{
@@ -17277,7 +17261,6 @@
 /area/crew_quarters/dorms)
 "aHV" = (
 /obj/structure/closet,
-/obj/item/storage/box/donkpockets,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -23502,7 +23485,6 @@
 	icon_state = "0-4"
 	},
 /obj/structure/table,
-/obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "aUH" = (
@@ -32391,7 +32373,6 @@
 /area/engine/break_room)
 "blo" = (
 /obj/structure/table/glass,
-/obj/item/storage/box/donkpockets,
 /obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko{
 	pixel_x = -6;
 	pixel_y = 6
@@ -34093,7 +34074,6 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/item/storage/fancy/donut_box,
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -34379,9 +34359,6 @@
 /area/hallway/primary/starboard)
 "bpg" = (
 /obj/structure/table/reinforced,
-/obj/machinery/microwave{
-	pixel_y = 6
-	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bph" = (
@@ -38285,7 +38262,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/item/storage/fancy/donut_box,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -40478,15 +40454,11 @@
 /turf/open/space,
 /area/space/nearstation)
 "bAU" = (
-/obj/machinery/microwave{
-	pixel_y = 4
-	},
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "bAV" = (
 /obj/machinery/light/small,
-/obj/item/storage/box/donkpockets,
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
@@ -44597,7 +44569,6 @@
 	id = "kitchen";
 	name = "Serving Hatch"
 	},
-/obj/item/reagent_containers/food/snacks/pie/cream,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -44625,18 +44596,6 @@
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
-"bKj" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "Serving Hatch"
-	},
-/obj/item/storage/fancy/donut_box,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -46074,7 +46033,6 @@
 	pixel_y = 6
 	},
 /obj/item/stack/packageWrap,
-/obj/item/storage/box/donkpockets,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -46692,7 +46650,6 @@
 /area/crew_quarters/kitchen)
 "bOT" = (
 /obj/structure/table,
-/obj/item/storage/box/donkpockets,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -47736,7 +47693,6 @@
 /area/bridge/showroom/corporate)
 "bRH" = (
 /obj/structure/table,
-/obj/item/storage/fancy/donut_box,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
@@ -55043,7 +54999,6 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -32
 	},
-/obj/item/storage/box/donkpockets,
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -56721,10 +56676,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "clN" = (
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -64481,10 +64432,6 @@
 /obj/machinery/newscaster{
 	pixel_y = -30
 	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 5
-	},
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -64515,10 +64462,6 @@
 	},
 /area/medical/medbay/aft)
 "cBX" = (
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -68966,10 +68909,6 @@
 /area/medical/virology)
 "cKl" = (
 /obj/structure/table/glass,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/machinery/light_switch{
 	pixel_y = 26
 	},
@@ -68990,10 +68929,6 @@
 	pixel_x = 29
 	},
 /obj/structure/table/glass,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
@@ -102181,7 +102116,7 @@ art
 ayl
 aEt
 aAK
-aBY
+aDk
 aDk
 aEA
 aFK
@@ -118410,7 +118345,7 @@ bwO
 wOT
 bwO
 bBT
-bKj
+bKg
 bLK
 bjr
 ddE

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -3633,9 +3633,6 @@
 /area/security/main)
 "ajm" = (
 /obj/structure/table,
-/obj/item/storage/fancy/donut_box{
-	pixel_y = 2
-	},
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
@@ -20613,22 +20610,6 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"bad" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchenshutters";
-	name = "kitchen shutters"
-	},
-/obj/item/storage/fancy/donut_box,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "bae" = (
 /obj/structure/chair/stool/bar,
@@ -48754,9 +48735,6 @@
 /area/bridge)
 "eCa" = (
 /obj/structure/table,
-/obj/item/storage/box/donkpockets{
-	pixel_y = 5
-	},
 /obj/item/reagent_containers/food/drinks/soda_cans/lemon_lime,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -50192,10 +50170,6 @@
 /area/chapel/main/monastery)
 "gmn" = (
 /obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "gmp" = (
@@ -93980,7 +93954,7 @@ aWe
 pJx
 aRN
 aYX
-bad
+bbl
 bbl
 bbl
 bbl

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -35,10 +35,16 @@
 
 /obj/structure/closet/secure_closet/freezer/kitchen/PopulateContents()
 	..()
-	for(var/i = 0, i < 3, i++)
+	//MonkeStation Edit Start: Increased Roundstart Supplies
+	for(var/i = 0, i < 4, i++)
 		new /obj/item/reagent_containers/food/condiment/flour(src)
-	new /obj/item/reagent_containers/food/condiment/rice(src)
+		new /obj/item/reagent_containers/food/condiment/rice(src)
+	for(var/i = 0, i < 3, i++)
+		new /obj/item/reagent_containers/food/snacks/grown/potato(src)
+		new /obj/item/reagent_containers/food/snacks/grown/tomato(src)
 	new /obj/item/reagent_containers/food/condiment/sugar(src)
+	new /obj/item/storage/box/ingredients/wildcard(src)
+	//MonkeStation Edit End
 
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance
 	name = "maintenance refrigerator"
@@ -46,13 +52,8 @@
 	req_access = list()
 
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance/PopulateContents()
-	..()
 	for(var/i = 0, i < 5, i++)
-		new /obj/item/reagent_containers/food/condiment/milk(src)
-	for(var/i = 0, i < 5, i++)
-		new /obj/item/reagent_containers/food/condiment/soymilk(src)
-	for(var/i = 0, i < 2, i++)
-		new /obj/item/storage/fancy/egg_box(src)
+		new /obj/item/reagent_containers/food/condiment/soymilk(src) //MonkeStation Edit: Soy Milk for maint
 
 /obj/structure/closet/secure_closet/freezer/kitchen/mining
 	req_access = list()
@@ -63,7 +64,7 @@
 
 /obj/structure/closet/secure_closet/freezer/meat/PopulateContents()
 	..()
-	for(var/i = 0, i < 4, i++)
+	for(var/i = 0, i < 8, i++) //MonkeStation Edit: Doubled Meat
 		new /obj/item/reagent_containers/food/snacks/meat/slab/monkey(src)
 
 /obj/structure/closet/secure_closet/freezer/meat/open
@@ -77,11 +78,10 @@
 
 /obj/structure/closet/secure_closet/freezer/fridge/PopulateContents()
 	..()
-	for(var/i = 0, i < 5, i++)
+	for(var/i = 0, i < 4, i++) //MonkeStation Edit: Less Milk
 		new /obj/item/reagent_containers/food/condiment/milk(src)
-	for(var/i = 0, i < 5, i++)
 		new /obj/item/reagent_containers/food/condiment/soymilk(src)
-	for(var/i = 0, i < 2, i++)
+	for(var/i = 0, i < 3, i++) //MonkeStation Edit: More eggs!
 		new /obj/item/storage/fancy/egg_box(src)
 
 /obj/structure/closet/secure_closet/freezer/fridge/open

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -446,7 +446,7 @@
 /datum/supply_pack/security/vending/security
 	name = "SecTech Supply Crate"
 	desc = "Officer Paul bought all the donuts? Then refill the security vendor with ths crate."
-	cost = 1200
+	cost = 2400 //MonkeStation Edit: Junk food vending cost increase
 	contains = list(/obj/item/vending_refill/security)
 	crate_name = "SecTech supply crate"
 
@@ -2012,7 +2012,7 @@
 /datum/supply_pack/service/vending/snack
 	name = "Snack Supply Crate"
 	desc = "One vending machine refill of cavity-bringin' goodness! The number one dentist recommended order!"
-	cost = 800
+	cost = 1500 //MonkeStation Edit: Junk food vending cost increase
 	contains = list(/obj/item/vending_refill/snack)
 	crate_name = "snacks supply crate"
 
@@ -2079,7 +2079,7 @@
 /datum/supply_pack/organic/randomized/chef
 	name = "Excellent Meat Crate"
 	desc = "The best cuts in the whole galaxy."
-	cost = 1700
+	cost = 1200 //MonkeStation Edit: Reduction in raw food costs
 	access_budget = ACCESS_KITCHEN
 	contains = list(/obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/slime,
 					/obj/item/reagent_containers/food/snacks/meat/slab/killertomato,
@@ -2124,7 +2124,7 @@
 /datum/supply_pack/organic/food
 	name = "Food Crate"
 	desc = "Get things cooking with this crate full of useful ingredients! Contains a dozen eggs, three bananas, and some flour, rice, milk, soymilk, salt, pepper, enzyme, sugar, and monkeymeat."
-	cost = 1000
+	cost = 800 //MonkeStation Edit: Decrease of raw food crate costs
 	access_budget = ACCESS_KITCHEN
 	contains = list(/obj/item/reagent_containers/food/condiment/flour,
 					/obj/item/reagent_containers/food/condiment/rice,
@@ -2144,7 +2144,7 @@
 /datum/supply_pack/organic/randomized/chef/fruits
 	name = "Fruit Crate"
 	desc = "Rich of vitamins, may contain oranges."
-	cost = 1200
+	cost = 800 //MonkeStation Edit: Decrease of raw food crate costs
 	access_budget = ACCESS_KITCHEN
 	contains = list(/obj/item/reagent_containers/food/snacks/grown/citrus/lime,
 					/obj/item/reagent_containers/food/snacks/grown/citrus/orange,
@@ -2261,7 +2261,7 @@
 /datum/supply_pack/organic/randomized/chef/vegetables
 	name = "Vegetables Crate"
 	desc = "Grown in vats."
-	cost = 1000
+	cost = 600 //MonkeStation Edit: Decrease of raw food crate costs
 	access_budget = ACCESS_KITCHEN
 	contains = list(/obj/item/reagent_containers/food/snacks/grown/chili,
 					/obj/item/reagent_containers/food/snacks/grown/corn,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2207,7 +2207,7 @@
 	. = ..()
 	if(!anomalous_box_provided)
 		for(var/obj/item/pizzabox/P in C)
-			if(prob(1)) //1% chance for each box, so 4% total chance per order
+			if(prob(0.20)) //0.20% chance for each box, so 1% total chance per order//MonkeStation Edit: Reduced odds
 				var/obj/item/pizzabox/infinite/fourfiveeight = new(C)
 				fourfiveeight.boxtag = P.boxtag
 				qdel(P)
@@ -2489,7 +2489,7 @@
 
 /datum/supply_pack/critter/snake
 	name = "Snake Crate"
-	desc = "Tired of these MOTHER FUCKING snakes on this MOTHER FUCKING space station? Then this isn't the crate for you. Contains three poisonous snakes."
+	desc = "Tired of these MOTHER FUCKING snakes on this MOTHER FUCKING space station? Then this isn't the crate for you. Contains three poisonous snakes." //aren't they technically venomous?
 	cost = 3000
 	access_budget = ACCESS_SECURITY
 	contains = list(/mob/living/simple_animal/hostile/retaliate/poison/snake,

--- a/code/modules/exploration_crew/exploration_vendor.dm
+++ b/code/modules/exploration_crew/exploration_vendor.dm
@@ -23,7 +23,7 @@ GLOBAL_VAR_INIT(exploration_points, 0)
 		new /datum/data/vendor_equipment("Multi-Purpose Energy Gun",	/obj/item/gun/energy/e_gun/mini/exploration,						20000),
 		new /datum/data/vendor_equipment("Expanded E. Oxygen Tank",		/obj/item/tank/internals/emergency_oxygen/engi,						1000),
 		new /datum/data/vendor_equipment("Survival Knife",				/obj/item/kitchen/knife/combat/survival,							1000),
-		new /datum/data/vendor_equipment("Pizza",						/obj/item/pizzabox/margherita,										200),
+		new /datum/data/vendor_equipment("Pizza",						/obj/item/pizzabox/margherita,										2000), //MonkeStation Edit: More spendy pizza
 		new /datum/data/vendor_equipment("Whiskey",						/obj/item/reagent_containers/food/drinks/bottle/whiskey,			1000),
 		new /datum/data/vendor_equipment("Absinthe",					/obj/item/reagent_containers/food/drinks/bottle/absinthe/premium,	1000),
 		new /datum/data/vendor_equipment("Cigar",						/obj/item/clothing/mask/cigarette/cigar/havana,						1500),

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -145,7 +145,7 @@
 		new /datum/data/vendor_equipment("Advanced Ore Scanner",		/obj/item/t_scanner/adv_mining_scanner,								800),
 		new /datum/data/vendor_equipment("Explorer's Webbing",			/obj/item/storage/belt/mining,										500),
 		new /datum/data/vendor_equipment("Jump Boots",					/obj/item/clothing/shoes/bhop,										2000),
-		new /datum/data/vendor_equipment("Proto-Kinetic Crusher",		/obj/item/kinetic_crusher,								800),
+		new /datum/data/vendor_equipment("Proto-Kinetic Crusher",		/obj/item/kinetic_crusher,											800),
 		new /datum/data/vendor_equipment("Proto-Kinetic Accelerator",	/obj/item/gun/energy/kinetic_accelerator,							500),
 		new /datum/data/vendor_equipment("Resonator",					/obj/item/resonator,												750),
 		new /datum/data/vendor_equipment("Upgraded Resonator",			/obj/item/resonator/upgraded,										1500),
@@ -177,7 +177,7 @@
 		new /datum/data/vendor_equipment("Luxury Bar Capsule",			/obj/item/survivalcapsule/luxuryelite,								10000),
 		new /datum/data/vendor_equipment("Lazarus Injector",			/obj/item/lazarus_injector,											1000),
 		new /datum/data/vendor_equipment("1000 Space Cash",				/obj/item/stack/spacecash/c1000,									2000),
-		new /datum/data/vendor_equipment("Pizza",						/obj/item/pizzabox/margherita,										200),
+		new /datum/data/vendor_equipment("Pizza",						/obj/item/pizzabox/margherita,										2000), //MonkeStation Edit: More Spendy Pizza
 		new /datum/data/vendor_equipment("Whiskey",						/obj/item/reagent_containers/food/drinks/bottle/whiskey,			100),
 		new /datum/data/vendor_equipment("Absinthe",					/obj/item/reagent_containers/food/drinks/bottle/absinthe/premium,	100),
 		new /datum/data/vendor_equipment("Cigar",						/obj/item/clothing/mask/cigarette/cigar/havana,						150),

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -11,14 +11,13 @@
 					/obj/item/grenade/flashbang = 4,
 					/obj/item/assembly/flash/handheld = 5,
 					/obj/item/book/manual/wiki/security_space_law = 3,
-					/obj/item/reagent_containers/food/snacks/donut = 12,
+					/obj/item/reagent_containers/food/snacks/donut = 4, //MonkeStation Edit: Reduction of free food
 					/obj/item/storage/box/evidence = 6,
 					/obj/item/flashlight/seclite = 4,
 					/obj/item/holosign_creator/security = 3,
 					/obj/item/restraints/legcuffs/bola/energy = 7,
 					/obj/item/club = 5)
-	contraband = list(/obj/item/clothing/glasses/sunglasses/advanced = 2,
-					  /obj/item/storage/fancy/donut_box = 2)
+	contraband = list(/obj/item/clothing/glasses/sunglasses/advanced = 2) //MonkeStation Edit: Reduction of free food
 	premium = list(/obj/item/storage/belt/security/webbing = 5,
 					/obj/item/storage/backpack/duffelbag/sec/deputy = 4,
 				   /obj/item/coin/antagtoken = 1,

--- a/code/modules/vending/snack.dm
+++ b/code/modules/vending/snack.dm
@@ -4,20 +4,22 @@
 	product_slogans = "Try our new nougat bar!;Twice the calories for half the price!"
 	product_ads = "The healthiest!;Award-winning chocolate bars!;Mmm! So good!;Oh my god it's so juicy!;Have a snack.;Snacks are good for you!;Have some more Getmore!;Best quality snacks straight from mars.;We love chocolate!;Try our new jerky!"
 	icon_state = "snack"
-	products = list(/obj/item/reagent_containers/food/snacks/spacetwinkie = 6,
-					/obj/item/reagent_containers/food/snacks/cheesiehonkers = 6,
-					/obj/item/reagent_containers/food/snacks/candy = 6,
-		            /obj/item/reagent_containers/food/snacks/chips = 6,
-		            /obj/item/reagent_containers/food/snacks/sosjerky = 6,
-					/obj/item/reagent_containers/food/snacks/no_raisin = 6,
-					/obj/item/reagent_containers/food/drinks/dry_ramen = 3,
+	//MonkeStation Edit Start: Reduction of Junk Food
+	products = list(/obj/item/reagent_containers/food/snacks/spacetwinkie = 2,
+					/obj/item/reagent_containers/food/snacks/cheesiehonkers = 2,
+					/obj/item/reagent_containers/food/snacks/candy = 2,
+		            /obj/item/reagent_containers/food/snacks/chips = 2,
+		            /obj/item/reagent_containers/food/snacks/sosjerky = 2,
+					/obj/item/reagent_containers/food/snacks/no_raisin = 2,
+					/obj/item/reagent_containers/food/drinks/dry_ramen = 2,
 					/obj/item/reagent_containers/food/snacks/energybar = 6)
-	contraband = list(/obj/item/reagent_containers/food/snacks/syndicake = 6)
+	contraband = list(/obj/item/reagent_containers/food/snacks/syndicake = 2)
+	//MonkeStation Edit End
 	refill_canister = /obj/item/vending_refill/snack
 	var/chef_compartment_access = "28" //ACCESS_KITCHEN
-	default_price = 20
+	default_price = 50 //MonkeStation Edit: Reduction of junk food
 	extra_price = 30
-	payment_department = ACCOUNT_SRV
+	payment_department = NO_FREEBIES //MonkeStation Edit: NO FREE LUNCH
 
 /obj/item/vending_refill/snack
 	machine_name = "Getmore Chocolate Corp"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This is part one of a rework of how we handle food on all stations, eventually leading to a full port of the /tg/ cooking system.

All roundstart Doughnut Boxes and Donk Pocket Boxes have been removed from all stations.
All junk food vendors have less food in them, as well as the remaining food being more expensive.
Resupply crates for SecTec and Food Vending Machines have had their prices increased.

All raw food crates have been lowered in price.
Roundstart kitchens will have a bit more food by default.

## Why It's Good For The Game

As it stands, you never need to actually go to the kitchen for food.
Stations are so overstocked with food that you can load up on donuts and cheesy honkers and never worry about hunger.
This has lead to the Cook and, by extension, the Botanist to become very boring roles.

This change will be the start of making the service department actually feel useful again, rather than a new player teaching role or a wasted pile of food sitting on the counter.

A side effect is likely to be an increase of round length due to people needing to go over to the kitchen rather than a nearby break room or vending machine.

## Changelog

:cl:
del: Removed ALL default donut boxes from stations
del: Removed ALL default Donk Pocket boxes from stations
balance: Universally Reduces the amount of junk food in vending machines to 2 each, down from 6 each. This excludes "High Power Energy Bars" as they are one of the only foods Ethereals can eat.
balance: Increases the cost of SecTech Supply Crates to 2400, up from 1200.
balance: Increases the cost of Snack Supply Crates to 1500, up from 1500.
balance: Decreases Excellent Meat Crate costs to 1200, down from 1700.
balance: Decreases Food Crate costs to 800, down from 1000.
balance: Decreases Fruit Crate costs to 800, down from 1200.
balance: Decreases Vegetables Crate costs to 600, down from 1000.
balance: Removes Donut Boxes from SecTec vendors.
balance: Reduces the count of donuts in SecTec vendors to 4, down from 12.
balance: Increases the base cost of junk food to 50.
balance: Junk food vending machines now have NO_FREEBIES as a tag, no free lunches for anyone.
balance: Infinite Pizza Boxes odds are now at 1% per crate ordered, down from 5%
balance: Exploration & Mining Pizza costs 2,000 points, up from 200
tweak: Roundstart Flour & Rice in the kitchen increased to 4 (From 3 & 1)
add: 3 Potatoes and 3 Tomatoes added to the kitchen freezer.
add: One Wildcard box of ingredients added to the freezer.
del: Maintenance freezer only gets Soy Milk.
tweak: Roundstart Monkey Meat increased to 8 pieces in the kitchen, from 4.
tweak: Kitchen Milk & Soy Milk decreased to 4 each, from 5.
tweak: Egg Boxes increased to 3, from 2.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
