### PR TITLE
Baja Blast Fixes

### DIFF
--- a/monkestation/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/monkestation/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -1,5 +1,5 @@
-/datum/chemical_reaction/bajablast
+/datum/chemical_reaction/baja_blast
 	name = "Baja Blast"
-	id = /datum/reagent/bajablast
-	results = list(/datum/reagent/bajablast = 3)
+	id = /datum/reagent/consumable/baja_blast
+	results = list(/datum/reagent/consumable/baja_blast = 3)
 	required_reagents = list(/datum/reagent/consumable/limejuice = 1, /datum/reagent/oil = 1, /datum/reagent/consumable/sugar = 1)

--- a/monkestation/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/monkestation/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -1,4 +1,4 @@
-/datum/reagent/bajablast
+/datum/reagent/consumable/baja_blast
 	name = "Baja Blast"
 	description = "A substance applied to the skin by gamers to lighten the skin."
 	color = "#63FFE0" // Teal
@@ -6,7 +6,7 @@
 	overdose_threshold = 11 //Slightly more than one un-nozzled spraybottle.
 	taste_description = "lime and the tropics"
 
-/datum/reagent/bajablast/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
+/datum/reagent/consumable/baja_blast/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
 	if(ishuman(M))
 		if(method == PATCH || method == VAPOR)
 			var/mob/living/carbon/human/N = M
@@ -33,13 +33,13 @@
 			N.regenerate_icons()
 	..()
 
-/datum/reagent/bajablast/overdose_process(mob/living/M)
+/datum/reagent/consumable/baja_blast/overdose_process(mob/living/M)
 	metabolization_rate = 1 * REAGENTS_METABOLISM
 	if(prob(3))
 		M.say(pick(	"Poggers.", "Swag.", "Bruh.", "You're such a bot.", "You need a nerf, bro.",
 					"I need a buff, bro.", "Stop cheesing.", "Rush B.", "Rush A.",
 					"No camping.", "Look, an easter egg.", "GG no RE!", "Damn RNG!",
-					"Noob.", "POGCHAMP!!", "A new PB!"), forced = /datum/reagent/bajablast) //This doesn't deserve a string file. I have to repress gamers.
+					"Noob.", "POGCHAMP!!", "A new PB!"), forced = /datum/reagent/consumable/baja_blast) //This doesn't deserve a string file. I have to repress gamers.
 		return
 	if(prob(3))
 		M.visible_message("<span class = 'warning'>[pick("[M] flexes their gamer skills.",
@@ -53,7 +53,7 @@
 		return
 	..()
 	return
-/datum/reagent/consumable/bajablast/on_mob_life(mob/living/carbon/M)
+/datum/reagent/consumable/baja_blast/on_mob_life(mob/living/carbon/M)
 	M.Jitter(20)
 	M.dizziness = min(5,M.dizziness+1)
 	M.drowsyness = 0
@@ -61,16 +61,16 @@
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, BODYTEMP_NORMAL)
 	..()
 
-/datum/reagent/consumable/bajablast/on_mob_metabolize(mob/living/L)
+/datum/reagent/consumable/baja_blast/on_mob_metabolize(mob/living/L)
 	..()
 	if(ismonkey(L))
 		L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=-0.75, blacklisted_movetypes=(FLYING|FLOATING))
 
-/datum/reagent/consumable/bajablast/on_mob_end_metabolize(mob/living/L)
+/datum/reagent/consumable/baja_blast/on_mob_end_metabolize(mob/living/L)
 	L.remove_movespeed_modifier(type)
 	..()
 
-/datum/reagent/bajablast/overdose_start(mob/living/M)
+/datum/reagent/consumable/baja_blast/overdose_start(mob/living/M)
 	. = ..()
 	if(!ishuman(M))
 		return

--- a/monkestation/code/modules/reagents/reagent_containers/medspray.dm
+++ b/monkestation/code/modules/reagents/reagent_containers/medspray.dm
@@ -3,5 +3,5 @@
 	desc = "A bottle of Baja Blast, designed for rapid deployment during gaming."
 	icon_state = "spraytan"
 	apply_type = TOUCH
-	list_reagents = list(/datum/reagent/bajablast = 55)
+	list_reagents = list(/datum/reagent/consumable/baja_blast = 55)
 	amount_per_transfer_from_this = 11

--- a/monkestation/code/modules/reagents/reagent_containers/spray.dm
+++ b/monkestation/code/modules/reagents/reagent_containers/spray.dm
@@ -2,4 +2,4 @@
 	name = "Baja Blast Spray"
 	volume = 50
 	desc = "A sprayer of advanced Gamer Fuel, designed for rapid deployment during gaming sessions."
-	list_reagents = list(/datum/reagent/bajablast = 50)
+	list_reagents = list(/datum/reagent/consumable/baja_blast = 50)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Removes the accidental double define of Baja Blast which caused the crafted version to only cause shakes.

Gives the reagent itself a more proper snake_case name.

## Why It's Good For The Game

Crafting Baja Blast should ACTUALLY create Baja Blast.

## Changelog

:cl:
fix: Crafted Baja Blast is now the same as regular Baja Blast
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
