### PR TITLE
Redefines the Graverobber Hat

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -140,7 +140,7 @@
 /obj/item/storage/box/holy/graverobber/PopulateContents()
 	new /obj/item/clothing/suit/armor/riot/chaplain/graverobber_coat(src)
 	new /obj/item/clothing/under/rank/civilian/graverobber_under(src)
-	new /obj/item/clothing/head/chaplain/graverobber_hat(src)
+	new /obj/item/clothing/head/helmet/chaplain/graverobber_hat(src)
 	new /obj/item/clothing/gloves/graverobber_gloves(src)
 
 /obj/item/clothing/suit/armor/riot/chaplain/graverobber_coat
@@ -150,7 +150,7 @@
 	item_state = "graverobber_coat"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 
-/obj/item/clothing/head/chaplain/graverobber_hat
+/obj/item/clothing/head/helmet/chaplain/graverobber_hat
 	name = "grave robber hat"
 	desc = "A tattered leather hat. It reeks of death."
 	icon_state = "graverobber_hat"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

The Graverobber Hat is now a child of helmet/chaplain, which gives it equal armor as the rest of the chaplain equipment.


## Why It's Good For The Game
No reason to make one piece of armor weaker when all of the other Chaplain options are equal to each other.

closes #267 

## Changelog

:cl:
tweak: Graverobber's Hats are now armored
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
