### PR TITLE
Use operating computers while lying down

### DIFF
--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -62,7 +62,7 @@
 
 
 /obj/machinery/computer/operating/ui_state(mob/user)
-	return GLOB.not_incapacitated_state
+	return GLOB.conscious_state
 
 /obj/machinery/computer/operating/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/modules/tgui/states/not_incapacitated.dm
+++ b/code/modules/tgui/states/not_incapacitated.dm
@@ -25,8 +25,12 @@ GLOBAL_DATUM_INIT(not_incapacitated_turf_state, /datum/ui_state/not_incapacitate
 	turf_check = no_turfs
 
 /datum/ui_state/not_incapacitated_state/can_use_topic(src_object, mob/user)
-	if(user.stat != CONSCIOUS)
+	if(user.stat)
 		return UI_CLOSE
 	if(user.incapacitated() || (turf_check && !isturf(user.loc)))
 		return UI_DISABLED
+	if(isliving(user))
+		var/mob/living/L = user
+		if(!(L.mobility_flags & MOBILITY_STAND))
+			return UI_DISABLED
 	return UI_INTERACTIVE

--- a/code/modules/tgui/states/not_incapacitated.dm
+++ b/code/modules/tgui/states/not_incapacitated.dm
@@ -25,12 +25,8 @@ GLOBAL_DATUM_INIT(not_incapacitated_turf_state, /datum/ui_state/not_incapacitate
 	turf_check = no_turfs
 
 /datum/ui_state/not_incapacitated_state/can_use_topic(src_object, mob/user)
-	if(user.stat)
+	if(user.stat != CONSCIOUS)
 		return UI_CLOSE
 	if(user.incapacitated() || (turf_check && !isturf(user.loc)))
 		return UI_DISABLED
-	if(isliving(user))
-		var/mob/living/L = user
-		if(!(L.mobility_flags & MOBILITY_STAND))
-			return UI_DISABLED
 	return UI_INTERACTIVE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Allows the user to use the operating computer while lying down. 
The minor inconvenience of laying down is negated anyways by the wiki. Less demand on looking up things on the wiki, the better.

closes https://github.com/Monkestation/MonkeStation/issues/263


## Changelog

:cl:

tweak: You can use operating computers while lying down, just try not to get blood all over the keyboard

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
