### PR TITLE
Mailman Spawn Rooms

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3508,6 +3508,7 @@
 #include "monkestation\code\datums\traits\negative.dm"
 #include "monkestation\code\datums\traits\neutral.dm"
 #include "monkestation\code\game\area\Space_Station_13_areas.dm"
+#include "monkestation\code\game\objects\effects\landmarks.dm"
 #include "monkestation\code\game\objects\effects\misc.dm"
 #include "monkestation\code\game\objects\effects\decals\cleanable\chemicalmesses.dm"
 #include "monkestation\code\game\objects\effects\decals\cleanable\misc.dm"

--- a/monkestation/_maps/RandomRooms/10x5/mailroom_10x5.dmm
+++ b/monkestation/_maps/RandomRooms/10x5/mailroom_10x5.dmm
@@ -1,0 +1,387 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/table/wood,
+/obj/item/mail/junkmail,
+/obj/item/mail/junkmail,
+/obj/item/mail/junkmail{
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"b" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/template_noop)
+"c" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/template_noop)
+"d" = (
+/obj/item/trash/chips,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/template_noop)
+"e" = (
+/obj/structure/table/wood,
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap{
+	pixel_y = 6
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"f" = (
+/obj/item/trash/can/food/beans,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/template_noop)
+"g" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/structure/toilet{
+	dir = 4;
+	desc = "Ahh, that's the ticket."
+	},
+/obj/item/toy/plush/moth{
+	pixel_x = 3;
+	pixel_y = -6;
+	name = "Tyria Plushie";
+	desc = "Wow! It's a limited edition Tyria Arctiinae plush! Wait, who even is that?"
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"h" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/pet/cat,
+/turf/open/floor/wood,
+/area/template_noop)
+"i" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/table/wood,
+/obj/item/mail/junkmail{
+	pixel_x = -2
+	},
+/obj/item/mail/junkmail{
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"j" = (
+/obj/item/clothing/head/mailman,
+/obj/item/clothing/under/misc/mailman,
+/obj/item/clothing/shoes/laceup,
+/obj/structure/closet,
+/obj/item/storage/bag/mail,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/template_noop)
+"l" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/grimy,
+/area/template_noop)
+"n" = (
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/under/misc/mailman,
+/obj/item/clothing/head/mailman,
+/obj/structure/closet,
+/obj/item/storage/bag/mail,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"q" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/shovel,
+/obj/effect/decal/cleanable/robot_debris,
+/turf/open/floor/wood,
+/area/template_noop)
+"r" = (
+/obj/effect/temp_visual/ratvar/window/single,
+/obj/structure/table/wood,
+/obj/item/mail/junkmail,
+/obj/item/mail/junkmail{
+	pixel_x = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/obj/item/flashlight/lamp{
+	pixel_x = 5;
+	pixel_y = 13
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"t" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/papersack,
+/turf/open/floor/wood,
+/area/template_noop)
+"v" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/wrapping_paper,
+/obj/item/stack/wrapping_paper{
+	pixel_y = 7
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"w" = (
+/turf/closed/wall,
+/area/template_noop)
+"x" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/table/wood,
+/obj/item/mail/junkmail,
+/obj/item/mail/junkmail{
+	pixel_x = 7
+	},
+/obj/item/mail/junkmail{
+	pixel_x = 4;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"y" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_box/magazine/toy/pistol{
+	pixel_x = 2
+	},
+/turf/open/floor/plasteel,
+/area/template_noop)
+"A" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/wirecutters{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/lighter{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/machinery/light/small,
+/turf/open/floor/wood,
+/area/template_noop)
+"B" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1;
+	pixel_x = -3
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1;
+	pixel_y = 17;
+	pixel_x = -10
+	},
+/turf/open/floor/plasteel/stairs/old,
+/area/template_noop)
+"C" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/trash/energybar,
+/obj/item/trash/popcorn,
+/obj/item/trash/plate,
+/obj/item/trash/semki,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/confetti,
+/turf/open/floor/wood,
+/area/template_noop)
+"F" = (
+/obj/item/clothing/suit/armor/vest,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken,
+/obj/effect/landmark/start/randommaint/mailman,
+/turf/open/floor/wood,
+/area/template_noop)
+"G" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall,
+/area/template_noop)
+"L" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/turf/open/floor/wood,
+/area/template_noop)
+"M" = (
+/obj/item/trash/can,
+/obj/item/trash/can{
+	pixel_x = 5;
+	pixel_y = -8
+	},
+/obj/item/trash/can{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/template_noop)
+"P" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/grimy,
+/area/template_noop)
+"Q" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"S" = (
+/obj/structure/closet/crate/wooden,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/template_noop)
+"T" = (
+/obj/item/bedsheet/random{
+	pixel_y = 7
+	},
+/obj/structure/bed{
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -8;
+	pixel_y = -7
+	},
+/obj/item/storage/pill_bottle/zoom{
+	pixel_y = -9;
+	desc = "This can't be good for me, but I feel great!""This can't be good for me, but I feel great!";
+	name = "Health Pills";
+	pixel_x = 10
+	},
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/drinks/bottle/vodka{
+	pixel_y = -3;
+	pixel_x = -1
+	},
+/turf/open/floor/wood,
+/area/template_noop)
+"U" = (
+/obj/effect/decal/cleanable/ash{
+	pixel_y = -11;
+	pixel_x = -1
+	},
+/obj/structure/chair/wood,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/template_noop)
+"V" = (
+/obj/structure/chair/wood{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/template_noop)
+"W" = (
+/obj/structure/closet/crate/wooden,
+/obj/effect/spawner/lootdrop/maintenance/four,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/food/egg_smudge,
+/turf/open/floor/wood,
+/area/template_noop)
+"X" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/grimy,
+/area/template_noop)
+"Y" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock,
+/turf/open/floor/wood,
+/area/template_noop)
+
+(1,1,1) = {"
+r
+a
+X
+v
+t
+"}
+(2,1,1) = {"
+V
+x
+P
+U
+A
+"}
+(3,1,1) = {"
+Q
+i
+X
+M
+e
+"}
+(4,1,1) = {"
+y
+B
+X
+d
+L
+"}
+(5,1,1) = {"
+X
+X
+X
+X
+P
+"}
+(6,1,1) = {"
+j
+n
+X
+c
+W
+"}
+(7,1,1) = {"
+w
+G
+X
+q
+h
+"}
+(8,1,1) = {"
+f
+b
+P
+S
+C
+"}
+(9,1,1) = {"
+F
+G
+l
+G
+G
+"}
+(10,1,1) = {"
+T
+G
+X
+Y
+g
+"}

--- a/monkestation/_maps/RandomRooms/3x5/mailman_mailroom_3x5.dmm
+++ b/monkestation/_maps/RandomRooms/3x5/mailman_mailroom_3x5.dmm
@@ -1,0 +1,149 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/item/bedsheet/random,
+/obj/structure/bed,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -3;
+	pixel_y = 19
+	},
+/obj/item/storage/pill_bottle/zoom{
+	pixel_y = 6;
+	desc = "This can't be good for me, but I feel great!""This can't be good for me, but I feel great!";
+	name = "Health Pills"
+	},
+/obj/item/reagent_containers/food/drinks/bottle/vodka{
+	pixel_y = 20;
+	pixel_x = 7
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/carpet/grimy,
+/area/template_noop)
+"e" = (
+/obj/structure/table/wood,
+/obj/item/stack/packageWrap{
+	pixel_y = 6
+	},
+/obj/item/stack/packageWrap{
+	pixel_y = 14
+	},
+/obj/item/wirecutters,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/template_noop)
+"i" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/grimy,
+/area/template_noop)
+"k" = (
+/obj/structure/table/wood,
+/obj/item/mail/junkmail{
+	pixel_x = 4
+	},
+/obj/item/mail/junkmail{
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/flashlight/lamp,
+/turf/open/floor/wood,
+/area/template_noop)
+"p" = (
+/obj/structure/chair/wood{
+	dir = 1;
+	pixel_x = 1;
+	pixel_y = 16
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/pistachios{
+	pixel_y = -6;
+	pixel_x = 17
+	},
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/wood,
+/area/template_noop)
+"u" = (
+/obj/structure/table/wood,
+/obj/item/mail/junkmail{
+	pixel_y = 8
+	},
+/obj/item/mail/junkmail,
+/obj/item/shovel{
+	pixel_x = 2;
+	pixel_y = -11
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/wood,
+/area/template_noop)
+"v" = (
+/turf/closed/wall,
+/area/template_noop)
+"D" = (
+/obj/effect/landmark/start/randommaint/mailman,
+/obj/item/reagent_containers/food/snacks/pizzaslice/meat{
+	pixel_x = 11;
+	pixel_y = 14;
+	desc = "Magically cures light wounds when eaten""Magically cures light wounds when eaten""Magically cures light wounds when eaten"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/item/trash/cheesie,
+/turf/open/floor/carpet/grimy,
+/area/template_noop)
+"F" = (
+/obj/structure/table/wood,
+/obj/item/hand_labeler{
+	pixel_x = 10;
+	pixel_y = 12
+	},
+/obj/item/storage/bag/mail{
+	pixel_y = 1;
+	pixel_x = -5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood,
+/area/template_noop)
+"R" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/grimy,
+/area/template_noop)
+"T" = (
+/obj/structure/table/wood,
+/obj/item/mail/junkmail{
+	pixel_x = -3
+	},
+/obj/item/mail/junkmail{
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/wood,
+/area/template_noop)
+
+(1,1,1) = {"
+k
+e
+R
+v
+a
+"}
+(2,1,1) = {"
+T
+p
+R
+v
+D
+"}
+(3,1,1) = {"
+u
+F
+R
+i
+R
+"}

--- a/monkestation/_maps/random_rooms.dm
+++ b/monkestation/_maps/random_rooms.dm
@@ -55,3 +55,23 @@
 	template_width = 10
 	weight = 2
 	stock = 1
+
+/datum/map_template/random_room/mailman_mailroom_3x5
+	name = "Small Mailroom"
+	room_id = "Mailroom_3x5"
+	mappath = "monkestation/_maps/RandomRooms/3x5/mailman_mailroom_3x5.dmm"
+	centerspawner = FALSE
+	template_width = 3
+	template_height = 5
+	weight = 7
+	stock = 1
+
+/datum/map_template/random_room/mailman_mailroom_10x5
+	name = "Mailroom"
+	room_id = "Mailroom_10x5"
+	mappath = "monkestation/_maps/RandomRooms/10x5/mailroom_10x5.dmm"
+	centerspawner = FALSE
+	template_width = 10
+	template_height = 5
+	weight = 6
+	stock = 1

--- a/monkestation/code/game/objects/effects/landmarks.dm
+++ b/monkestation/code/game/objects/effects/landmarks.dm
@@ -1,0 +1,3 @@
+/obj/effect/landmark/start/randommaint/mailman
+	name = "Mailman"
+	job = "Mailman"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Adds a random 10x5 and 3x5 mailroom for roundstart Mailman spawning.

Adds a map landmark to the code for further mapping.

## Why It's Good For The Game

As it stands, Mailmen are latejoin only.
This allows for them to be more in line with the rest of the gimmick job spawns.

![image](https://user-images.githubusercontent.com/62958508/161632905-b82bd354-ecda-4e18-aade-c7364c66ca71.png)
![image](https://user-images.githubusercontent.com/62958508/161632922-372e24b3-13da-46cd-887b-b4f6632bec58.png)


## Changelog

:cl:
add: Adds two new random rooms for roundstart Mailmen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
