### PR TITLE
Jungle Mapgen

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3558,6 +3558,8 @@
 #include "monkestation\code\modules\mob\living\simple_animal\friendly\dog.dm"
 #include "monkestation\code\modules\mob\living\simple_animal\friendly\honk_platinum.dm"
 #include "monkestation\code\modules\mob\living\simple_animal\hostile\bees.dm"
+#include "monkestation\code\modules\procedural_mapping\mapGeneratorModules\jungle.dm"
+#include "monkestation\code\modules\procedural_mapping\mapGenerators\jungle.dm"
 #include "monkestation\code\modules\reagents\chemistry\reagents\drink_reagents.dm"
 #include "monkestation\code\modules\reagents\chemistry\reagents\food_reagents.dm"
 #include "monkestation\code\modules\reagents\chemistry\reagents\other_reagents.dm"

--- a/monkestation/code/modules/procedural_mapping/mapGeneratorModules/jungle.dm
+++ b/monkestation/code/modules/procedural_mapping/mapGeneratorModules/jungle.dm
@@ -1,0 +1,30 @@
+//Jungle Map Generation
+//Whoa, thought it was a nightmare. Lord, it's all so true.
+
+/datum/mapGeneratorModule/bottomLayer/jungle_underbrush
+	spawnableTurfs = list(/turf/open/floor/grass = 100)
+
+/datum/mapGeneratorModule/jungle_trees
+	spawnableAtoms = list(/obj/structure/flora/tree/jungle = 5,
+							/obj/structure/flora/tree/jungle/small = 25)
+
+/datum/mapGeneratorModule/jungle_shrubs
+	clusterCheckFlags = CLUSTER_CHECK_NONE
+	spawnableAtoms = list(/obj/structure/flora/junglebush = 20,
+							/obj/structure/flora/junglebush/large = 10)
+
+/datum/mapGeneratorModule/jungle_rocks
+	clusterCheckFlags = CLUSTER_CHECK_SAME_ATOMS
+	spawnableAtoms = list(/obj/structure/flora/rock/jungle = 25,
+							/obj/structure/flora/rock/pile/largejungle = 10)
+
+/datum/mapGeneratorModule/jungle_water
+	clusterCheckFlags = CLUSTER_CHECK_NONE
+	spawnableTurfs = list(/turf/open/water/jungle = 10)
+
+/datum/mapGeneratorModule/bottomLayer/jungle_dirt
+	spawnableTurfs = list(/turf/open/floor/plating/dirt/jungle = 2,
+							/turf/open/floor/plating/dirt/jungle/dark = 2,
+							/turf/open/floor/plating/dirt/jungle/wasteland = 2,
+							/turf/open/floor/plating/grass/jungle = 2)
+

--- a/monkestation/code/modules/procedural_mapping/mapGenerators/jungle.dm
+++ b/monkestation/code/modules/procedural_mapping/mapGenerators/jungle.dm
@@ -1,0 +1,8 @@
+/datum/mapGenerator/jungle
+	modules = list(/datum/mapGeneratorModule/bottomLayer/jungle_underbrush,
+					/datum/mapGeneratorModule/jungle_shrubs,
+					/datum/mapGeneratorModule/jungle_trees,
+					/datum/mapGeneratorModule/jungle_rocks,
+					/datum/mapGeneratorModule/jungle_water,
+					/datum/mapGeneratorModule/bottomLayer/jungle_dirt)
+	buildmode_name = "Pattern: Jungle"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Adds a jungle to the list of build mode map generation options.

## Why It's Good For The Game

I want to be able to run gimmick station rounds in Space 'nam

## Changelog

:cl:
admin: Adds a Jungle mapgen for build mode
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
