### PR TITLE
Singularity Nullified Achievement & Singularity Interaction Refactor

### DIFF
--- a/code/__DEFINES/achievements.dm
+++ b/code/__DEFINES/achievements.dm
@@ -7,6 +7,7 @@
 #define MEDAL_TIMEWASTE 		      "Overextended The Joke"
 #define MEDAL_RODSUPLEX 		      "Feat of Strength"
 #define MEDAL_SINGULARITY_DEATH       "Crossing the Horizon" // get eaten by a singularity
+#define MEDAL_SINGULARITY_BUSTER	  "The Lord Dethroned" // Singularity Nullified
 #define MEDAL_GET_CLUWNED             "KILLMEKILLMEKILLME" // get turned into a vile creature known as a cluwne
 #define MEDAL_USE_WEIGHT_MACHINE      "Survival of the Fittest"
 #define MEDAL_UNWRENCH_HIGH_PRESSURE  "WHOOSH!"

--- a/code/datums/achievements/misc_achievements.dm
+++ b/code/datums/achievements/misc_achievements.dm
@@ -36,6 +36,11 @@
 	desc = "Someone submit an OSHA complaint about that CE!"
 	database_id = MEDAL_SINGULARITY_DEATH
 
+/datum/award/achievement/misc/singularity_buster
+	name = "The Lord Dethroned"
+	desc = "You spared the station from the tyrants destructive reign! Someone is getting a holiday bonus."
+	database_id = MEDAL_SINGULARITY_BUSTER
+
 /datum/award/achievement/misc/cluwne
 	name = "KILLMEKILLMEKILLME"
 	desc = "Green, Mean, Honking Machine"

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -117,18 +117,6 @@
 
 /obj/singularity/bullet_act(obj/item/projectile/P)
 	qdel(P)
-//	if(istype(P, /obj/item/projectile/bullet/SRN_rocket))
-//		for(var/mob/M as() in GLOB.player_list)
-//			if(M.get_virtual_z_level() == get_virtual_z_level())
-//				SEND_SOUND(M, 'sound/magic/charge.ogg')
-//				to_chat(M, "<span class='boldannounce'>You feel reality distort for a moment...</span>")
-//				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "delam", /datum/mood_event/delam)
-//				shake_camera(M, 15, 3)
-//				continue
-//		new/obj/singularity/spatial_rift(src.loc)
-//		qdel(src)
-//	else
-//		qdel(P)
 	return BULLET_ACT_HIT
 
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -1,5 +1,3 @@
-
-
 /obj/singularity
 	name = "gravitational singularity"
 	desc = "A gravitational singularity."
@@ -78,10 +76,7 @@
 	consume(user)
 
 /obj/singularity/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/gun/ballistic/SRN_rocketlauncher))
-		user.client?.give_award(/datum/award/achievement/misc/singularity_buster, user)
-	else
-		consume(user)
+	consume(user)
 	return 1
 
 /obj/singularity/Process_Spacemove() //The singularity stops drifting for no man!
@@ -121,18 +116,19 @@
 
 
 /obj/singularity/bullet_act(obj/item/projectile/P)
-	var/turf/T = get_turf(src)
-	if(istype(P, /obj/item/projectile/bullet/SRN_rocket))
-		for(var/mob/M as() in GLOB.player_list)
-			if(M.get_virtual_z_level() == get_virtual_z_level())
-				SEND_SOUND(M, 'sound/magic/charge.ogg')
-				to_chat(M, "<span class='boldannounce'>You feel reality distort for a moment...</span>")
-				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "delam", /datum/mood_event/delam)
-				shake_camera(M, 15, 3)
-		new/obj/singularity/spatial_rift(T)
-		qdel(src)
-	else
-		qdel(P)
+	qdel(P)
+//	if(istype(P, /obj/item/projectile/bullet/SRN_rocket))
+//		for(var/mob/M as() in GLOB.player_list)
+//			if(M.get_virtual_z_level() == get_virtual_z_level())
+//				SEND_SOUND(M, 'sound/magic/charge.ogg')
+//				to_chat(M, "<span class='boldannounce'>You feel reality distort for a moment...</span>")
+//				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "delam", /datum/mood_event/delam)
+//				shake_camera(M, 15, 3)
+//				continue
+//		new/obj/singularity/spatial_rift(src.loc)
+//		qdel(src)
+//	else
+//		qdel(P)
 	return BULLET_ACT_HIT
 
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -78,7 +78,10 @@
 	consume(user)
 
 /obj/singularity/attackby(obj/item/W, mob/user, params)
-	consume(user)
+	if(istype(W, /obj/item/gun/ballistic/SRN_rocketlauncher))
+		user.client?.give_award(/datum/award/achievement/misc/singularity_buster, user)
+	else
+		consume(user)
 	return 1
 
 /obj/singularity/Process_Spacemove() //The singularity stops drifting for no man!
@@ -117,7 +120,7 @@
 	return
 
 
-/obj/singularity/bullet_act(obj/item/projectile/P, mob/living/user)
+/obj/singularity/bullet_act(obj/item/projectile/P)
 	var/turf/T = get_turf(src)
 	if(istype(P, /obj/item/projectile/bullet/SRN_rocket))
 		for(var/mob/M as() in GLOB.player_list)

--- a/monkestation/code/modules/power/singularity/spatial_rift.dm
+++ b/monkestation/code/modules/power/singularity/spatial_rift.dm
@@ -1,8 +1,8 @@
-/// spatial rift
+/// Spatial Rift
 /// Basically a BoH Tear, but weaker because it spawns after nullifying a tesloose or singlo and those have done enough damage
 /obj/singularity/spatial_rift
 	name = "a small tear in the fabric of reality, a good place to stuff problems"
-	desc = "Your own comprehension of reality starts bending as you stare this."
+	desc = "Your own comprehension of reality starts bending as you stare at this."
 	icon = 'icons/effects/96x96.dmi'
 	icon_state = "boh_tear"
 	is_real = FALSE
@@ -14,30 +14,13 @@
 	grav_pull = 2
 	current_size = STAGE_FIVE
 	allowed_size = STAGE_FIVE
-	var/ghosts = list()
-	var/old_loc
+	obj_flags = CAN_BE_HIT | DANGEROUS_POSSESSION
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
+
 
 /obj/singularity/spatial_rift/Initialize(mapload)
 	. = ..()
-	old_loc = get_turf(src)
-	addtimer(CALLBACK(src, /atom/movable.proc/moveToNullspace), 5 SECONDS) // vanishes after 5 seconds
-	QDEL_IN(src, 10 MINUTES)
-
-/// Retrieve all the items consumed
-/obj/singularity/spatial_rift/proc/retrieve_consumed_items()
-	for(var/atom/movable/content in contents)
-		content.forceMove(old_loc)
-		if(ismob(content))
-			var/mob/M = content
-			if(!M.mind)
-				continue
-			for(var/mob/dead/observer/ghost in ghosts)
-				if(ghost.mind == M.mind)
-					ghosts -= ghost
-					ghost.can_reenter_corpse = TRUE
-					ghost.reenter_corpse()
-					break
-	qdel(src)
+	QDEL_IN(src, 5 SECONDS) // vanishes after 5 seconds
 
 /obj/singularity/spatial_rift/process()
 	eat()
@@ -61,7 +44,7 @@
 
 /obj/singularity/spatial_rift/admin_investigate_setup()
 	var/turf/T = get_turf(src)
-	message_admins("A Spatial rift has been created at [ADMIN_VERBOSEJMP(T)]. [ADMIN_RETRIEVE_BOH_ITEMS(src)]")
+	message_admins("A Spatial rift has been created at [ADMIN_VERBOSEJMP(T)].]")
 	investigate_log("was created at [AREACOORD(T)].", INVESTIGATE_ENGINES)
 
 /obj/singularity/spatial_rift/attack_tk(mob/living/user)

--- a/monkestation/code/modules/power/singularity/spatial_rift.dm
+++ b/monkestation/code/modules/power/singularity/spatial_rift.dm
@@ -19,6 +19,15 @@
 
 /obj/singularity/spatial_rift/Initialize(mapload)
 	. = ..()
+
+	for(var/mob/M as() in GLOB.player_list)
+		if(M.get_virtual_z_level() == get_virtual_z_level())
+			SEND_SOUND(M, 'sound/magic/charge.ogg')
+			to_chat(M, "<span class='boldannounce'>You feel reality distort for a moment...</span>")
+			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "delam", /datum/mood_event/delam)
+			shake_camera(M, 15, 3)
+			continue
+
 	old_loc = get_turf(src)
 	addtimer(CALLBACK(src, /atom/movable.proc/moveToNullspace), 5 SECONDS) // vanishes after 5 seconds
 	QDEL_IN(src, 10 MINUTES)

--- a/monkestation/code/modules/power/singularity/spatial_rift.dm
+++ b/monkestation/code/modules/power/singularity/spatial_rift.dm
@@ -19,15 +19,6 @@
 
 /obj/singularity/spatial_rift/Initialize(mapload)
 	. = ..()
-
-	for(var/mob/M as() in GLOB.player_list)
-		if(M.get_virtual_z_level() == get_virtual_z_level())
-			SEND_SOUND(M, 'sound/magic/charge.ogg')
-			to_chat(M, "<span class='boldannounce'>You feel reality distort for a moment...</span>")
-			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "delam", /datum/mood_event/delam)
-			shake_camera(M, 15, 3)
-			continue
-
 	old_loc = get_turf(src)
 	addtimer(CALLBACK(src, /atom/movable.proc/moveToNullspace), 5 SECONDS) // vanishes after 5 seconds
 	QDEL_IN(src, 10 MINUTES)

--- a/monkestation/code/modules/projectiles/projectile/special/rocket.dm
+++ b/monkestation/code/modules/projectiles/projectile/special/rocket.dm
@@ -6,7 +6,7 @@
 	damage = 10
 	ricochets_max = 0 //it's a MISSILE
 
-/obj/item/projectile/bullet/SRN_rocket/on_hit(atom/target, mob/user, blocked = FALSE)
+/obj/item/projectile/bullet/SRN_rocket/on_hit(atom/target, blocked = FALSE)
 	..()
 	if(ishuman(target))
 		var/mob/living/carbon/human/M = target
@@ -17,7 +17,6 @@
 		M.emote("scream")
 	else
 		playsound(src.loc, "sparks", 100, 1)
-
 	return BULLET_ACT_HIT
 
 /obj/item/projectile/bullet/SRN_rocket/Impact(atom/A)
@@ -26,17 +25,14 @@
 		var/mob/living/user = firer
 		firer = user
 		user.client.give_award(/datum/award/achievement/misc/singularity_buster, user)
-		message_admins("[firer] THIS WORKS")
 		user.emote("scream")
+
+		for(var/mob/player as anything in GLOB.player_list)
+			SEND_SOUND(player, 'sound/magic/charge.ogg')
+			to_chat(player, "<span class='boldannounce'>You feel reality distort for a moment...</span>")
+			shake_camera(player, 15, 3)
 
 		new/obj/singularity/spatial_rift(A.loc)
 		qdel(A)
 
-		for(var/mob/M as() in GLOB.player_list)
-			if(M.get_virtual_z_level() == get_virtual_z_level())
-				SEND_SOUND(M, 'sound/magic/charge.ogg')
-				to_chat(M, "<span class='boldannounce'>You feel reality distort for a moment...</span>")
-				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "delam", /datum/mood_event/delam)
-				shake_camera(M, 15, 3)
-				continue
 	return

--- a/monkestation/code/modules/projectiles/projectile/special/rocket.dm
+++ b/monkestation/code/modules/projectiles/projectile/special/rocket.dm
@@ -8,11 +8,6 @@
 
 /obj/item/projectile/bullet/SRN_rocket/on_hit(atom/target, mob/user, blocked = FALSE)
 	..()
-//	if(istype(target, /obj/singularity))
-//		var/atom/movable/firer = user
-//		user.client.give_award(/datum/award/achievement/misc/singularity_buster, user)
-//		message_admins("[firer] nullified the singularity")
-//		user.emote("scream")
 	if(ishuman(target))
 		var/mob/living/carbon/human/M = target
 		playsound(src.loc, "pierce", 100, 1)

--- a/monkestation/code/modules/projectiles/projectile/special/rocket.dm
+++ b/monkestation/code/modules/projectiles/projectile/special/rocket.dm
@@ -23,7 +23,6 @@
 	. = ..()
 	if(istype(A, /obj/singularity))
 		var/mob/living/user = firer
-		firer = user
 		user.client.give_award(/datum/award/achievement/misc/singularity_buster, user)
 		user.emote("scream")
 

--- a/monkestation/code/modules/projectiles/projectile/special/rocket.dm
+++ b/monkestation/code/modules/projectiles/projectile/special/rocket.dm
@@ -6,9 +6,15 @@
 	damage = 10
 	ricochets_max = 0 //it's a MISSILE
 
-/obj/item/projectile/bullet/SRN_rocket/on_hit(atom/target, mob/living/carbon/human/M)
+/obj/item/projectile/bullet/SRN_rocket/on_hit(atom/target, mob/user, blocked = FALSE)
 	..()
+//	if(istype(target, /obj/singularity))
+//		var/atom/movable/firer = user
+//		user.client.give_award(/datum/award/achievement/misc/singularity_buster, user)
+//		message_admins("[firer] nullified the singularity")
+//		user.emote("scream")
 	if(ishuman(target))
+		var/mob/living/carbon/human/M = target
 		playsound(src.loc, "pierce", 100, 1)
 		M.oxyloss = 5
 		M.hallucination = 15
@@ -16,4 +22,26 @@
 		M.emote("scream")
 	else
 		playsound(src.loc, "sparks", 100, 1)
+
 	return BULLET_ACT_HIT
+
+/obj/item/projectile/bullet/SRN_rocket/Impact(atom/A)
+	. = ..()
+	if(istype(A, /obj/singularity))
+		var/mob/living/user = firer
+		firer = user
+		user.client.give_award(/datum/award/achievement/misc/singularity_buster, user)
+		message_admins("[firer] THIS WORKS")
+		user.emote("scream")
+
+		new/obj/singularity/spatial_rift(A.loc)
+		qdel(A)
+
+		for(var/mob/M as() in GLOB.player_list)
+			if(M.get_virtual_z_level() == get_virtual_z_level())
+				SEND_SOUND(M, 'sound/magic/charge.ogg')
+				to_chat(M, "<span class='boldannounce'>You feel reality distort for a moment...</span>")
+				SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "delam", /datum/mood_event/delam)
+				shake_camera(M, 15, 3)
+				continue
+	return

--- a/tools/HubMigrator/HubMigrator.dm
+++ b/tools/HubMigrator/HubMigrator.dm
@@ -6,6 +6,7 @@
 #define MEDAL_CLOWNCARKING 		"Round and Full"
 #define MEDAL_THANKSALOT 		"The Best Driver"
 #define MEDAL_SINGULARITY_DEATH       "Crossing the Horizon" // get eaten by a singularity
+#define MEDAL_SINGULARITY_BUSTER	  "The Lord Dethroned" //Singularity Nullified
 #define MEDAL_GET_CLUWNED             "KILLMEKILLMEKILLME" // get turned into a vile creature known as a cluwne
 #define MEDAL_USE_WEIGHT_MACHINE      "Survival of the Fittest"
 #define MEDAL_UNWRENCH_HIGH_PRESSURE  "WHOOSH!"
@@ -58,6 +59,7 @@
 						MEDAL_CLOWNCARKING,
 						MEDAL_THANKSALOT,
                         MEDAL_SINGULARITY_DEATH,
+						MEDAL_SINGULARITY_BUSTER,
                         MEDAL_GET_CLUWNED,
                         MEDAL_USE_WEIGHT_MACHINE,
                         MEDAL_UNWRENCH_HIGH_PRESSURE,

--- a/tools/HubMigrator/HubMigrator.dm
+++ b/tools/HubMigrator/HubMigrator.dm
@@ -1,45 +1,45 @@
 //Misc Medal hub IDs
-#define MEDAL_METEOR 			"Your Life Before Your Eyes"
-#define MEDAL_PULSE 			"Jackpot"
+#define MEDAL_METEOR			"Your Life Before Your Eyes"
+#define MEDAL_PULSE				"Jackpot"
 #define MEDAL_TIMEWASTE 		"Overextended The Joke"
 #define MEDAL_RODSUPLEX 		"Feat of Strength"
-#define MEDAL_CLOWNCARKING 		"Round and Full"
+#define MEDAL_CLOWNCARKING		"Round and Full"
 #define MEDAL_THANKSALOT 		"The Best Driver"
-#define MEDAL_SINGULARITY_DEATH       "Crossing the Horizon" // get eaten by a singularity
-#define MEDAL_SINGULARITY_BUSTER	  "The Lord Dethroned" //Singularity Nullified
-#define MEDAL_GET_CLUWNED             "KILLMEKILLMEKILLME" // get turned into a vile creature known as a cluwne
-#define MEDAL_USE_WEIGHT_MACHINE      "Survival of the Fittest"
-#define MEDAL_UNWRENCH_HIGH_PRESSURE  "WHOOSH!"
-#define MEDAL_COMPLETE_ALL_OBJECTIVES "Greentext"
-#define MEDAL_APPLY_REAGENT_METH      "NYOOOOM"
-#define MEDAL_APPLY_REAGENT_SOYMILK   "Soyboy"
-#define MEDAL_15_AI_LAW_CHANGES       "Dave, my mind is going"
-#define MEDAL_DETONATE_WELDERBOMB     "That was stupid of you."
-#define MEDAL_SUCCUMB                 "Please just end the pain"
-#define MEDAL_GHOSTS                  "G-G-Ghosts?"
+#define MEDAL_SINGULARITY_DEATH			"Crossing the Horizon" // get eaten by a singularity
+#define MEDAL_SINGULARITY_BUSTER		"The Lord Dethroned" //Singularity Nullified
+#define MEDAL_GET_CLUWNED				"KILLMEKILLMEKILLME" // get turned into a vile creature known as a cluwne
+#define MEDAL_USE_WEIGHT_MACHINE		"Survival of the Fittest"
+#define MEDAL_UNWRENCH_HIGH_PRESSURE	"WHOOSH!"
+#define MEDAL_COMPLETE_ALL_OBJECTIVES	"Greentext"
+#define MEDAL_APPLY_REAGENT_METH		"NYOOOOM"
+#define MEDAL_APPLY_REAGENT_SOYMILK		"Soyboy"
+#define MEDAL_15_AI_LAW_CHANGES			"Dave, my mind is going"
+#define MEDAL_DETONATE_WELDERBOMB		"That was stupid of you."
+#define MEDAL_SUCCUMB					"Please just end the pain"
+#define MEDAL_GHOSTS					"G-G-Ghosts?"
 
 //Boss medals
 
 // Medal hub IDs for boss medals (Pre-fixes)
-#define BOSS_MEDAL_ANY		  "Killer"
-#define BOSS_MEDAL_MINER	  "Blood-drunk Miner"
-#define BOSS_MEDAL_BUBBLEGUM  "Bubblegum"
-#define BOSS_MEDAL_COLOSSUS	  "Colossus"
-#define BOSS_MEDAL_DRAKE	  "Drake"
-#define BOSS_MEDAL_HIEROPHANT "Hierophant"
-#define BOSS_MEDAL_LEGION	  "Legion"
-#define BOSS_MEDAL_TENDRIL	  "Tendril"
-#define BOSS_MEDAL_SWARMERS   "Swarmer Beacon"
+#define BOSS_MEDAL_ANY			"Killer"
+#define BOSS_MEDAL_MINER		"Blood-drunk Miner"
+#define BOSS_MEDAL_BUBBLEGUM	"Bubblegum"
+#define BOSS_MEDAL_COLOSSUS		"Colossus"
+#define BOSS_MEDAL_DRAKE		"Drake"
+#define BOSS_MEDAL_HIEROPHANT	"Hierophant"
+#define BOSS_MEDAL_LEGION		"Legion"
+#define BOSS_MEDAL_TENDRIL		"Tendril"
+#define BOSS_MEDAL_SWARMERS		"Swarmer Beacon"
 
 // Medal hub IDs for boss-kill scores
-#define BOSS_SCORE 	         "Bosses Killed"
-#define BUBBLEGUM_SCORE 	 "Bubblegum Killed"
-#define COLOSSUS_SCORE 	     "Colossus Killed"
-#define DRAKE_SCORE 	     "Drakes Killed"
-#define HIEROPHANT_SCORE 	 "Hierophants Killed"
-#define LEGION_SCORE 	     "Legion Killed"
-#define SWARMER_BEACON_SCORE "Swarmer Beacons Killed"
-#define TENDRIL_CLEAR_SCORE	 "Tendrils Killed"
+#define BOSS_SCORE				"Bosses Killed"
+#define BUBBLEGUM_SCORE			"Bubblegum Killed"
+#define COLOSSUS_SCORE			"Colossus Killed"
+#define DRAKE_SCORE				"Drakes Killed"
+#define HIEROPHANT_SCORE		"Hierophants Killed"
+#define LEGION_SCORE			"Legion Killed"
+#define SWARMER_BEACON_SCORE	"Swarmer Beacons Killed"
+#define TENDRIL_CLEAR_SCORE		"Tendrils Killed"
 
 
 
@@ -58,17 +58,17 @@
 						MEDAL_RODSUPLEX,
 						MEDAL_CLOWNCARKING,
 						MEDAL_THANKSALOT,
-                        MEDAL_SINGULARITY_DEATH,
+						MEDAL_SINGULARITY_DEATH,
 						MEDAL_SINGULARITY_BUSTER,
-                        MEDAL_GET_CLUWNED,
-                        MEDAL_USE_WEIGHT_MACHINE,
-                        MEDAL_UNWRENCH_HIGH_PRESSURE,
-                        MEDAL_COMPLETE_ALL_OBJECTIVES,
-                        MEDAL_APPLY_REAGENT_METH,
-                        MEDAL_APPLY_REAGENT_SOYMILK,
-                        MEDAL_15_AI_LAW_CHANGES,
-                        MEDAL_DETONATE_WELDERBOMB,
-                        MEDAL_SUCCUMB,
+						MEDAL_GET_CLUWNED,
+						MEDAL_USE_WEIGHT_MACHINE,
+						MEDAL_UNWRENCH_HIGH_PRESSURE,
+						MEDAL_COMPLETE_ALL_OBJECTIVES,
+						MEDAL_APPLY_REAGENT_METH,
+						MEDAL_APPLY_REAGENT_SOYMILK,
+						MEDAL_15_AI_LAW_CHANGES,
+						MEDAL_DETONATE_WELDERBOMB,
+						MEDAL_SUCCUMB,
 						MEDAL_GHOSTS,
 						BOSS_MEDAL_ANY,
 						BOSS_MEDAL_MINER,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Adds an achievement for nullifying a singularity, because achievements. Updates code to run on impact proc from the SRN_rocket projectile to delete singularities and spawn spatial tear. Tested across different singularity types successfully.

## Changelog
:cl:
add: Achievement for Nullifying Singularities
refactor: Moves code interactions from singularity to SRN_rocket projectile
/:cl: