### PR TITLE
Messages can no longer be sent by servers to inactive PDAs

### DIFF
--- a/code/game/machinery/telecomms/computers/message.dm
+++ b/code/game/machinery/telecomms/computers/message.dm
@@ -420,6 +420,10 @@
 							message = "<span class='notice'>NOTICE: No message entered!</span>"
 							return attack_hand(usr)
 
+						if(customrecepient.toff)
+							message = "<span class='notice'>NOTICE: Recepient has messages turned off!</span>"
+							return attack_hand(usr)
+						
 						var/datum/signal/subspace/messaging/pda/signal = new(src, list(
 							"name" = "[customsender]",
 							"job" = "[customjob]",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Fixes #261

# About The Pull Request

Fixes a bug where it was possible for a server to send messages after a PDA turns off messaging.

## Why It's Good For The Game

Normally, the PDAs get removed from the list when their messages are turned off, but if you were to select a PDA before it turns off messaging, you could still send messages and annoy the hell out of people. That is not great, so this PR fixes that.

## Changelog

:cl:
fix: message servers no longer send messages if the recipient is turned off
/:cl: