### PR TITLE
Box Kitchen & Tribal Bar Fix

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -17135,9 +17135,6 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
 "aYJ" = (
-/obj/machinery/light_switch{
-	pixel_y = -25
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -42929,6 +42926,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"fHQ" = (
+/obj/machinery/light_switch{
+	pixel_y = -25
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "fJe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -96276,7 +96279,7 @@ aVz
 aVz
 aVz
 aVz
-aVz
+fHQ
 aJI
 bbz
 aYV

--- a/monkestation/_maps/RandomRooms/_Bars/Meta/tribal_bar.dmm
+++ b/monkestation/_maps/RandomRooms/_Bars/Meta/tribal_bar.dmm
@@ -96,9 +96,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/turf/open/floor/plasteel/stairs{
-	dir = 4
-	},
+/turf/open/floor/grass/fakebasalt,
 /area/template_noop)
 "p" = (
 /obj/machinery/firealarm{
@@ -281,9 +279,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel/stairs{
-	dir = 8
-	},
+/turf/open/floor/grass/fakebasalt,
 /area/template_noop)
 "Q" = (
 /obj/effect/landmark/event_spawn,
@@ -323,17 +319,9 @@
 	},
 /turf/open/floor/grass/fakebasalt,
 /area/template_noop)
-"X" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/stairs{
-	dir = 8
-	},
-/area/template_noop)
 "Y" = (
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/stairs{
-	dir = 4
-	},
+/turf/open/floor/grass/fakebasalt,
 /area/template_noop)
 "Z" = (
 /obj/machinery/airalarm{
@@ -437,7 +425,7 @@ A
 D
 E
 A
-X
+Y
 P
 A
 A


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Moves the light switch one tile in the Box Station kitchen.

Removes the broken stairs in the Meta Tribal Bar.


## Changelog

:cl:
fix: Metastation's Tribal Bar no longer has stairs to nowhere.
fix: Boxstation's Kitchen no longer has a light switch in a door.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
