### PR TITLE
WALTER FOR LAWYER OFFICE PET

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -57930,6 +57930,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 8
 	},
+/obj/structure/bed/dogbed/walter,
+/mob/living/simple_animal/pet/dog/bullterrier/walter,
 /turf/open/floor/wood,
 /area/lawoffice)
 "xNj" = (

--- a/_maps/map_files/CorgStation/CorgStation.dmm
+++ b/_maps/map_files/CorgStation/CorgStation.dmm
@@ -83985,6 +83985,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/structure/bed/dogbed/walter,
+/mob/living/simple_animal/pet/dog/bullterrier/walter,
 /turf/open/floor/plasteel/dark,
 /area/lawoffice)
 "tQw" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -110744,8 +110744,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/mob/living/simple_animal/pet/dog/bullterrier/walter,
-/obj/structure/bed/dogbed/walter,
+/obj/structure/bed/dogbed/walter{
+	name = "Captain's bed"
+	},
+/mob/living/simple_animal/pet/dog/australianshepherd/captain,
 /turf/open/floor/plasteel,
 /area/security/warden)
 "pAL" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -54526,6 +54526,8 @@
 	pixel_x = 26;
 	pixel_y = 26
 	},
+/obj/structure/bed/dogbed/walter,
+/mob/living/simple_animal/pet/dog/bullterrier/walter,
 /turf/open/floor/wood,
 /area/lawoffice)
 "cdk" = (

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -93776,6 +93776,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/bed/dogbed/walter,
+/mob/living/simple_animal/pet/dog/bullterrier/walter,
 /turf/open/floor/wood,
 /area/lawoffice)
 "vXg" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -1634,6 +1634,8 @@
 	pixel_x = 24;
 	req_access_txt = "38"
 	},
+/obj/structure/bed/dogbed/walter,
+/mob/living/simple_animal/pet/dog/bullterrier/walter,
 /turf/open/floor/plasteel/dark,
 /area/lawoffice)
 "add" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -17918,6 +17918,8 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/structure/bed/dogbed/walter,
+/mob/living/simple_animal/pet/dog/bullterrier/walter,
 /turf/open/floor/wood,
 /area/lawoffice)
 "aKk" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -54575,6 +54575,11 @@
 	luminosity = 2
 	},
 /area/maintenance/department/science)
+"oca" = (
+/obj/structure/bed/dogbed/walter,
+/mob/living/simple_animal/pet/dog/bullterrier/walter,
+/turf/open/floor/wood,
+/area/lawoffice)
 "ocb" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/tile/green{
@@ -81953,7 +81958,7 @@ xJy
 ufM
 sJr
 sJr
-sJr
+oca
 aiu
 jhk
 aiu


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Adds/Moves Walter to being a pet for the Lawyer! simple as that, also moves Deltastation Walter to being a Lawyer office pet, while Deltastation's security pet is now Captain the doggo

## Why It's Good For The Game

Walter for the Lawyer Saul Goodman

https://imgur.com/PBdkkFe

## Changelog

:cl:
tweak: Walter the Dog is now a Lawyer pet rather than the Warden's pet
/:cl:
