### PR TITLE
Exploration Shuttle Supplies

### DIFF
--- a/_maps/shuttles/exploration_corg.dmm
+++ b/_maps/shuttles/exploration_corg.dmm
@@ -669,6 +669,10 @@
 /obj/item/circuitboard/computer/shuttle/exploration_shuttle,
 /obj/item/stack/sheet/mineral/plasma/five,
 /obj/effect/turf_decal/bot,
+/obj/item/electronics/apc,
+/obj/item/wallframe/apc,
+/obj/item/stack/cable_coil/red,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/exploration)
 "Hm" = (

--- a/_maps/shuttles/exploration_delta.dmm
+++ b/_maps/shuttles/exploration_delta.dmm
@@ -61,7 +61,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	locked = 0
+	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
@@ -428,6 +430,10 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/item/wallframe/apc,
+/obj/item/electronics/apc,
+/obj/item/stack/cable_coil/red,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plating,
 /area/shuttle/exploration)
 "ZX" = (

--- a/_maps/shuttles/exploration_fland.dmm
+++ b/_maps/shuttles/exploration_fland.dmm
@@ -29,7 +29,8 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/auto_name/north{
-	cell_type = /obj/item/stock_parts/cell/high
+	cell_type = /obj/item/stock_parts/cell/high;
+	locked = 0
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/shuttle/exploration)
@@ -215,6 +216,9 @@
 /obj/item/gps/mining,
 /obj/item/circuitboard/computer/shuttle/exploration_shuttle,
 /obj/item/stack/sheet/mineral/plasma/fifty,
+/obj/item/electronics/apc,
+/obj/item/wallframe/apc,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/tech/grid,
 /area/shuttle/exploration)
 "ma" = (
@@ -576,7 +580,6 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/storage/box/donkpockets,
 /turf/open/floor/plasteel,
 /area/shuttle/exploration)
 "IM" = (

--- a/_maps/shuttles/exploration_kilo.dmm
+++ b/_maps/shuttles/exploration_kilo.dmm
@@ -25,7 +25,9 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/power/apc/auto_name/east{
+	locked = 0
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -60,10 +62,6 @@
 	dir = 1
 	},
 /obj/item/storage/box/donkpockets,
-/obj/item/storage/box/donkpockets/donkpockethonk{
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/exploration)
 "gz" = (
@@ -165,6 +163,10 @@
 /obj/item/stack/sheet/mineral/plasma/twenty,
 /obj/item/mining_scanner,
 /obj/item/pickaxe,
+/obj/item/wallframe/apc,
+/obj/item/electronics/apc,
+/obj/item/stack/cable_coil/red,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/exploration)
 "pK" = (
@@ -175,6 +177,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown,
+/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/exploration)
 "qt" = (

--- a/_maps/shuttles/exploration_shuttle.dmm
+++ b/_maps/shuttles/exploration_shuttle.dmm
@@ -197,7 +197,8 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/north{
-	pixel_y = 24
+	pixel_y = 24;
+	locked = 0
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -212,6 +213,10 @@
 /obj/item/gps/mining,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/multitool,
+/obj/item/wallframe/apc,
+/obj/item/electronics/apc,
+/obj/item/stack/cable_coil/red,
+/obj/item/stock_parts/cell/high,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/exploration)
 "D" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Unlocks the APC on all Exploration Shuttles.

Adds an emergency cell, APC frame and APC electronics to all exploration shuttles.

Adds tools required to assemble the APC frame to all exploration shuttles that didn't have the toolset.


## Why It's Good For The Game

Prevents players from getting stranded due to an APC/power issue...as long as they remember to use the remaining supplies to get back home.

closes #103 

## Changelog

:cl:
add: Exploration Shuttles have had a few emergency supplies added to them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
