### PR TITLE
Pride's Mirror Fix

### DIFF
--- a/code/modules/ruins/objects_and_mobs/sin_ruins.dm
+++ b/code/modules/ruins/objects_and_mobs/sin_ruins.dm
@@ -114,10 +114,10 @@
 	"<span class='notice'>Perfect. Much better! Now <i>nobody</i> will be able to resist yo-</span>")
 
 	var/turf/T = get_turf(user)
-	var/list/levels = SSmapping.levels_by_trait(ZTRAIT_DYNAMIC_LEVEL)
+	var/list/levels = SSmapping.levels_by_trait(ZTRAIT_STATION)
 	var/turf/dest
 	if (levels.len)
-		dest = locate(T.x, T.y, pick(levels))
+		dest = find_safe_turf(zlevels=levels)
 
 	T.ChangeTurf(/turf/open/chasm, flags = CHANGETURF_INHERIT_AIR)
 	var/turf/open/chasm/C = T


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

You are now dropped onto the station Z-level, rather than an empty space Z-level when using Pride's Mirror.

RIP Space Z-levels, my beloved.


## Why It's Good For The Game

As Z-levels were thrown away with the Exploration update, Pride's Mirror drops you into an empty void with no chance of return.
You now just get dropped onto the station, which could be just as annoying for a miner actually having to interact with people.

closes #232 

## Changelog

:cl:
fix: Pride's Mirror now drops you onto the station, rather than the endless void.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
