### PR TITLE
Raven Console Swap

### DIFF
--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -19,8 +19,8 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "af" = (
-/obj/machinery/computer/shuttle_flight,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/computer/emergency_shuttle,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "ag" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Gives the Raven Cruiser an emergency shuttle console as intended, allowing it to actually be launched rapidly or hijacked.

## Why It's Good For The Game

This was the only shuttle model that DIDN'T have the console, so this brings it back in line.

## Changelog

:cl:
fix: The Raven Cruiser can now be rush launched and hijacked
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
