### PR TITLE
IPC Limb Dmg Adjustments

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -24,7 +24,7 @@
 	damage_overlay_type = "synth"
 	mutant_bodyparts = list("ipc_screen", "ipc_antenna", "ipc_chassis")
 	default_features = list("ipc_screen" = "BSOD", "ipc_antenna" = "None")
-	burnmod = 2
+	burnmod = 1.5	//Default was 2 //Monkestation Edit
 	heatmod = 1.5
 	brutemod = 1
 	clonemod = 0

--- a/code/modules/surgery/bodyparts/species_parts/ipc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/ipc_bodyparts.dm
@@ -7,7 +7,7 @@
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC | BODYTYPE_BOXHEAD
 
 	body_damage_coeff = 0.2	//IPC's Head can dismember	//Monkestation Edit
-	max_damage = 40	//Keep in mind that this value is used in the TRAIT_EASYDISMEMBER	//Monkestation Edit
+	max_damage = 40	//Keep in mind that this value is used in the //Monkestation Edit
 
 	light_brute_msg = "scratched"
 	medium_brute_msg = "dented"

--- a/code/modules/surgery/bodyparts/species_parts/ipc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/ipc_bodyparts.dm
@@ -5,6 +5,10 @@
 	is_dimorphic = FALSE
 	should_draw_greyscale = FALSE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC | BODYTYPE_BOXHEAD
+
+	body_damage_coeff = 0.2	//IPC's Head can dismember	//Monkestation Edit
+	max_damage = 40	//Keep in mind that this value is used in the TRAIT_EASYDISMEMBER	//Monkestation Edit
+
 	light_brute_msg = "scratched"
 	medium_brute_msg = "dented"
 	heavy_brute_msg = "sheared"
@@ -21,6 +25,9 @@
 	should_draw_greyscale = FALSE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 
+	body_damage_coeff = 1	//IPC Chest	//Monkestation Edit
+	max_damage = 200	//Monkestation Edit
+
 	light_brute_msg = "scratched"
 	medium_brute_msg = "dented"
 	heavy_brute_msg = "sheared"
@@ -35,6 +42,9 @@
 	limb_id = "synth"
 	should_draw_greyscale = FALSE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
+
+	body_damage_coeff = 0.1	//IPC's Limbs Should Dismember Easier	//Monkestation Edit
+	max_damage = 30	//Monkestation Edit
 
 	light_brute_msg = "scratched"
 	medium_brute_msg = "dented"
@@ -51,6 +61,9 @@
 	should_draw_greyscale = FALSE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 
+	body_damage_coeff = 0.1	//IPC's Limbs Should Dismember Easier	//Monkestation Edit
+	max_damage = 30	//Monkestation Edit
+
 	light_brute_msg = "scratched"
 	medium_brute_msg = "dented"
 	heavy_brute_msg = "sheared"
@@ -66,6 +79,9 @@
 	should_draw_greyscale = FALSE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 
+	body_damage_coeff = 0.1	//IPC's Limbs Should Dismember Easier	//Monkestation Edit
+	max_damage = 30	//Monkestation Edit
+
 	light_brute_msg = "scratched"
 	medium_brute_msg = "dented"
 	heavy_brute_msg = "sheared"
@@ -80,6 +96,9 @@
 	limb_id = "synth"
 	should_draw_greyscale = FALSE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
+
+	body_damage_coeff = 0.1	//IPC's Limbs Should Dismember Easier	//Monkestation Edit
+	max_damage = 30	//Monkestation Edit
 
 	light_brute_msg = "scratched"
 	medium_brute_msg = "dented"

--- a/code/modules/surgery/bodyparts/species_parts/ipc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/ipc_bodyparts.dm
@@ -25,7 +25,7 @@
 	should_draw_greyscale = FALSE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 
-	body_damage_coeff = 1	//IPC Chest	//Monkestation Edit
+	body_damage_coeff = 1	//IPC Chest at default	//Monkestation Edit
 	max_damage = 200	//Monkestation Edit
 
 	light_brute_msg = "scratched"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
IPC's limbs are easier to destroy and knock off. They have lower max health but don't transfer as much damage to the body.
This will probably need adjustments over time to get it feeling right, but I will be closely testing it since I play as an IPC.

## Why It's Good For The Game
I feel IPC's should be able to experience being blown apart more and still survive.

## Changelog

:cl:
balance: IPC's are slightly stronger, but their limbs are weaker. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
