### PR TITLE
Ports Shuttle Ceilings From /tg/

### DIFF
--- a/code/game/turfs/open/floor/reinf_floor.dm
+++ b/code/game/turfs/open/floor/reinf_floor.dm
@@ -36,11 +36,6 @@
 	name = "shuttle ceiling plating"
 	desc = "Sturdy exterior hull plating, keeping the shuttle below safe."
 	initial_gas_mix = AIRLESS_ATMOS
-	var/old_turf_type
-
-/turf/open/floor/engine/ceiling/AfterChange(flags, oldType)
-	. = ..()
-	old_turf_type = oldType
 // MONKE EDIT END //
 
 /turf/open/floor/engine/break_tile()

--- a/code/game/turfs/open/floor/reinf_floor.dm
+++ b/code/game/turfs/open/floor/reinf_floor.dm
@@ -31,7 +31,7 @@
 	icon_state = "engine_light"
 
 // MONKE EDIT ADDITION //
-/// RCD-immune plating generated only by shuttle code for shuttle ceilings on multi-z maps, should not be mapped in or creatable in any other way
+/// plating generated only by shuttle code for shuttle ceilings on multi-z maps, should not be mapped in or creatable in any other way
 /turf/open/floor/engine/ceiling
 	name = "shuttle ceiling plating"
 	desc = "Sturdy exterior hull plating, keeping the shuttle below safe."

--- a/code/game/turfs/open/floor/reinf_floor.dm
+++ b/code/game/turfs/open/floor/reinf_floor.dm
@@ -30,6 +30,19 @@
 /turf/open/floor/engine/airless/light
 	icon_state = "engine_light"
 
+// MONKE EDIT ADDITION //
+/// RCD-immune plating generated only by shuttle code for shuttle ceilings on multi-z maps, should not be mapped in or creatable in any other way
+/turf/open/floor/engine/ceiling
+	name = "shuttle ceiling plating"
+	desc = "Sturdy exterior hull plating, keeping the shuttle below safe."
+	initial_gas_mix = AIRLESS_ATMOS
+	var/old_turf_type
+
+/turf/open/floor/engine/ceiling/AfterChange(flags, oldType)
+	. = ..()
+	old_turf_type = oldType
+// MONKE EDIT END //
+
 /turf/open/floor/engine/break_tile()
 	return //unbreakable
 

--- a/code/modules/shuttle/docking.dm
+++ b/code/modules/shuttle/docking.dm
@@ -180,7 +180,7 @@
 		if(new_ceiling)
 			// generate ceiling
 			if(istype(new_ceiling, /turf/open/openspace))
-				new_ceiling.ChangeTurf(/turf/open/floor/engine/ceiling, list(typesof(/turf/open/openspace)))
+				new_ceiling.ChangeTurf(/turf/open/floor/engine/ceiling, list(/turf/open/openspace))
 		var/turf/old_ceiling = get_step_multiz(old_turf, UP)
 		if(old_ceiling && istype(old_ceiling, /turf/open/floor/engine/ceiling)) // check if a ceiling was generated previously
 			// remove old ceiling

--- a/code/modules/shuttle/docking.dm
+++ b/code/modules/shuttle/docking.dm
@@ -179,7 +179,7 @@
 		var/turf/new_ceiling = get_step_multiz(new_turf, UP) // check if a ceiling is needed
 		if(new_ceiling)
 			// generate ceiling
-			if(istype(new_ceiling, typesof(/turf/open/openspace)))
+			if(istype(new_ceiling, /turf/open/openspace))
 				new_ceiling.ChangeTurf(/turf/open/floor/engine/ceiling, list(typesof(/turf/open/openspace)))
 		var/turf/old_ceiling = get_step_multiz(old_turf, UP)
 		if(old_ceiling && istype(old_ceiling, /turf/open/floor/engine/ceiling)) // check if a ceiling was generated previously

--- a/code/modules/shuttle/docking.dm
+++ b/code/modules/shuttle/docking.dm
@@ -167,9 +167,26 @@
 		CHECK_TICK
 		if(!(old_turfs[old_turfs[i]] & MOVE_TURF))
 			continue
+		/* // MONKE REMOVAL //
 		var/turf/oldT = old_turfs[i]
 		var/turf/newT = new_turfs[i]
 		newT.afterShuttleMove(oldT, rotation)																//turfs
+		*/
+		// MONKE ADDITION BEGIN //
+		var/turf/old_turf = old_turfs[i]
+		var/turf/new_turf = new_turfs[i]
+		new_turf.afterShuttleMove(old_turf, rotation) //turfs
+		var/turf/new_ceiling = get_step_multiz(new_turf, UP) // check if a ceiling is needed
+		if(new_ceiling)
+			// generate ceiling
+			if(istype(new_ceiling, /turf/open/openspace))
+				new_ceiling.ChangeTurf(/turf/open/floor/engine/ceiling, list(typesof(/turf/open/openspace)))
+		var/turf/old_ceiling = get_step_multiz(old_turf, UP)
+		if(old_ceiling && istype(old_ceiling, /turf/open/floor/engine/ceiling)) // check if a ceiling was generated previously
+			// remove old ceiling
+			var/turf/open/floor/engine/ceiling/old_shuttle_ceiling = old_ceiling
+			old_shuttle_ceiling.ChangeTurf(old_shuttle_ceiling.old_turf_type)
+		// MONKE ADDITION END //
 
 	for(var/i in 1 to moved_atoms.len)
 		CHECK_TICK

--- a/code/modules/shuttle/docking.dm
+++ b/code/modules/shuttle/docking.dm
@@ -179,7 +179,7 @@
 		var/turf/new_ceiling = get_step_multiz(new_turf, UP) // check if a ceiling is needed
 		if(new_ceiling)
 			// generate ceiling
-			if(istype(new_ceiling, /turf/open/openspace))
+			if(istype(new_ceiling, typesof(/turf/open/openspace)))
 				new_ceiling.ChangeTurf(/turf/open/floor/engine/ceiling, list(typesof(/turf/open/openspace)))
 		var/turf/old_ceiling = get_step_multiz(old_turf, UP)
 		if(old_ceiling && istype(old_ceiling, /turf/open/floor/engine/ceiling)) // check if a ceiling was generated previously

--- a/code/modules/shuttle/docking.dm
+++ b/code/modules/shuttle/docking.dm
@@ -185,7 +185,7 @@
 		if(old_ceiling && istype(old_ceiling, /turf/open/floor/engine/ceiling)) // check if a ceiling was generated previously
 			// remove old ceiling
 			var/turf/open/floor/engine/ceiling/old_shuttle_ceiling = old_ceiling
-			old_shuttle_ceiling.ChangeTurf(old_shuttle_ceiling.old_turf_type)
+			old_shuttle_ceiling.ChangeTurf(/turf/baseturf_bottom)
 		// MONKE ADDITION END //
 
 	for(var/i in 1 to moved_atoms.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/64493, with some minor alterations. This is absolutely needed for #347.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Shuttles shouldn't vent all their air upon updating
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Testing Procedure</summary>

TL;DR, to make sure this PR works (or still works for your shuttles in the future), open up config/maps.txt and re-enable multi-z debug. Load up the game, change to that map, and park as **CLOSE** to the station as possible (As the rest isn't actually openspace for some dumb reason)

If even a part of your shuttle is close enough, the ceiling will generate and replace any openspace turfs it comes across. It will **not** replace regular space turfs, so please use openspace ONLY on the upper deck of your station.
![image](https://user-images.githubusercontent.com/50649185/167864098-fc45fd74-ae21-47b5-b914-477cd4d9f979.png)

</details>

## Changelog

:cl: RandomGamer123, Iamgoofball, IssacTheSharkWolf, unit0016
add: Shuttles now have ceilings if used on Multi-Z maps.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
