### PR TITLE
Ling Spawned Teratoma can no longer use guns

### DIFF
--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -228,7 +228,7 @@ GLOBAL_LIST_INIT(strippable_monkey_items, create_strippable_list(list(
 	id = "teratoma"
 	say_mod = "mumbles"
 	species_traits = list(NOTRANSSTING, NO_DNA_COPY, EYECOLOR, HAIR, FACEHAIR, LIPS)
-	inherent_traits = list(TRAIT_NOHUNGER, TRAIT_RADIMMUNE, TRAIT_BADDNA, TRAIT_NONECRODISEASE, TRAIT_MONKEYLIKE)	//Made of mutated cells
+	inherent_traits = list(TRAIT_NOHUNGER, TRAIT_RADIMMUNE, TRAIT_BADDNA, TRAIT_NOGUNS, TRAIT_NONECRODISEASE, TRAIT_MONKEYLIKE)	//Made of mutated cells
 	default_features = list("mcolor" = "FFF", "wings" = "None")
 	skinned_type = /obj/item/stack/sheet/animalhide/monkey
 	liked_food = JUNKFOOD | FRIED | GROSS | RAW
@@ -253,8 +253,9 @@ GLOBAL_LIST_INIT(strippable_monkey_items, create_strippable_list(list(
 /mob/living/carbon/monkey/tumor/handle_mutations_and_radiation()
 	return
 
-/mob/living/carbon/monkey/tumor/IsAdvancedToolUser()//There's no reason to have guns as these mobs.
+/mob/living/carbon/monkey/tumor/can_use_guns(obj/item/G)
 	return FALSE
+
 
 /mob/living/carbon/monkey/tumor/has_dna()
 	return FALSE

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -228,7 +228,7 @@ GLOBAL_LIST_INIT(strippable_monkey_items, create_strippable_list(list(
 	id = "teratoma"
 	say_mod = "mumbles"
 	species_traits = list(NOTRANSSTING, NO_DNA_COPY, EYECOLOR, HAIR, FACEHAIR, LIPS)
-	inherent_traits = list(TRAIT_NOHUNGER, TRAIT_RADIMMUNE, TRAIT_BADDNA, TRAIT_NOGUNS, TRAIT_NONECRODISEASE)	//Made of mutated cells
+	inherent_traits = list(TRAIT_NOHUNGER, TRAIT_RADIMMUNE, TRAIT_BADDNA, TRAIT_NONECRODISEASE, TRAIT_MONKEYLIKE)	//Made of mutated cells
 	default_features = list("mcolor" = "FFF", "wings" = "None")
 	skinned_type = /obj/item/stack/sheet/animalhide/monkey
 	liked_food = JUNKFOOD | FRIED | GROSS | RAW
@@ -252,6 +252,9 @@ GLOBAL_LIST_INIT(strippable_monkey_items, create_strippable_list(list(
 
 /mob/living/carbon/monkey/tumor/handle_mutations_and_radiation()
 	return
+
+/mob/living/carbon/monkey/tumor/IsAdvancedToolUser()//There's no reason to have guns as these mobs.
+	return FALSE
 
 /mob/living/carbon/monkey/tumor/has_dna()
 	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
There was a previous fix to remove gun usage from Teratoma, but it only hit the species, and ling spawned teratoma still are able to use guns. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Teratoma are supposed to be annoying and slippery. Using guns leads to them ventcrawling into the armory and shooting people.  That's not annoying, thats harmful.  
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->


## Changelog

:cl:
fix: Ling Spawned Teratoma can no longer use guns
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
