### PR TITLE
Autoname Cameras addition & Network tags for areas

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -17084,6 +17084,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aXm" = (
@@ -29180,6 +29181,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "bLV" = (
@@ -38892,8 +38896,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
@@ -43420,6 +43424,19 @@
 /mob/living/simple_animal/pet/fox/Renault,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"fFP" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "fGe" = (
 /obj/machinery/light{
 	dir = 4
@@ -46267,6 +46284,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
+"jiK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/storage)
 "jjB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -52029,7 +52052,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/junction,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "pWN" = (
@@ -52865,6 +52890,9 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
 	req_access_txt = "5"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/medical/storage)
@@ -96441,7 +96469,7 @@ cuI
 gHx
 bof
 bKL
-hfA
+fFP
 hfA
 hfA
 hfA
@@ -96955,7 +96983,7 @@ cuJ
 cvf
 bRO
 cvE
-bII
+jiK
 cwa
 bVa
 bPo

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -74,6 +74,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 /area/asteroid/nearstation/bomb_site
 	name = "Bomb Testing Asteroid"
+	network = list("ss13", "toxins")
 
 //STATION13
 
@@ -255,10 +256,12 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/maintenance/disposal
 	name = "Waste Disposal"
 	icon_state = "disposal"
+	network = list("ss13", "turbine")
 
 /area/maintenance/disposal/incinerator
 	name = "Incinerator"
 	icon_state = "disposal"
+	network = list("ss13", "turbine")
 
 //Maintenance - Upper
 
@@ -701,39 +704,47 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	sound_environment = SOUND_AREA_LARGE_ENCLOSED
 	lighting_colour_tube = "#ffce93"
 	lighting_colour_bulb = "#ffbc6f"
+	network = list("ss13", "engine")
 
 /area/engine/engine_smes
 	name = "Engineering SMES"
 	icon_state = "engine_smes"
+	network = list("ss13", "engine")
 
 /area/engine/engineering
 	name = "Engineering"
 	icon_state = "engine"
+	network = list("ss13", "engine")
 
 /area/engine/atmos
 	name = "Atmospherics"
 	icon_state = "atmos"
 	flags_1 = NONE
+	network = list("ss13", "atmos")
 
 /area/engine/atmospherics_engine
 	name = "Atmospherics Engine"
 	icon_state = "atmos_engine"
 	area_flags = BLOBS_ALLOWED | UNIQUE_AREA
 	sound_environment = SOUND_AREA_LARGE_ENCLOSED
+	network = list("ss13", "engine")
 
 /area/engine/engine_room //donut station specific
 	name = "Engine Room"
 	icon_state = "atmos_engine"
+	network = list("ss13", "engine")
 
 /area/engine/engine_room/external
 	name = "Supermatter External Access"
 	icon_state = "engine_foyer"
+	network = list("ss13", "engine")
 
 /area/engine/supermatter
 	name = "Supermatter Engine"
 	icon_state = "engine_sm"
 	area_flags = BLOBS_ALLOWED | UNIQUE_AREA
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
+	network = list("ss13", "engine")
 
 /area/engine/break_room
 	name = "Engineering Foyer"
@@ -747,6 +758,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "grav_gen"
 	clockwork_warp_allowed = FALSE
 	clockwork_warp_fail = "The gravitons generated here could throw off your warp's destination and possibly throw you into deep space."
+	network = list("ss13", "gravgen")
 
 /area/engine/storage
 	name = "Engineering Storage"
@@ -760,6 +772,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/engine/transit_tube
 	name = "Transit Tube"
 	icon_state = "transit_tube"
+	network = list("ss13", "minisat")
 
 
 //Solars
@@ -771,47 +784,58 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	flags_1 = NONE
 	ambience_index = AMBIENCE_ENGI
 	sound_environment = SOUND_AREA_SPACE
+	network = list("solar")
 
 /area/solar/fore
 	name = "Fore Solar Array"
 	icon_state = "yellow"
 	sound_environment = SOUND_AREA_STANDARD_STATION
+	network = list("solar")
 
 /area/solar/aft
 	name = "Aft Solar Array"
 	icon_state = "yellow"
+	network = list("solar")
 
 /area/solar/aux/port
 	name = "Port Bow Auxiliary Solar Array"
 	icon_state = "panelsA"
+	network = list("solar")
 
 /area/solar/aux/starboard
 	name = "Starboard Bow Auxiliary Solar Array"
 	icon_state = "panelsA"
+	network = list("solar")
 
 /area/solar/starboard
 	name = "Starboard Solar Array"
 	icon_state = "panelsS"
+	network = list("solar")
 
 /area/solar/starboard/aft
 	name = "Starboard Quarter Solar Array"
 	icon_state = "panelsAS"
+	network = list("solar")
 
 /area/solar/starboard/fore
 	name = "Starboard Bow Solar Array"
 	icon_state = "panelsFS"
+	network = list("solar")
 
 /area/solar/port
 	name = "Port Solar Array"
 	icon_state = "panelsP"
+	network = list("solar")
 
 /area/solar/port/aft
 	name = "Port Quarter Solar Array"
 	icon_state = "panelsAP"
+	network = list("solar")
 
 /area/solar/port/fore
 	name = "Port Bow Solar Array"
 	icon_state = "panelsFP"
+	network = list("solar")
 
 
 
@@ -820,30 +844,37 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/maintenance/solars
 	name = "Solar Maintenance"
 	icon_state = "yellow"
+	network = list("solar")
 
 /area/maintenance/solars/port
 	name = "Port Solar Maintenance"
 	icon_state = "SolarcontrolP"
+	network = list("solar")
 
 /area/maintenance/solars/port/aft
 	name = "Port Quarter Solar Maintenance"
 	icon_state = "SolarcontrolAP"
+	network = list("solar")
 
 /area/maintenance/solars/port/fore
 	name = "Port Bow Solar Maintenance"
 	icon_state = "SolarcontrolFP"
+	network = list("solar")
 
 /area/maintenance/solars/starboard
 	name = "Starboard Solar Maintenance"
 	icon_state = "SolarcontrolS"
+	network = list("solar")
 
 /area/maintenance/solars/starboard/aft
 	name = "Starboard Quarter Solar Maintenance"
 	icon_state = "SolarcontrolAS"
+	network = list("solar")
 
 /area/maintenance/solars/starboard/fore
 	name = "Starboard Bow Solar Maintenance"
 	icon_state = "SolarcontrolFS"
+	network = list("solar")
 
 //Teleporter
 
@@ -869,60 +900,73 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	mood_message = "<span class='nicegreen'>I feel safe in here!\n</span>"
 	lighting_colour_tube = "#e7f8ff"
 	lighting_colour_bulb = "#d5f2ff"
+	network = list("ss13", "medbay")
 
 /area/medical/abandoned
 	name = "Abandoned Medbay"
 	icon_state = "medbay3"
 	ambientsounds = list('sound/ambience/signal.ogg')
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
+	network = list("ss13", "medbay")
 
 /area/medical/medbay/balcony
 	name = "Medbay Balcony"
 	icon_state = "medbay"
+	network = list("ss13", "medbay")
 
 /area/medical/medbay/central
 	name = "Medbay Central"
 	icon_state = "medbay"
+	network = list("ss13", "medbay")
 
 /area/medical/medbay/lobby
 	name = "Medbay Lobby"
 	icon_state = "medbay"
+	network = list("ss13", "medbay")
 
 	//Medbay is a large area, these additional areas help level out APC load.
 
 /area/medical/medbay/zone2
 	name = "Medbay"
 	icon_state = "medbay2"
+	network = list("ss13", "medbay")
 
 /area/medical/medbay/aft
 	name = "Medbay Aft"
 	icon_state = "medbay3"
+	network = list("ss13", "medbay")
 
 /area/medical/storage
 	name = "Medbay Storage"
 	icon_state = "medbay2"
+	network = list("ss13", "medbay")
 
 /area/medical/patients_rooms
 	name = "Patients' Rooms"
 	icon_state = "patients"
 	sound_environment = SOUND_AREA_SMALL_SOFTFLOOR
+	network = list("ss13", "medbay")
 
 /area/medical/patients_rooms/room_a
 	name = "Patient Room A"
 	icon_state = "patients"
+	network = list("ss13", "medbay")
 
 /area/medical/patients_rooms/room_b
 	name = "Patient Room B"
 	icon_state = "patients"
+	network = list("ss13", "medbay")
 
 /area/medical/patients_rooms/room_c
 	name = "Patient Room C"
 	icon_state = "patients"
+	network = list("ss13", "medbay")
 
 /area/medical/virology
 	name = "Virology"
 	icon_state = "virology"
 	flags_1 = NONE
+	network = list("ss13", "medbay")
 
 /area/medical/morgue
 	name = "Morgue"
@@ -931,46 +975,57 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
 	mood_bonus = -2
 	mood_message = "<span class='warning'>It smells like death in here!\n</span>"
+	network = list("ss13", "medbay")
 
 /area/medical/chemistry
 	name = "Chemistry"
 	icon_state = "chem"
+	network = list("ss13", "medbay")
 
 /area/medical/chemistry/upper
 	name = "Upper Chemistry"
 	icon_state = "chem"
+	network = list("ss13", "medbay")
 
 /area/medical/apothecary
 	name = "Apothecary"
 	icon_state = "apothecary"
+	network = list("ss13", "medbay")
 
 /area/medical/surgery
 	name = "Surgery"
 	icon_state = "surgery"
+	network = list("ss13", "medbay")
 
 /area/medical/surgery/aux
 	name = "Auxillery Surgery"
 	icon_state = "surgery"
+	network = list("ss13", "medbay")
 
 /area/medical/cryo
 	name = "Cryogenics"
 	icon_state = "cryo"
+	network = list("ss13", "medbay")
 
 /area/medical/exam_room
 	name = "Exam Room"
 	icon_state = "exam_room"
+	network = list("ss13", "medbay")
 
 /area/medical/genetics
 	name = "Genetics Lab"
 	icon_state = "genetics"
+	network = list("ss13", "medbay")
 
 /area/medical/genetics/cloning
 	name = "Cloning Lab"
 	icon_state = "cloning"
+	network = list("ss13", "medbay")
 
 /area/medical/sleeper
 	name = "Medbay Treatment Center"
 	icon_state = "exam_room"
+	network = list("ss13", "medbay")
 
 
 //Security
@@ -992,6 +1047,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "brig"
 	mood_bonus = -3
 	mood_message = "<span class='warning'>I hate cramped brig cells.\n</span>"
+	network = list("interrogation")
 
 /area/security/courtroom
 	name = "Courtroom"
@@ -1003,6 +1059,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "sec_prison"
 	mood_bonus = -4
 	mood_message = "<span class='warning'>I'm trapped here with little hope of escape!\n</span>"
+	network = list("ss13", "prison")
 
 /area/security/processing
 	name = "Labor Shuttle Dock"
@@ -1036,20 +1093,25 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "execution_room"
 	mood_bonus = -5
 	mood_message = "<span class='warning'>I feel a sense of impending doom.\n</span>"
+	network = list("ss13", "prison")
 
 /area/security/execution/transfer
 	name = "Transfer Centre"
+	network = list("ss13", "prison")
 
 /area/security/execution/education
 	name = "Prisoner Education Chamber"
+	network = list("ss13", "prison")
 
 /area/security/nuke_storage
 	name = "Vault"
 	icon_state = "nuke_storage"
+	network = list("vault")
 
 /area/ai_monitored/nuke_storage
 	name = "Vault"
 	icon_state = "nuke_storage"
+	network = list("vault")
 
 /area/security/checkpoint
 	name = "Security Checkpoint"
@@ -1091,28 +1153,34 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/security/prison/vip
 	name = "VIP Prison Wing"
 	icon_state = "sec_prison"
+	network = list("ss13", "prison")
 
 /area/security/prison/asteroid
 	name = "Outer Asteroid Prison Wing"
 	icon_state = "sec_prison"
+	network = list("ss13", "prison")
 
 /area/security/prison/asteroid/service
 	name = "Outer Asteroid Prison Wing Services"
 	icon_state = "sec_prison"
+	network = list("ss13", "prison")
 
 /area/security/prison/asteroid/arrival
 	name = "Outer Asteroid Prison Wing Arrival"
 	icon_state = "sec_prison"
+	network = list("ss13", "prison")
 
 /area/security/prison/asteroid/abbandoned
 	name = "Outer Asteroid Prison Wing Abbandoned maintenance"
 	icon_state = "sec_prison"
 	mood_bonus = -2
 	mood_message = "<span class='warning'>This place gives me the creeps...\n</span>"
+	network = list("ss13", "prison")
 
 /area/security/prison/asteroid/shielded
 	name = "Outer Asteroid Prison Wing Shielded area"
 	icon_state = "sec_prison"
+	network = list("ss13", "prison")
 
 //Service
 
@@ -1207,82 +1275,101 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	lighting_colour_tube = "#f0fbff"
 	lighting_colour_bulb = "#e4f7ff"
 	sound_environment = SOUND_AREA_STANDARD_STATION
+	network = list("ss13", "rd")
 
 /area/science/lab
 	name = "Research and Development"
 	icon_state = "toxlab"
+	network = list("ss13", "rd")
 
 /area/science/xenobiology
 	name = "Xenobiology Lab"
 	icon_state = "toxlab"
+	network = list("ss13", "rd", "xeno")
 
 /area/science/shuttle
 	name = "Shuttle Construction"
 	lighting_colour_tube = "#ffe3cc"
 	lighting_colour_bulb = "#ffdbb8"
+	network = list("ss13", "rd")
 
 /area/science/storage
 	name = "Toxins Storage"
 	icon_state = "toxstorage"
+	network = list("ss13", "rd")
 
 /area/science/test_area
 	name = "Toxins Test Area"
 	area_flags = BLOBS_ALLOWED | UNIQUE_AREA
 	icon_state = "toxtest"
+	network = list("rd","toxins")
 
 /area/science/mixing
 	name = "Toxins Mixing Lab"
 	icon_state = "toxmix"
+	network = list("ss13", "rd")
 
 /area/science/mixing/chamber
 	name = "Toxins Mixing Chamber"
 	area_flags = BLOBS_ALLOWED | UNIQUE_AREA
 	icon_state = "toxmix"
+	network = list("ss13", "rd")
 
 /area/science/misc_lab
 	name = "Testing Lab"
 	icon_state = "toxmisc"
+	network = list("ss13", "rd")
 
 /area/science/misc_lab/range
 	name = "Research Testing Range"
 	icon_state = "toxmisc"
+	network = list("ss13", "rd")
 
 /area/science/server
 	name = "Research Division Server Room"
 	icon_state = "server"
+	network = list("ss13", "rd")
 
 /area/science/explab
 	name = "Experimentation Lab"
 	icon_state = "toxmisc"
+	network = list("ss13", "rd")
 
 /area/science/robotics
 	name = "Robotics"
 	icon_state = "medresearch"
+	network = list("ss13", "rd")
 
 /area/science/robotics/mechbay
 	name = "Mech Bay"
 	icon_state = "mechbay"
+	network = list("ss13", "rd")
 
 /area/science/robotics/lab
 	name = "Robotics Lab"
 	icon_state = "ass_line"
+	network = list("ss13", "rd")
 
 /area/science/research
 	name = "Research Division"
 	icon_state = "medresearch"
+	network = list("ss13", "rd")
 
 /area/science/research/abandoned
 	name = "Abandoned Research Lab"
 	icon_state = "medresearch"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
+	network = list("ss13", "rd")
 
 /area/science/nanite
 	name = "Nanite Lab"
 	icon_state = "toxmisc"
+	network = list("ss13", "rd")
 
 /area/science/shuttledock
 	name = "Science Shuttle Dock"
 	icon_state = "toxmisc"
+	network = list("ss13", "rd")
 
 //Storage
 /area/storage
@@ -1389,6 +1476,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "AI Satellite Maint"
 	icon_state = "storage"
 	ambience_index = AMBIENCE_DANGER
+	network = list("minisat")
 
 	//Turret_protected
 
@@ -1399,53 +1487,65 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "AI Upload Chamber"
 	icon_state = "ai_upload"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
+	network = list("aiupload")
 
 /area/ai_monitored/turret_protected/ai_upload_foyer
 	name = "AI Upload Access"
 	icon_state = "ai_foyer"
 	sound_environment = SOUND_AREA_SMALL_ENCLOSED
+	network = list("aiupload")
 
 /area/ai_monitored/turret_protected/ai
 	name = "AI Chamber"
 	icon_state = "ai_chamber"
+	network = list("aicore")
 
 /area/ai_monitored/turret_protected/aisat
 	name = "AI Satellite"
 	icon_state = "ai"
 	sound_environment = SOUND_ENVIRONMENT_ROOM
+	network = list("minisat")
 
 /area/ai_monitored/turret_protected/aisat/atmos
 	name = "AI Satellite Atmos"
 	icon_state = "ai"
+	network = list("minisat")
 
 /area/ai_monitored/turret_protected/aisat/foyer
 	name = "AI Satellite Foyer"
 	icon_state = "ai"
+	network = list("minisat")
 
 /area/ai_monitored/turret_protected/aisat/service
 	name = "AI Satellite Service"
 	icon_state = "ai"
+	network = list("minisat")
 
 /area/ai_monitored/turret_protected/aisat/hallway
 	name = "AI Satellite Hallway"
 	icon_state = "ai"
+	network = list("minisat")
 
 /area/aisat
 	name = "AI Satellite Exterior"
 	icon_state = "yellow"
+	network = list("minisat")
 
 /area/ai_monitored/turret_protected/aisat_interior
 	name = "AI Satellite Antechamber"
 	icon_state = "ai"
 	sound_environment = SOUND_AREA_LARGE_ENCLOSED
+	network = list("minisat")
 
 /area/ai_monitored/turret_protected/AIsatextAS
 	name = "AI Sat Ext"
 	icon_state = "storage"
+	network = list("minisat")
 
 /area/ai_monitored/turret_protected/AIsatextAP
 	name = "AI Sat Ext"
 	icon_state = "storage"
+	network = list("minisat")
 
 
 // Telecommunications Satellite
@@ -1460,11 +1560,14 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Telecomms Control Room"
 	icon_state = "tcomsatcomp"
 	sound_environment = SOUND_AREA_MEDIUM_SOFTFLOOR
+	network = list("ss13", "tcomms")
 
 /area/tcommsat/server
 	name = "Telecomms Server Room"
 	icon_state = "tcomsatcham"
+	network = list("ss13", "tcomms")
 
 /area/tcommsat/relay
 	name = "Telecommunications Relay"
 	icon_state = "tcomsatcham"
+	network = list("ss13", "tcomms")

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -14,6 +14,8 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	invisibility = INVISIBILITY_LIGHTING
 
+	var/network = list("ss13")
+
 	var/area_flags = VALID_TERRITORY | BLOBS_ALLOWED | UNIQUE_AREA
 
 	var/clockwork_warp_allowed = TRUE // Can servants warp into this area from Reebe?

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -67,6 +67,7 @@
 				if(C.number)
 					number = max(number, C.number+1)
 		c_tag = "[A.name] #[number]"
+		network = A.network
 
 
 // UPGRADE PROCS

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -127,7 +127,7 @@
 		return
 
 	if(action == "switch_camera")
-		var/c_tag = params["name"]
+		var/c_tag = format_text(params["name"])
 		var/list/cameras = get_available_cameras()
 		var/obj/machinery/camera/C = cameras[c_tag]
 		active_camera = C
@@ -323,7 +323,7 @@
 /obj/machinery/computer/security/telescreen/ce
 	name = "\improper Chief Engineer's telescreen"
 	desc = "Used for watching the engine, telecommunications and the minisat."
-	network = list("engine", "singularity", "tcomms", "minisat")
+	network = list("engine", "singularity", "tcomms", "minisat", "solar", "gravgen", "atmos")
 
 /obj/machinery/computer/security/telescreen/cmo
 	name = "\improper Chief Medical Officer's telescreen"

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -106,7 +106,7 @@
 		return
 
 	if(action == "switch_camera")
-		var/c_tag = params["name"]
+		var/c_tag = format_text(params["name"])
 		var/list/cameras = get_available_cameras()
 		var/obj/machinery/camera/selected_camera = cameras[c_tag]
 		active_camera = selected_camera


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

BoxStation uses autoname cameras which are missing network tags unlike the other maps(which are manual), so I integrated network tags into areas and have autoname cameras also grab the network tag for said area. This means telescreens will detect the cameras they are suppose to on BoxStation.

I like the idea of autoname cameras being more useful and less tedious when building a map. 

BoxStation CMO area disposals also now direct to where it is suppose to.

closes https://github.com/Monkestation/MonkeStation/issues/208

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Changelog

:cl:

fix: BoxStation CMO disposals link back into the system properly
code: autonameCameras now autonetwork too
code: network variable added to areas for autonameCameras

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
