### PR TITLE
Backup Exploration Generation

### DIFF
--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/ruin_generator.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/ruin_generator/ruin_generator.dm
@@ -24,6 +24,12 @@
 	catch(var/exception/e)
 		message_admins("Space ruin failed to generate!")
 		stack_trace("Space ruin failed to generate! [e] on [e.file]:[e.line]")
+		//MonkeStation Edit: Adds a backup objective generation method.
+		if(linked_objective)
+			var/turf/backup_objective_spawn = locate(rand(center_x),rand(center_y), center_z)
+			linked_objective.generate_objective_stuff(backup_objective_spawn)
+			message_admins("Created backup objective successfully.")
+		//MonkeStation Edit End
 	space_level.generating = FALSE
 
 /proc/_generate_space_ruin(center_x, center_y, center_z, border_x, border_y, datum/orbital_objective/linked_objective, forced_decoration, datum/ruin_event/ruin_event)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Adds a backup method to generate the explorer objective, even if ruin generation entirely fails half way through.
Note: This will generate VIPs in space potentially. But it will prevent missions from hanging and becoming admin-only resets.

## Why It's Good For The Game

I am tired of having to open the Orbits subsystem to reset missions because of a random piece of debris with a runtime error causing the ENTIRE generation proc to fail.

## Changelog

:cl:
fix: Exploration objectives should spawn even on a failed map load.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
