### PR TITLE
Craftable Ook Mask

### DIFF
--- a/monkestation/code/datums/components/crafting/recipes.dm
+++ b/monkestation/code/datums/components/crafting/recipes.dm
@@ -16,3 +16,11 @@
 					/obj/item/stack/cable_coil = 1)
 	tools = list(/obj/item/reagent_containers/food/snacks/grown/banana)
 	category = CAT_CLOTHING
+
+/datum/crafting_recipe/paper_mask
+	name = "Monkey Mask"
+	result = /obj/item/clothing/mask/ookmask
+	time = 10
+	reqs = list(/obj/item/paper = 5)
+	category = CAT_CLOTHING
+	tools = list(TOOL_WIRECUTTER)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

You can now craft Ook masks with 5 paper and wirecutters.

## Why It's Good For The Game

I meant to do this a WHILE ago, but entirely forgot.
Gotta have the mask of the server's owner available for all.

## Changelog

:cl:
add: Ook masks are now craftable in the crafting menu for 5 Paper
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
