### PR TITLE
Removes Flip/Spin Stuns

### DIFF
--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -36,30 +36,6 @@
 	mob_type_allowed_typecache = list(/mob/living, /mob/dead/observer)
 	mob_type_ignore_stat_typecache = list(/mob/dead/observer)
 
-//MonkeStation Edit: /tg/ emote hotkeys
-/datum/emote/flip/check_cooldown(mob/user, intentional)
-	. = ..()
-	if(.)
-		return
-	if(!can_run_emote(user, intentional=intentional))
-		return
-	if(isliving(user))
-		var/mob/living/flippy_mcgee = user
-		if(prob(20))
-			flippy_mcgee.Knockdown(1 SECONDS)
-			flippy_mcgee.visible_message(
-				"<span class='notice'>[flippy_mcgee] attempts to do a flip and falls over, what a doofus!</span>",
-				"<span class='notice'>You attempt to do a flip while still off balance from the last flip and fall down!</span>"
-			)
-			if(prob(50))
-				flippy_mcgee.adjustBruteLoss(1)
-		else
-			flippy_mcgee.visible_message(
-				"<span class='notice'>[flippy_mcgee] stumbles a bit after their flip.</span>",
-				"<span class='notice'>You stumble a bit from still being off balance from your last flip.</span>"
-			)
-//MonkeStation Edit End
-
 /datum/emote/flip/run_emote(mob/user, params , type_override, intentional)
 	. = ..()
 	if(.)
@@ -74,7 +50,6 @@
 					if(worn_headwear.contents.len)
 						worn_headwear.throw_hats(rand(2,3), get_turf(hat_loser), hat_loser)
 			//MonkeStation Edit End
-			L.confused += 2
 
 /datum/emote/spin
 	key = "spin"
@@ -97,7 +72,6 @@
 					if(worn_headwear.contents.len)
 						worn_headwear.throw_hats(rand(1,2), get_turf(hat_loser), hat_loser)
 			//MonkeStation Edit End
-			L.confused += 2
 		if(iscyborg(user) && user.has_buckled_mobs())
 			var/mob/living/silicon/robot/R = user
 			var/datum/component/riding/riding_datum = R.GetComponent(/datum/component/riding)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Flipping no longer applies a chance to trip, or dizziness.

Spinning no longer applies dizziness.

## Why It's Good For The Game

We already have emote cooldowns, so I see no reason to make flipping and spinning so dangerous.
Have some fun with it. BUT I SWEAR IF YOU NERDS POWERGAME EMOTES, I AM QDEL'ING YOUR LEGS.

## Changelog

:cl:
balance: Spin/flip no longer applies negative effects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
