### PR TITLE
New MetaStation Telecoms Hallway

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -80101,6 +80101,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"tuH" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 31
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "tuO" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=13.2-Tcommstore";
@@ -80731,6 +80740,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"vOH" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "vRq" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -81100,6 +81116,21 @@
 /obj/item/canvas/twentythree_twentythree,
 /turf/open/floor/plasteel,
 /area/storage/art)
+"xco" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 31
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "xdW" = (
 /obj/machinery/vending/wardrobe/jani_wardrobe,
 /turf/open/floor/plasteel,
@@ -135882,8 +135913,8 @@ bnA
 bpN
 bsa
 bjQ
-jOd
-vqv
+xco
+vOH
 btL
 bAW
 bxn
@@ -136910,8 +136941,8 @@ bnE
 bpR
 byM
 bjQ
-dTA
-vqv
+tuH
+vOH
 btL
 bvz
 bxr

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -34930,25 +34930,11 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "brS" = (
-/obj/machinery/door/window{
-	name = "MiniSat Walkway Access"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"brT" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "brU" = (
-/obj/structure/window/reinforced,
 /obj/structure/showcase/cyborg/old{
 	dir = 8;
 	pixel_x = 9;
@@ -34957,9 +34943,6 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 24
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -35859,31 +35842,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "btN" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Telecomms Control Room";
-	req_one_access_txt = "19; 61"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
+/turf/closed/wall/r_wall,
+/area/ai_monitored/turret_protected/aisat_interior)
 "btO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -75873,6 +75836,12 @@
 "dQI" = (
 /turf/open/floor/plasteel/white,
 /area/science/shuttledock)
+"dTA" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "dUj" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -76133,6 +76102,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
+"eMG" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "eXl" = (
 /obj/machinery/power/apc/auto_name/south{
 	pixel_y = -24
@@ -76430,6 +76405,13 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
+"fYv" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "fZP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -76450,6 +76432,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
+"ghn" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "ghU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -77194,6 +77185,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"iSa" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "iSW" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -77242,6 +77240,18 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"jaF" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "jdU" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
@@ -77468,6 +77478,15 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/maintenance/department/science)
+"jKm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "jKK" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
@@ -77504,6 +77523,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"jOd" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "jPO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -78267,6 +78298,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mzu" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mzI" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "mEV" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -78766,6 +78814,20 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"oiI" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Foyer";
+	req_one_access_txt = "32;19"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "ojg" = (
 /turf/closed/wall,
 /area/science/misc_lab/range)
@@ -78797,6 +78859,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"okf" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "okx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -79057,6 +79127,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/auxiliary)
+"pgv" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "pgA" = (
 /obj/structure/sign/departments/minsky/security/security{
 	pixel_y = 32
@@ -79216,6 +79298,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
+"pXb" = (
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"pXu" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "pYC" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -79352,6 +79444,18 @@
 /mob/living/simple_animal/bot/cleanbot/medbay,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"qxQ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "qBh" = (
 /obj/structure/table,
 /obj/item/paicard,
@@ -79396,6 +79500,10 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer1,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"qGz" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
 "qLf" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album,
@@ -79414,6 +79522,17 @@
 "qOT" = (
 /turf/open/space/basic,
 /area/science/shuttledock)
+"qUl" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "qVR" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -79922,6 +80041,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"tbz" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "tjt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -80140,6 +80268,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"uet" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "ueO" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -80237,6 +80374,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"usU" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "utH" = (
 /obj/machinery/telecomms/processor/preset_exploration,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -80257,6 +80403,21 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/break_room)
+"uwQ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	pixel_y = 28
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "uAJ" = (
 /obj/machinery/status_display/evac{
 	pixel_x = -32
@@ -80359,6 +80520,35 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
+"uUS" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Telecomms Control Room";
+	req_one_access_txt = "19; 61"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "vag" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/tile/blue{
@@ -80444,6 +80634,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"vqv" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "vzO" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -80683,6 +80879,26 @@
 /obj/machinery/ecto_sniffer,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"wrP" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Foyer";
+	req_one_access_txt = "32;19"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "wtq" = (
 /turf/closed/wall,
 /area/maintenance/aft/secondary)
@@ -80700,6 +80916,11 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"wxN" = (
+/obj/structure/grille,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
 "wxT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -133604,6 +133825,9 @@ bgg
 bns
 bpF
 brS
+mzu
+pgv
+usU
 bjO
 bjO
 bjO
@@ -133626,9 +133850,6 @@ anT
 anT
 anT
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -133860,8 +134081,11 @@ aOY
 aSG
 bnt
 bpG
-brT
-aOU
+pXb
+pXb
+jKm
+pXu
+qUl
 aOY
 bcQ
 bzl
@@ -133883,9 +134107,6 @@ aNw
 aTQ
 aaa
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -134118,7 +134339,10 @@ vUC
 bnu
 bpH
 brU
-aOV
+pXb
+jKm
+pXu
+uet
 aaa
 aMq
 bzm
@@ -134140,9 +134364,6 @@ bjO
 bUK
 bBb
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -134376,6 +134597,9 @@ aRy
 bpI
 aRy
 aRy
+wrP
+oiI
+aRy
 aaa
 aaa
 aTT
@@ -134397,9 +134621,6 @@ bcQ
 bzl
 bgn
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -134632,6 +134853,9 @@ blB
 bnw
 bpJ
 brW
+bjP
+jOd
+vqv
 aRy
 bvt
 aaa
@@ -134654,9 +134878,6 @@ aMq
 bzl
 bgn
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -134889,6 +135110,9 @@ blC
 bnx
 bpK
 bsf
+bjP
+jOd
+vqv
 aRy
 aRy
 aRy
@@ -134911,9 +135135,6 @@ aMq
 bzl
 bgn
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -135146,6 +135367,9 @@ blD
 bny
 bpL
 brY
+bjP
+jOd
+vqv
 btL
 btL
 btL
@@ -135170,9 +135394,6 @@ bBb
 anT
 anT
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -135403,6 +135624,9 @@ bjQ
 bjQ
 bpM
 bjQ
+bjQ
+jOd
+vqv
 btL
 bvu
 bGh
@@ -135427,9 +135651,6 @@ bAT
 aNw
 aaa
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -135660,6 +135881,9 @@ brX
 bnA
 bpN
 bsa
+bjQ
+jOd
+vqv
 btL
 bAW
 bxn
@@ -135684,9 +135908,6 @@ bpn
 cpO
 bgn
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -135917,6 +136138,9 @@ blF
 bnB
 bpO
 bsb
+bjQ
+jaF
+qxQ
 btL
 bvw
 bxo
@@ -135941,9 +136165,6 @@ bsR
 bpr
 bgn
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -136175,6 +136396,9 @@ bnC
 bpP
 bsc
 btN
+uwQ
+mzI
+uUS
 bAX
 bxp
 bzq
@@ -136198,9 +136422,6 @@ ckT
 cmX
 bgn
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -136431,6 +136652,9 @@ blH
 bnD
 bpQ
 bsd
+bjQ
+tbz
+ghn
 btL
 bvy
 bxq
@@ -136455,9 +136679,6 @@ cmK
 bpr
 bgn
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -136688,6 +136909,9 @@ bse
 bnE
 bpR
 byM
+bjQ
+dTA
+vqv
 btL
 bvz
 bxr
@@ -136712,9 +136936,6 @@ bpq
 bzv
 bgn
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -136945,6 +137166,9 @@ bjQ
 bjQ
 bpS
 bjQ
+bjQ
+dTA
+vqv
 btL
 bvA
 bxs
@@ -136969,9 +137193,6 @@ aVk
 aOY
 aaa
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -137202,6 +137423,9 @@ blJ
 bnF
 bpT
 byO
+bjT
+dTA
+vqv
 btL
 btL
 btL
@@ -137226,9 +137450,6 @@ bBb
 anT
 anT
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -137459,6 +137680,9 @@ blK
 bnG
 bpU
 bsg
+bjT
+dTA
+vqv
 aRy
 aRy
 aRy
@@ -137481,9 +137705,6 @@ aMq
 bez
 bgn
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -137716,6 +137937,9 @@ blL
 bnH
 bpV
 bsh
+bjT
+dTA
+vqv
 aRy
 bvt
 aaa
@@ -137738,9 +137962,6 @@ aMq
 bez
 bgn
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -137973,6 +138194,9 @@ blM
 bnI
 bpW
 bsi
+bjT
+dTA
+vqv
 aRy
 aaa
 aaa
@@ -137995,9 +138219,6 @@ bly
 bez
 bgn
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -138231,6 +138452,9 @@ aRy
 bpX
 aRy
 aRy
+fYv
+iSa
+aRy
 aaa
 aMq
 bzu
@@ -138252,9 +138476,6 @@ bMt
 bUM
 bBb
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -138489,6 +138710,9 @@ bpY
 bgn
 aaa
 aaa
+aaa
+vLD
+aaa
 aMq
 bez
 aVk
@@ -138509,9 +138733,6 @@ aOY
 aNC
 aaa
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -138746,6 +138967,9 @@ bpZ
 bsj
 aNw
 aNw
+aNw
+okf
+aNw
 bly
 bez
 bgn
@@ -138766,9 +138990,6 @@ anT
 anT
 anT
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -139004,12 +139225,12 @@ bjO
 bjO
 bjO
 bjO
+bjO
+bjO
+bjO
 aUh
 bBb
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -139262,11 +139483,11 @@ aOY
 aOY
 aOY
 aNC
+aOY
+aOY
+aNC
 aaa
 anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -139515,15 +139736,15 @@ anT
 anT
 anT
 anT
+qGz
+qGz
+wxN
+eMG
 anT
 anT
 anT
 anT
 anT
-anT
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -78410,6 +78410,12 @@
 /obj/item/blood_filter,
 /turf/open/floor/plasteel/white/side,
 /area/medical/surgery)
+"mVe" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "mWS" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -78987,6 +78993,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"oEw" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "oGF" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -80050,6 +80071,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"thf" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "tjt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -80628,6 +80658,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"vnw" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "vox" = (
 /turf/open/floor/engine/vacuum,
 /area/maintenance/starboard)
@@ -134370,7 +134407,7 @@ vUC
 bnu
 bpH
 brU
-pXb
+mVe
 jKm
 pXu
 uet
@@ -135656,8 +135693,8 @@ bjQ
 bpM
 bjQ
 bjQ
-jOd
-vqv
+oEw
+vnw
 btL
 bvu
 bGh
@@ -137198,8 +137235,8 @@ bjQ
 bpS
 bjQ
 bjQ
-dTA
-vqv
+thf
+vnw
 btL
 bvA
 bxs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Adds a new hallway route to Telecom's at the AI Sat, so you don't have to get shot by AI turrets to fix communications. 

## Why It's Good For The Game
Being able to fix the Telecom's as CE good, and even better for lowpop.
close: https://github.com/Monkestation/MonkeStation/issues/255

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots</summary>

![image](https://user-images.githubusercontent.com/101475356/167274392-f0bbba48-127f-42c2-a146-6b48b91f40e1.png)

</details>

## Changelog

:cl:
fix: There is now a hallway around the turrets at the AI sat that leads to the  tcomms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
