### PR TITLE
IPC Chest Health Increase

### DIFF
--- a/code/modules/surgery/bodyparts/species_parts/ipc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/ipc_bodyparts.dm
@@ -26,7 +26,7 @@
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 
 	body_damage_coeff = 1	//IPC Chest at default	//Monkestation Edit
-	max_damage = 200	//Monkestation Edit
+	max_damage = 250	//Monkestation Edit
 
 	light_brute_msg = "scratched"
 	medium_brute_msg = "dented"

--- a/code/modules/surgery/bodyparts/species_parts/ipc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/ipc_bodyparts.dm
@@ -25,8 +25,8 @@
 	should_draw_greyscale = FALSE
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 
-	body_damage_coeff = 1	//IPC Chest at default	//Monkestation Edit
-	max_damage = 250	//Monkestation Edit
+	body_damage_coeff = 1	//IPC Chest at default	///Monkestation Edit
+	max_damage = 250	//Default: 200 ///Monkestation Edit
 
 	light_brute_msg = "scratched"
 	medium_brute_msg = "dented"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Increases the max health for IPC chest from 200 to 250. This should make surviving dismemberment a bit easier and to account for the head having lower health. My previous change didn't account for the amount of max health I removed from head enough.

## Why It's Good For The Game
Removing IPC limbs are fun and makes them feel more robotic, so the mechanic is more about disabling an IPC through disabling their limbs or using energy weapons.

## Changelog

:cl:
balance: Added more health to IPC chest to account for their easy dismemberment
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
