### PR TITLE
Pandora Nerf

### DIFF
--- a/_maps/RuinGeneration/13x17_pizzaroom.dmm
+++ b/_maps/RuinGeneration/13x17_pizzaroom.dmm
@@ -33,7 +33,7 @@
 /turf/open/floor/plating/asteroid,
 /area/ruin/unpowered)
 "t" = (
-/mob/living/simple_animal/hostile/asteroid/elite/pandora,
+/mob/living/simple_animal/hostile/asteroid/elite/pandora/exploration,
 /turf/open/indestructible/hierophant,
 /area/ruin/unpowered)
 "v" = (

--- a/beestation.dme
+++ b/beestation.dme
@@ -3609,6 +3609,7 @@
 #include "monkestation\code\modules\mob\living\simple_animal\friendly\dog.dm"
 #include "monkestation\code\modules\mob\living\simple_animal\friendly\honk_platinum.dm"
 #include "monkestation\code\modules\mob\living\simple_animal\hostile\bees.dm"
+#include "monkestation\code\modules\mob\living\simple_animal\hostile\mining_mobs\elites\pandora_exploration.dm"
 #include "monkestation\code\modules\power\singularity\spatial_rift.dm"
 #include "monkestation\code\modules\procedural_mapping\mapGeneratorModules\jungle.dm"
 #include "monkestation\code\modules\procedural_mapping\mapGenerators\jungle.dm"

--- a/monkestation/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora_exploration.dm
+++ b/monkestation/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/pandora_exploration.dm
@@ -1,0 +1,39 @@
+/mob/living/simple_animal/hostile/asteroid/elite/pandora/exploration
+	name = "Pyxis"
+	desc = "A magic box with similar power and design to the Hierophant. Seems unwilling to close."
+	maxHealth = 400
+	health = 400
+	melee_damage = 10
+	attack_action_types = list(/datum/action/innate/elite_attack/singular_shot,
+								/datum/action/innate/elite_attack/magic_box,
+								/datum/action/innate/elite_attack/pandora_teleport)
+
+/mob/living/simple_animal/hostile/asteroid/elite/pandora/OpenFire()
+	if(client)
+		switch(chosen_attack)
+			if(SINGULAR_SHOT)
+				singular_shot(target)
+			if(MAGIC_BOX)
+				magic_box(target)
+			if(PANDORA_TELEPORT)
+				pandora_teleport(target)
+		return
+	var/aiattack = rand(1,3)
+	switch(aiattack)
+		if(SINGULAR_SHOT)
+			singular_shot(target)
+		if(MAGIC_BOX)
+			magic_box(target)
+		if(PANDORA_TELEPORT)
+			pandora_teleport(target)
+
+/mob/living/simple_animal/hostile/asteroid/elite/pandora/exploration/Life()
+	. = ..()
+	if(health >= maxHealth * 0.5)
+		cooldown_time = 2.5 SECONDS
+		return
+	if(health < maxHealth * 0.5 && health > maxHealth * 0.25)
+		cooldown_time = 2 SECONDS
+		return
+	else
+		cooldown_time = 1.5 SECONDS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Creates a new form of the Pandora, the Pyxis, with half the health and longer cooldowns specifically for the Exploration map that has it.

The Pyxis has had the "AOE Blast" ability removed from it, to better work within the confined spaces that explorers have to deal with.

## Why It's Good For The Game

Explorers have less mobility than the average miner, as well as less possible defensive equipment.
This coupled with a boss-tier enemy that a miner can CHOOSE to trigger, rather than walk straight into, means that explorer teams will often by wiped out by an entirely unexpected enemy teleporting to them.

Random wipes aren't fun, nor should exploration have the same level of threat as the average miner.

## Changelog

:cl:
add: A weaker form of the Pandora called the Pyxis
balance: Exploration missions will now fight the Pyxis rather than the Pandora
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
