### PR TITLE
Tesla Movement Changes

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -40,8 +40,11 @@
 
 /obj/singularity/energy_ball/process()
 	handle_energy()
-
-	move_the_basket_ball(4 + orbiting_balls.len * 1.5)
+	//MonkeStation Edit Start: Slows the tesla a bit
+	if(last_move <= world.time + 4 SECONDS)
+		last_move = world.time
+		move_the_basket_ball(1 + (orbiting_balls.len / 2 ))
+	//MonkeStation Edit End
 
 	playsound(src.loc, 'sound/magic/lightningbolt.ogg', 100, 1, extrarange = 30)
 
@@ -51,10 +54,10 @@
 	//Main one can zap
 	//Tesla only zaps if the tick usage isn't over the limit.
 	if(!TICK_CHECK)
-		tesla_zap(src, 7, TESLA_DEFAULT_POWER, TESLA_ENERGY_PRIMARY_BALL_FLAGS)
+		tesla_zap(src, min(orbiting_balls.len, 5), TESLA_DEFAULT_POWER, TESLA_ENERGY_PRIMARY_BALL_FLAGS) //MonkeStation Edit: Reduction of bolt range
 	else
 		//Weaker, less intensive zap
-		tesla_zap(src, 4, TESLA_DEFAULT_POWER, TESLA_ENERGY_MINI_BALL_FLAGS)
+		tesla_zap(src, min(orbiting_balls.len, 3), TESLA_DEFAULT_POWER, TESLA_ENERGY_MINI_BALL_FLAGS) //MonkeStation Edit: Reduction of bolt range
 		pixel_x = -32
 		pixel_y = -32
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Adds a 4 second delay to each tesla ball movement.

Reduces the distance the tesla travels in each movement from 6-21 to 1-6.

Greater Tesla Zaps are now between 0 and 5 range.

Weaker Tesla Zaps are between 0 and 3 range.

## Why It's Good For The Game

As we want to have the tesla as a roundstart engine, we need to slightly reduce it's round ending power.
This, along with #224, will make it more reasonable to have.

## Changelog

:cl:
add: Teslas now have a 4 second delay between movement
balance: Teslas travel less distance in each movement step
balance: Tesla zaps are shorter ranged
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
