### PR TITLE
Slight Armor Nerf

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -259,6 +259,7 @@
 	desc = "A classic suit of plate armour, highly effective at stopping melee attacks."
 	icon_state = "knight_green"
 	item_state = "knight_green"
+	blocks_shove_knockdown = FALSE //MonkeStation Edit: Weakens plate armor slightly
 	move_sound = null
 
 /obj/item/clothing/suit/armor/riot/knight/yellow


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Removes the knockdown immunity from plate armor.

## Why It's Good For The Game

Plate Armor has all of the advantages from Riot Armor, but doesn't share any disadvantages.
This brings it in line with the Chaplain's armor.
Closes #238

## Changelog

:cl:
balance: Plate Armor no longer provides Knockdown Immunity
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
