### PR TITLE
Mushroom Replication Removal

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
@@ -44,7 +44,7 @@
 	},
 /area/ruin/powered)
 "k" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /turf/open/floor/plating/asteroid{
 	name = "dirt"
 	},
@@ -72,7 +72,7 @@
 /turf/open/floor/plating/asteroid/basalt,
 /area/ruin/powered)
 "q" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /turf/open/floor/plating,
 /area/ruin/powered)
 "r" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
@@ -83,7 +83,7 @@
 	},
 /area/ruin/unpowered)
 "n" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood{
 	initial_gas_mix = "o2=14;n2=5;co2=13;TEMP=300"
@@ -134,7 +134,7 @@
 	},
 /area/ruin/unpowered)
 "u" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /turf/open/floor/wood{
 	initial_gas_mix = "o2=14;n2=5;co2=13;TEMP=300"
 	},
@@ -167,7 +167,7 @@
 /area/ruin/unpowered)
 "z" = (
 /obj/structure/table/wood,
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /obj/item/a_gift,
 /turf/open/floor/wood{
 	initial_gas_mix = "o2=14;n2=5;co2=13;TEMP=300"
@@ -232,7 +232,7 @@
 	},
 /area/ruin/unpowered)
 "J" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
 	initial_gas_mix = "o2=14;n2=5;co2=13;TEMP=300"

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_standruin.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_standruin.dmm
@@ -19,7 +19,7 @@
 /obj/structure/stone_tile/cracked{
 	dir = 4
 	},
-/obj/structure/glowshroom/single{
+/obj/structure/glowshroom{
 	icon_state = "glowshroom3";
 	dir = 4
 	},
@@ -59,15 +59,15 @@
 /obj/structure/stone_tile/cracked{
 	dir = 4
 	},
-/obj/structure/glowshroom/single,
-/obj/structure/glowshroom/single{
+/obj/structure/glowshroom,
+/obj/structure/glowshroom{
 	icon_state = "glowshroom3"
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/standruin)
 "aj" = (
 /obj/structure/stone_tile/slab/cracked,
-/obj/structure/glowshroom/single{
+/obj/structure/glowshroom{
 	icon_state = "glowshroom3"
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -107,7 +107,7 @@
 /area/ruin/unpowered/standruin)
 "ap" = (
 /obj/structure/stone_tile/slab/cracked,
-/obj/structure/glowshroom/single{
+/obj/structure/glowshroom{
 	icon_state = "glowshroom1";
 	dir = 4
 	},
@@ -419,7 +419,7 @@
 /area/ruin/unpowered/standruin)
 "bh" = (
 /obj/structure/stone_tile/slab/burnt,
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/standruin)
 "bi" = (
@@ -427,7 +427,7 @@
 	dir = 8
 	},
 /obj/structure/flora/ash/tall_shroom,
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/standruin)
 "bj" = (
@@ -452,7 +452,7 @@
 /area/ruin/unpowered/standruin)
 "bn" = (
 /obj/structure/stone_tile/center,
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/standruin)
 "bo" = (

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -336,7 +336,7 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /turf/open/floor/mineral/titanium/blue,
 /area/ruin/space/has_grav/derelictoutpost/dockedship)
 "bh" = (
@@ -410,7 +410,7 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /obj/structure/sign/warning/vacuum{
 	pixel_y = 32
 	},
@@ -911,7 +911,7 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost)
 "cj" = (
@@ -938,7 +938,7 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /obj/effect/decal/cleanable/blood/old{
 	name = "dried blood trail";
 	icon_state = "trails_1";
@@ -1216,7 +1216,7 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -1335,7 +1335,7 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/derelictoutpost/cargobay)
@@ -1553,7 +1553,7 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav/derelictoutpost)
 "du" = (
@@ -1623,7 +1623,7 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /turf/open/floor/plating/asteroid,
 /area/ruin/space/has_grav/derelictoutpost)
 "dz" = (
@@ -1832,7 +1832,7 @@
 	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
 	name = "gelatinous floor"
 	},
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /obj/effect/decal/cleanable/blood/old{
 	name = "dried blood trail";
 	icon_state = "trails_1";

--- a/_maps/RandomZLevels/caves.dmm
+++ b/_maps/RandomZLevels/caves.dmm
@@ -1036,7 +1036,7 @@
 	},
 /area/awaymission/caves/research)
 "cY" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /turf/open/floor/plasteel{
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},
@@ -1783,7 +1783,7 @@
 /turf/open/floor/plasteel,
 /area/awaymission/caves/BMP_asteroid)
 "fv" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /turf/open/floor/plating/asteroid/basalt{
 	initial_gas_mix = "n2=23;o2=14;TEMP=2.7"
 	},

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -802,7 +802,7 @@
 /turf/closed/wall,
 /area/awaymission/undergroundoutpost45/central)
 "bW" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /turf/open/floor/plating/asteroid{
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
@@ -3056,7 +3056,7 @@
 	},
 /area/awaymission/undergroundoutpost45/central)
 "gf" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /turf/open/floor/plating/asteroid{
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;
@@ -13755,7 +13755,7 @@
 /area/awaymission/undergroundoutpost45/caves)
 "yl" = (
 /obj/structure/alien/weeds,
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/open/floor/plating/asteroid{
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
@@ -13823,7 +13823,7 @@
 /area/awaymission/undergroundoutpost45/caves)
 "yt" = (
 /obj/structure/alien/weeds,
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /turf/open/floor/plating/asteroid{
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	heat_capacity = 1e+006;

--- a/_maps/shuttles/whiteship_fland.dmm
+++ b/_maps/shuttles/whiteship_fland.dmm
@@ -249,7 +249,7 @@
 "kH" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
@@ -569,7 +569,7 @@
 "Fj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /obj/item/storage/box/zipties,
 /obj/machinery/firealarm{
 	dir = 8;
@@ -603,7 +603,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "HL" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /obj/machinery/atmospherics/pipe/manifold/dark/hidden,
 /turf/open/floor/grass,
 /area/shuttle/abandoned)
@@ -618,7 +618,7 @@
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
 "Iv" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /obj/machinery/button/door{
 	id = "botanyShipR";
 	name = "Cargo Blast Door Toggle";
@@ -668,7 +668,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/abandoned)
 "NE" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /obj/machinery/light,
 /turf/open/floor/grass,
 /area/shuttle/abandoned)
@@ -735,7 +735,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/abandoned)
 "Tq" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -752,7 +752,7 @@
 /turf/open/floor/wood,
 /area/shuttle/abandoned)
 "TH" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/dp_vent_pump{
@@ -796,7 +796,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/abandoned)
 "XW" = (
-/obj/structure/glowshroom/single,
+/obj/structure/glowshroom,
 /turf/open/floor/grass,
 /area/shuttle/abandoned)
 "Yf" = (

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -10,10 +10,7 @@
 	icon_state = "glowshroom" //replaced in New
 	layer = ABOVE_NORMAL_TURF_LAYER
 	max_integrity = 30
-	var/delay = 1200
 	var/floor = 0
-	var/generation = 1
-	var/spreadIntoAdjacentChance = 60
 	var/obj/item/seeds/myseed = /obj/item/seeds/glowshroom
 	var/static/list/blacklisted_glowshroom_turfs = typecacheof(list(
 	/turf/open/lava,
@@ -31,17 +28,6 @@
 	icon_state = "shadowshroom"
 	myseed = /obj/item/seeds/glowshroom/shadowshroom
 
-/obj/structure/glowshroom/single/Spread()
-	return
-
-/obj/structure/glowshroom/examine(mob/user)
-	. = ..()
-	. += "This is a [generation]\th generation [name]!"
-
-/obj/structure/glowshroom/Destroy()
-	if(myseed)
-		QDEL_NULL(myseed)
-	return ..()
 
 /obj/structure/glowshroom/New(loc, obj/item/seeds/newseed, mutate_stats)
 	..()
@@ -55,7 +41,6 @@
 		myseed.adjust_yield(rand(-1,2))
 		myseed.adjust_production(rand(-3,6))
 		myseed.adjust_endurance(rand(-3,6))
-	delay = delay - myseed.production * 100 //So the delay goes DOWN with better stats instead of up. :I
 	obj_integrity = myseed.endurance
 	max_integrity = myseed.endurance
 	var/datum/plant_gene/trait/glow/G = myseed.get_gene(/datum/plant_gene/trait/glow)
@@ -79,55 +64,6 @@
 		icon_state = "[base_icon_state][rand(1,3)]"
 	else //if on the floor, glowshroom on-floor sprite
 		icon_state = base_icon_state
-
-	addtimer(CALLBACK(src, .proc/Spread), delay)
-
-/obj/structure/glowshroom/proc/Spread()
-	var/turf/ownturf = get_turf(src)
-	var/shrooms_planted = 0
-	for(var/i in 1 to myseed.yield)
-		if(prob(1/(generation * generation) * 100))//This formula gives you diminishing returns based on generation. 100% with 1st gen, decreasing to 25%, 11%, 6, 4, 2...
-			var/list/possibleLocs = list()
-			var/spreadsIntoAdjacent = FALSE
-
-			if(prob(spreadIntoAdjacentChance))
-				spreadsIntoAdjacent = TRUE
-
-			for(var/turf/open/floor/earth in view(3,src))
-				if(is_type_in_typecache(earth, blacklisted_glowshroom_turfs))
-					continue
-				if(!ownturf.CanAtmosPass(earth))
-					continue
-				if(spreadsIntoAdjacent || !locate(/obj/structure/glowshroom) in view(1,earth))
-					possibleLocs += earth
-				CHECK_TICK
-
-			if(!possibleLocs.len)
-				break
-
-			var/turf/newLoc = pick(possibleLocs)
-
-			var/shroomCount = 0 //hacky
-			var/placeCount = 1
-			for(var/obj/structure/glowshroom/shroom in newLoc)
-				shroomCount++
-			for(var/wallDir in GLOB.cardinals)
-				var/turf/isWall = get_step(newLoc,wallDir)
-				if(isWall.density)
-					placeCount++
-			if(shroomCount >= placeCount)
-				continue
-
-			var/obj/structure/glowshroom/child = new type(newLoc, myseed, TRUE)
-			child.generation = generation + 1
-			shrooms_planted++
-
-			CHECK_TICK
-		else
-			shrooms_planted++ //if we failed due to generation, don't try to plant one later
-	if(shrooms_planted < myseed.yield) //if we didn't get all possible shrooms planted, try again later
-		myseed.yield -= shrooms_planted
-		addtimer(CALLBACK(src, .proc/Spread), delay)
 
 /obj/structure/glowshroom/proc/CalcDir(turf/location = loc)
 	var/direction = 16
@@ -160,6 +96,7 @@
 
 	floor = 1
 	return 1
+
 
 /obj/structure/glowshroom/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	if(damage_type == BURN && damage_amount)

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -28,6 +28,10 @@
 	icon_state = "shadowshroom"
 	myseed = /obj/item/seeds/glowshroom/shadowshroom
 
+/obj/structure/glowshroom/Destroy()
+	if(myseed)
+		QDEL_NULL(myseed)
+	return ..()
 
 /obj/structure/glowshroom/New(loc, obj/item/seeds/newseed, mutate_stats)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Mushrooms may no longer replicate by themselves.

## Why It's Good For The Game

Mushrooms are a laggy mess that haven't been updated in 5-11 years.
These are the only plants that can replicate by themselves, without any botanist assistance.

This is a case where "remove, not improve" is likely to be better simply because the system itself was a bad idea.
For example, during a two hour round, over 1100 mushrooms grew by themselves.
Each with a contained seed and various other data.
Even a cleanup attempt brought the server to a crawl, because it overloaded the garbage collector.

## Changelog

:cl:
del: Mushrooms may no longer replicate by themselves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
