### PR TITLE
reduce wheelchair grief

### DIFF
--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -59,6 +59,11 @@
 	if(has_buckled_mobs())
 		handle_rotation_overlayed()
 
+//monkestation edit - make wheelchair from other players unbuckles take time
+/obj/vehicle/ridden/wheelchair/unbuckle_mob(mob/living/buckled_mob, force)
+	if((usr != buckled_mob && do_after(usr, 2 SECONDS, null, buckled_mob)) || usr == buckled_mob)
+		. = ..()
+//monkestation edit end
 
 /obj/vehicle/ridden/wheelchair/post_buckle_mob(mob/living/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Adds a DoAfter() for unbuckling players from wheelchairs.  Wheelchair users unbuckling themselves remains the same
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
For some shitty reason people keep trying to grief paraplegics, and this makes it a bit harder to do.  A paraplegic shouldn't have to constantly worry about being unbuckled instantly and having their chair stolen.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
balance: It now takes 2 seconds to unbuckle another mob from a wheelchair.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
