### PR TITLE
Ports shaken drinks from paradise.

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3595,6 +3595,7 @@
 #include "monkestation\code\modules\clothing\under\miscellaneous.dm"
 #include "monkestation\code\modules\clothing\under\jobs\civilian\civilian.dm"
 #include "monkestation\code\modules\clothing\under\jobs\plasmaman\civilian_service.dm"
+#include "monkestation\code\modules\food_and_drinks\drinks\drinks.dm"
 #include "monkestation\code\modules\food_and_drinks\food\snacks_meat.dm"
 #include "monkestation\code\modules\food_and_drinks\recipes\drinks_recipes.dm"
 #include "monkestation\code\modules\hydroponics\plant_genes.dm"

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -20,6 +20,7 @@
 	var/can_shake = TRUE
 	var/can_burst = FALSE
 	var/canopened = FALSE
+	var/isShakeable = TRUE
 	var/burst_chance = 0
 	spillable = FALSE
 

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -10,7 +10,7 @@
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
 	reagent_flags = NONE //MONKESTATION EDIT
 	var/gulp_size = 5 //This is now officially broken ... need to think of a nice way to fix it.
-	possible_transfer_amounts = list(5,10,15,20,25,30,50)
+	possible_transfer_amounts = list()
 	volume = 50
 	resistance_flags = NONE
 	var/isGlass = TRUE //Whether the 'bottle' is made of glass or not so that milk cartons dont shatter when someone gets hit by it

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -15,6 +15,12 @@
 	resistance_flags = NONE
 	var/isGlass = TRUE //Whether the 'bottle' is made of glass or not so that milk cartons dont shatter when someone gets hit by it
 	var/beingChugged = FALSE //We don't want people downing 100u super fast with drinking glasses
+	//MONKESTATION EDITS START
+	var/times_shaken = 0
+	var/can_shake = TRUE
+	var/can_burst = FALSE
+	var/canopened = FALSE
+	var/burst_chance = 0
 
 /obj/item/reagent_containers/food/drinks/on_reagent_change(changetype)
 	. = ..()
@@ -471,7 +477,7 @@
 		H.visible_message("<span class='warning'>[H] is trying to take a big sip from [src]... The can is empty!</span>")
 		return SHAME
 	if(!is_drainable())
-		open_soda()
+		open_drink() //Monkestation edit
 		sleep(10)
 	H.visible_message("<span class='suicide'>[H] takes a big sip from [src]! It looks like [H.p_theyre()] trying to commit suicide!</span>")
 	playsound(H,'sound/items/drink.ogg', 80, 1)
@@ -506,6 +512,7 @@
 		qdel(src)
 		return
 
+/* MONKESTATION EDIT
 /obj/item/reagent_containers/food/drinks/soda_cans/proc/open_soda(mob/user)
 	to_chat(user, "You pull back the tab of \the [src] with a satisfying pop.") //Ahhhhhhhh
 	ENABLE_BITFIELD(reagents.flags, OPENCONTAINER)
@@ -516,6 +523,7 @@
 	if(!is_drainable())
 		open_soda(user)
 	return ..()
+*/
 
 /obj/item/reagent_containers/food/drinks/soda_cans/cola
 	name = "Space Cola"

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -8,7 +8,7 @@
 	icon_state = null
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
-	reagent_flags = OPENCONTAINER
+	reagent_flags = NONE //MONKESTATION EDIT
 	var/gulp_size = 5 //This is now officially broken ... need to think of a nice way to fix it.
 	possible_transfer_amounts = list(5,10,15,20,25,30,50)
 	volume = 50
@@ -21,6 +21,7 @@
 	var/can_burst = FALSE
 	var/canopened = FALSE
 	var/burst_chance = 0
+	spillable = FALSE
 
 /obj/item/reagent_containers/food/drinks/on_reagent_change(changetype)
 	. = ..()
@@ -101,7 +102,7 @@
 
 	else if(target.is_drainable()) //A dispenser. Transfer FROM it TO us.
 		if (!is_refillable())
-			to_chat(user, "<span class='warning'>[src]'s tab isn't open!</span>")
+			to_chat(user, "<span class='warning'>[src] isn't open!</span>") //MONKESTATION EDIT
 			return
 
 		if(!target.reagents.total_volume)
@@ -125,7 +126,13 @@
 /obj/item/reagent_containers/food/drinks/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
 	if(!.) //if the bottle wasn't caught
-		smash(hit_atom, throwingdatum?.thrower, TRUE)
+		if(isGlass)
+			smash(hit_atom, throwingdatum?.thrower, TRUE)
+		else
+			if(times_shaken < 5)
+				times_shaken++
+			else
+				handle_bursting()
 
 /obj/item/reagent_containers/food/drinks/proc/smash(atom/target, mob/thrower, ranged = FALSE)
 	if(!isGlass)
@@ -467,8 +474,8 @@
 	name = "soda can"
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
-	reagent_flags = NONE
-	spillable = FALSE
+	//reagent_flags = NONE MONKESTATION EDIT
+	//spillable = FALSE MONKESTAION EDIT
 	isGlass = FALSE
 	custom_price = 10
 

--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -11,6 +11,7 @@
 	max_integrity = 20
 	spillable = TRUE
 	resistance_flags = ACID_PROOF
+	reagent_flags = OPENCONTAINER //MONKESTATION ADDITION
 	obj_flags = UNIQUE_RENAME
 	drop_sound = 'sound/items/handling/drinkglass_drop.ogg'
 	pickup_sound =  'sound/items/handling/drinkglass_pickup.ogg'

--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -12,6 +12,7 @@
 	spillable = TRUE
 	resistance_flags = ACID_PROOF
 	reagent_flags = OPENCONTAINER //MONKESTATION ADDITION
+	isShakeable = FALSE //MONKESTATION ADDITION
 	obj_flags = UNIQUE_RENAME
 	drop_sound = 'sound/items/handling/drinkglass_drop.ogg'
 	pickup_sound =  'sound/items/handling/drinkglass_pickup.ogg'

--- a/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
@@ -46,7 +46,7 @@
 		can_shake = FALSE
 		addtimer(CALLBACK(src, .proc/reset_shakable), 1 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 		to_chat(H, "<span class='notice'>You start shaking up [src].</span>")
-		if(do_after(H, 1 SECONDS, target = H) &&  && isShakeable)
+		if(do_after(H, 1 SECONDS, target = H) && isShakeable)
 			visible_message("<span class='warning'>[user] shakes up [src]!</span>")
 			if(times_shaken == 0)
 				times_shaken++

--- a/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
@@ -34,7 +34,7 @@
 /obj/item/reagent_containers/food/drinks/AltClick(mob/user)
 	var/mob/living/carbon/human/H
 	H = user
-	if(canopened && !istype(src, /obj/item/reagent_containers/food/drinks/drinkingglass))
+	if(canopened && isShakeable))
 		to_chat(H, "<span class='warning'>You carefully reseal the [src].")
 		canopened = FALSE
 		spillable = FALSE

--- a/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
@@ -46,7 +46,7 @@
 		can_shake = FALSE
 		addtimer(CALLBACK(src, .proc/reset_shakable), 1 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 		to_chat(H, "<span class='notice'>You start shaking up [src].</span>")
-		if(do_after(H, 1 SECONDS, target = H))
+		if(do_after(H, 1 SECONDS, target = H) &&  && isShakeable)
 			visible_message("<span class='warning'>[user] shakes up [src]!</span>")
 			if(times_shaken == 0)
 				times_shaken++

--- a/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
@@ -32,9 +32,11 @@
 
 
 /obj/item/reagent_containers/food/drinks/AltClick(mob/user)
+	if(!isShakeable)
+	return
 	var/mob/living/carbon/human/H
 	H = user
-	if(canopened && isShakeable)
+	if(canopened)
 		to_chat(H, "<span class='warning'>You carefully reseal the [src].")
 		canopened = FALSE
 		spillable = FALSE
@@ -46,7 +48,7 @@
 		can_shake = FALSE
 		addtimer(CALLBACK(src, .proc/reset_shakable), 1 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 		to_chat(H, "<span class='notice'>You start shaking up [src].</span>")
-		if(do_after(H, 1 SECONDS, target = H) && isShakeable)
+		if(do_after(H, 1 SECONDS, target = H))
 			visible_message("<span class='warning'>[user] shakes up [src]!</span>")
 			if(times_shaken == 0)
 				times_shaken++

--- a/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
@@ -1,0 +1,81 @@
+/obj/item/reagent_containers/food/drinks/attack_self(mob/user)
+	if(!is_drainable())
+		open_drink(user)
+	return ..()
+
+/obj/item/reagent_containers/food/drinks/proc/open_drink(mob/user, burstopen = FALSE)
+	ENABLE_BITFIELD(reagents.flags, OPENCONTAINER)
+	playsound(src, "can_open", 50, 1)
+	spillable = TRUE
+	canopened = TRUE
+	if(!burstopen)
+		to_chat(user, "You open \the [src] with an audible pop.") //Ahhhhhhhh
+	else
+		visible_message("<span class='warning'>[src] bursts open!</span>")
+
+	if(times_shaken < 5)
+		visible_message("<span class='warning'>[src] fizzes violently!</span>")
+	else
+		visible_message("<span class='boldwarning'>[src] erupts into foam!</span>")
+		if(reagents.total_volume)
+			var/datum/effect_system/foam_spread/sodafizz = new
+			sodafizz.set_up(1, get_turf(src), reagents)
+			sodafizz.start()
+
+	for(var/mob/living/carbon/C in range(1, get_turf(src)))
+		to_chat(C, "<span class='warning'>You are splattered with [name]!</span>")
+		reagents.reaction(C, TOUCH)
+
+	reagents.remove_any(times_shaken / 5 * reagents.total_volume)
+
+
+/obj/item/reagent_containers/food/drinks/AltClick(mob/user)
+	var/mob/living/carbon/human/H
+	H = user
+	if(canopened)
+		to_chat(H, "<span class='warning'>You can't shake up an already opened drink!")
+		return ..()
+	else
+		can_shake = FALSE
+		addtimer(CALLBACK(src, .proc/reset_shakable), 1 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+		to_chat(H, "<span class='notice'>You start shaking up [src].</span>")
+		if(do_after(H, 1 SECONDS, target = H))
+			visible_message("<span class='warning'>[user] shakes up [src]!</span>")
+			if(times_shaken == 0)
+				times_shaken++
+				addtimer(CALLBACK(src, .proc/reset_shaken), 1 MINUTES, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_NO_HASH_WAIT)
+			else if(times_shaken < 5)
+				times_shaken++
+				addtimer(CALLBACK(src, .proc/reset_shaken), (70 - (times_shaken * 10)) SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_NO_HASH_WAIT)
+			else
+				addtimer(CALLBACK(src, .proc/reset_shaken), 20 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_NO_HASH_WAIT)
+				handle_bursting(user)
+
+/obj/item/reagent_containers/food/drinks/proc/reset_shaken()
+	times_shaken--
+	if(can_burst)
+		can_burst = FALSE
+		burst_chance = 0
+	if(times_shaken)
+		addtimer(CALLBACK(src, .proc/reset_shaken), (70 - (times_shaken * 10)) SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_NO_HASH_WAIT)
+
+/obj/item/reagent_containers/food/drinks/proc/reset_shakable()
+	can_shake = TRUE
+
+/obj/item/reagent_containers/food/drinks/proc/handle_bursting(mob/user)
+	if(times_shaken != 5 || canopened)
+		return
+
+	if(!can_burst)
+		can_burst = TRUE
+		burst_chance = 5
+		return
+
+	if(burst_chance < 50)
+		burst_chance += 5
+
+	if(prob((burst_chance)))
+		if(user)
+			open_drink(user, burstopen = TRUE)
+		else
+			open_drink(burstopen = TRUE)

--- a/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
@@ -33,7 +33,9 @@
 	var/mob/living/carbon/human/H
 	H = user
 	if(canopened)
-		to_chat(H, "<span class='warning'>You can't shake up an already opened drink!")
+		to_chat(H, "<span class='warning'>You carefully reseal the [src].")
+		canopened = FALSE
+		DISABLE_BITFIELD(reagents.flags, OPENCONTAINER)
 		return ..()
 	else
 		can_shake = FALSE
@@ -79,3 +81,11 @@
 			open_drink(user, burstopen = TRUE)
 		else
 			open_drink(burstopen = TRUE)
+
+/obj/item/reagent_containers/food/drinks/examine(mob/user)
+	. = ..()
+	if(canopened)
+		. += "<span class='notice'>It has been opened.</span>"
+		. += "<span class='info'>Alt-click to reseal it.</span>"
+	else
+		. += "<span class='info'>Alt-click to shake it up!</span>"

--- a/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
@@ -33,7 +33,7 @@
 
 /obj/item/reagent_containers/food/drinks/AltClick(mob/user)
 	if(!isShakeable)
-	return
+		return
 	var/mob/living/carbon/human/H
 	H = user
 	if(canopened)

--- a/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
@@ -39,6 +39,7 @@
 		canopened = FALSE
 		spillable = FALSE
 		possible_transfer_amounts = list()
+		times_shaken = 0
 		DISABLE_BITFIELD(reagents.flags, OPENCONTAINER)
 		return ..()
 	else

--- a/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
@@ -34,7 +34,7 @@
 /obj/item/reagent_containers/food/drinks/AltClick(mob/user)
 	var/mob/living/carbon/human/H
 	H = user
-	if(canopened)
+	if(canopened && !istype(src, /obj/item/reagent_containers/food/drinks/drinkingglass))
 		to_chat(H, "<span class='warning'>You carefully reseal the [src].")
 		canopened = FALSE
 		spillable = FALSE
@@ -94,3 +94,5 @@
 		. += "<span class='info'>Alt-click to reseal it.</span>"
 	else
 		. += "<span class='info'>Alt-click to shake it up!</span>"
+	if(times_shaken > 0)
+		. += "<span class='warning'>This container looks under pressure.</span>"

--- a/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
@@ -1,6 +1,7 @@
 /obj/item/reagent_containers/food/drinks/attack_self(mob/user)
 	if(!is_drainable())
 		open_drink(user)
+		return
 	return ..()
 
 /obj/item/reagent_containers/food/drinks/proc/open_drink(mob/user, burstopen = FALSE)
@@ -8,6 +9,7 @@
 	playsound(src, "can_open", 50, 1)
 	spillable = TRUE
 	canopened = TRUE
+	possible_transfer_amounts = list(5,10,15,20,25,30,50)
 	if(!burstopen)
 		to_chat(user, "You open \the [src] with an audible pop.") //Ahhhhhhhh
 	else
@@ -35,6 +37,8 @@
 	if(canopened)
 		to_chat(H, "<span class='warning'>You carefully reseal the [src].")
 		canopened = FALSE
+		spillable = FALSE
+		possible_transfer_amounts = list()
 		DISABLE_BITFIELD(reagents.flags, OPENCONTAINER)
 		return ..()
 	else

--- a/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
@@ -23,10 +23,10 @@
 			var/datum/effect_system/foam_spread/sodafizz = new
 			sodafizz.set_up(1, get_turf(src), reagents)
 			sodafizz.start()
-
-	for(var/mob/living/carbon/C in range(1, get_turf(src)))
-		to_chat(C, "<span class='warning'>You are splattered with [name]!</span>")
-		reagents.reaction(C, TOUCH)
+	if(times_shaken >= 3 && times_shaken < 5)
+		for(var/mob/living/carbon/C in range(1, get_turf(src)))
+			to_chat(C, "<span class='warning'>You are splattered with [name]!</span>")
+			reagents.reaction(C, TOUCH)
 
 	reagents.remove_any(times_shaken / 5 * reagents.total_volume)
 

--- a/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
@@ -23,7 +23,7 @@
 			var/datum/effect_system/foam_spread/sodafizz = new
 			sodafizz.set_up(1, get_turf(src), reagents)
 			sodafizz.start()
-	if(times_shaken >= 3 && times_shaken < 5)
+	if(times_shaken >= 1 && times_shaken < 5)
 		for(var/mob/living/carbon/C in range(1, get_turf(src)))
 			to_chat(C, "<span class='warning'>You are splattered with [name]!</span>")
 			reagents.reaction(C, TOUCH)

--- a/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/monkestation/code/modules/food_and_drinks/drinks/drinks.dm
@@ -34,7 +34,7 @@
 /obj/item/reagent_containers/food/drinks/AltClick(mob/user)
 	var/mob/living/carbon/human/H
 	H = user
-	if(canopened && isShakeable))
+	if(canopened && isShakeable)
 		to_chat(H, "<span class='warning'>You carefully reseal the [src].")
 		canopened = FALSE
 		spillable = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Ports the ability to shake drinks from paradise if shaken to much they will foam their contents on opening, or if done to much will explode foaming instantly. 
Also makes all drinks need to be opened before you can drink from them.
Adds the ability to reseal drinks for gimmicks.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It allows for some funny bar gimmicks and RP with the ability to give someone a shaken drink. Or a impromptu foaming container if resealed 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Beer exploding on open

![FoundBeer](https://user-images.githubusercontent.com/82520990/166811321-e1dd1847-4f21-4bc2-8cfb-9aa2c0d74ad4.gif)

Me shaking a beer than opening it

![beershake](https://user-images.githubusercontent.com/82520990/166811597-b90d6878-2d9a-4081-ac73-242a40e6411f.gif)

Me overshaking a beer and it exploding

![overshke](https://user-images.githubusercontent.com/82520990/166811825-2c770b72-51d4-428a-9b71-2a4dd221822e.gif)




</details>

## Changelog

:cl:
add: resealing option for drinks
add: shaken option for drinks
add: opening to other drinks aside from soda
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
