### PR TITLE
Contractor Jail Improvements

### DIFF
--- a/code/modules/antagonists/abductor/abductee/abductee_objectives.dm
+++ b/code/modules/antagonists/abductor/abductee/abductee_objectives.dm
@@ -10,7 +10,7 @@
 	explanation_text = "Steal all"
 
 /datum/objective/abductee/steal/New()
-	var/target = pick(list("pets","lights","monkeys","fruits","shoes","bars of soap", "weapons", "computers", "organs"))
+	var/target = pick(list("pets","lights","monkeys","fruits","shoes","bars of soap", "weapons", "computers", "organs", "tiles", "chemicals", "[pick(get_all_jobs)]s"))
 	explanation_text+=" [target]."
 
 /datum/objective/abductee/paint
@@ -43,7 +43,11 @@
 		explanation_text += " someone."
 
 /datum/objective/abductee/calling/New()
-	var/mob/dead/D = pick(GLOB.dead_mob_list)
+	var/mob/dead/D
+	if(prob(50))
+		D = pick(GLOB.player_list)
+	else
+		D = pick(GLOB.dead_mob_list)
 	if(D)
 		explanation_text = "You know that [D] has perished. Hold a seance to call [D.p_them()] from the spirit realm."
 

--- a/code/modules/antagonists/abductor/abductee/abductee_objectives.dm
+++ b/code/modules/antagonists/abductor/abductee/abductee_objectives.dm
@@ -10,7 +10,7 @@
 	explanation_text = "Steal all"
 
 /datum/objective/abductee/steal/New()
-	var/target = pick(list("pets","lights","monkeys","fruits","shoes","bars of soap", "weapons", "computers", "organs", "tiles", "chemicals", "[pick(get_all_jobs)]s"))
+	var/target = pick(list("pets","lights","monkeys","fruits","shoes","bars of soap", "weapons", "computers", "organs", "tiles", "chemicals", "[pick(get_all_jobs())]s"))
 	explanation_text+=" [target]."
 
 /datum/objective/abductee/paint

--- a/code/modules/antagonists/traitor/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/syndicate_contract.dm
@@ -189,11 +189,13 @@
 		M.flash_act()
 		M.Unconscious(10 SECONDS)
 		to_chat(M, "<span class='reallybig hypnophrase'>A million voices echo in your head... <i>\"Your mind held many valuable secrets - \
-					we thank you for providing them. Your value is expended, and you will be ransomed back to your station. We always get paid, \
+					the Elders thank you for providing them. Your value is expended, and you will be ransomed back to your station, mostly intact. We always get paid, \
 					so it's only a matter of time before we ship you back...\"</i></span>")
 		M.blur_eyes(10)
 		M.Dizzy(10)
 		M.confused += 5
+		if(ishuman(M) && M.mind != null && M.ckey != null)
+			M.mind.add_antag_datum(/datum/antagonist/abductee) //Monkestation Edit
 
 // We're returning the victim
 /datum/syndicate_contract/proc/returnVictim(var/mob/living/M)

--- a/code/modules/antagonists/traitor/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/syndicate_contract.dm
@@ -159,38 +159,41 @@
 
 // They're off to holding - handle the return timer and give some text about what's going on.
 /datum/syndicate_contract/proc/handleVictimExperience(var/mob/living/M)
-	// Ship 'em back - dead or alive, 4 minutes wait.
+	// Ship 'em back - dead or alive, 2 minute wait.
 	// Even if they weren't the target, we're still treating them the same.
-	addtimer(CALLBACK(src, .proc/returnVictim, M), (60 * 10) * 4)
+	addtimer(CALLBACK(src, .proc/returnVictim, M), 2 MINUTES) //MonkeStation Edit: Faster return
 
 	if (M.stat != DEAD)
-		// Heal them up - gets them out of crit/soft crit. If omnizine is removed in the future, this needs to be replaced with a
-		// method of healing them, consequence free, to a reasonable amount of health.
-		M.reagents.add_reagent(/datum/reagent/medicine/omnizine, 20)
+		// Heal them up - gets them out of crit/soft crit.
+		M.reagents.add_reagent(/datum/reagent/medicine/omnizine, 20) 		//Heal All
+		//MonkeStation Edit: Better Healing
+		M.reagents.add_reagent(/datum/reagent/medicine/tricordrazine, 20) 	//Heal All
+		M.reagents.add_reagent(/datum/reagent/medicine/salbutamol, 20) 		//Heal Oxy
+		M.reagents.add_reagent(/datum/reagent/iron, 20) 					//Heal Blood Loss
 
 		M.flash_act()
-		M.confused += 10
+		M.confused += 5
 		M.blur_eyes(5)
 		to_chat(M, "<span class='warning'>You feel strange...</span>")
-		sleep(60)
+		sleep(6 SECONDS)
 		to_chat(M, "<span class='warning'>That pod did something to you...</span>")
-		M.Dizzy(35)
-		sleep(65)
+		M.Dizzy(10)
+		sleep(6.5 SECONDS)
 		to_chat(M, "<span class='warning'>Your head pounds... It feels like it's going to burst out your skull!</span>")
 		M.flash_act()
-		M.confused += 20
+		M.confused += 5
 		M.blur_eyes(3)
-		sleep(30)
+		sleep(3 SECONDS)
 		to_chat(M, "<span class='warning'>Your head pounds...</span>")
-		sleep(100)
+		sleep(10 SECONDS)
 		M.flash_act()
-		M.Unconscious(200)
+		M.Unconscious(10 SECONDS)
 		to_chat(M, "<span class='reallybig hypnophrase'>A million voices echo in your head... <i>\"Your mind held many valuable secrets - \
 					we thank you for providing them. Your value is expended, and you will be ransomed back to your station. We always get paid, \
 					so it's only a matter of time before we ship you back...\"</i></span>")
 		M.blur_eyes(10)
-		M.Dizzy(15)
-		M.confused += 20
+		M.Dizzy(10)
+		M.confused += 5
 
 // We're returning the victim
 /datum/syndicate_contract/proc/returnVictim(var/mob/living/M)
@@ -228,8 +231,8 @@
 
 		M.flash_act()
 		M.blur_eyes(30)
-		M.Dizzy(35)
-		M.confused += 20
+		M.Dizzy(10)
+		M.confused += 10
 
 		new /obj/effect/pod_landingzone(possible_drop_loc[pod_rand_loc], return_pod)
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Reduces the amount of dizziness the contractor victim gets from 85 to 30.

Reduces the amount of confusion the contractor victim gets from 50 to 20.

Reduces the time spent in the timeshare from 4 minutes to 2 minutes.

Gives the contractor victim more healing chems.
Now adds 20u of: Omnizine, Tricordrazine, Salbutamol and Iron. (Originally just Omnizine)

Properly uses SECONDS defines in that section of the code.


## Why It's Good For The Game

The contractor jail isn't fun, lasts too long and often leaves the victim dead.
Zero interaction with any other player isn't fun, so reducing the time will keep it from sucking the life out of someone's round.

**GET OUT OF MY TIMESHARE**
closes #186 

## Changelog

:cl:
balance: Reduces the time spent in the contractor timeshare from 4 minutes to 2 minutes.
balance: Reduces the amount of dizziness the contractor victim gets from 85 to 30.
balance: Reduces the amount of confusion the contractor victim gets from 50 to 20.
add: Contractor victims now get an abductee objective
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
