### PR TITLE
Debtor Rework

### DIFF
--- a/_maps/RandomRooms/10x5/sk_rdm091_skidrow.dmm
+++ b/_maps/RandomRooms/10x5/sk_rdm091_skidrow.dmm
@@ -48,7 +48,6 @@
 /turf/open/floor/plating,
 /area/template_noop)
 "j" = (
-/obj/effect/landmark/start/randommaint/hobo,
 /obj/structure/bed/dogbed,
 /obj/item/bedsheet/random,
 /turf/open/floor/plating,

--- a/_maps/RandomRooms/3x3/sk_rdm092_hobohut.dmm
+++ b/_maps/RandomRooms/3x3/sk_rdm092_hobohut.dmm
@@ -50,7 +50,6 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/landmark/start/randommaint/hobo,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/template_noop)

--- a/beestation.dme
+++ b/beestation.dme
@@ -3608,6 +3608,7 @@
 #include "monkestation\code\game\objects\effects\spawners\roomspawner.dm"
 #include "monkestation\code\game\objects\items\anime.dm"
 #include "monkestation\code\game\objects\items\fluff_papers.dm"
+#include "monkestation\code\game\objects\items\granters.dm"
 #include "monkestation\code\game\objects\items\mail.dm"
 #include "monkestation\code\game\objects\items\plushes.dm"
 #include "monkestation\code\game\objects\items\prosthetic.dm"

--- a/code/datums/brain_damage/phobia.dm
+++ b/code/datums/brain_damage/phobia.dm
@@ -18,7 +18,6 @@
 	var/fear_state = PHOBIA_STATE_CALM
 	var/stress_check = 0
 	var/last_scare = 0
-	var/datum/martial_art/psychotic_brawling/psychotic_brawling //this is for fight-or-flight panic
 	var/list/trigger_words
 	//instead of cycling every atom, only cycle the relevant types
 	var/list/trigger_mobs
@@ -118,7 +117,6 @@
 				fear_state = PHOBIA_STATE_UNEASY
 				to_chat(owner, "<span class ='notice'>You're safe now... better be careful anyways.</span>")
 				owner.add_movespeed_modifier(MOVESPEED_ID_PHOBIA, TRUE, 100, override=TRUE, multiplicative_slowdown = 1)
-				psychotic_brawling.remove(owner)
 			if(fear_state <= PHOBIA_STATE_EDGY)
 				fear_state = PHOBIA_STATE_UNEASY
 				owner.add_movespeed_modifier(MOVESPEED_ID_PHOBIA, TRUE, 100, override=TRUE, multiplicative_slowdown = 1)
@@ -130,15 +128,13 @@
 				fear_state = PHOBIA_STATE_FIGHTORFLIGHT
 				to_chat(owner, "<span class ='notice'>It's gone for now... Better get out of here before it comes back.</span>")
 				owner.add_movespeed_modifier(MOVESPEED_ID_PHOBIA, TRUE, 100, override=TRUE, multiplicative_slowdown = -0.4)
-			if(fear_state <= PHOBIA_STATE_UNEASY) //ADRENALINE RUSH! You get psychotic brawling, a burst of speed, and some stun avoidance for awhile. If you fail to escape or destroy the threat during an adrenaline rush, you're fucked either way
+			if(fear_state <= PHOBIA_STATE_UNEASY) //ADRENALINE RUSH! You get a burst of speed, and some stun avoidance for awhile. If you fail to escape or destroy the threat during an adrenaline rush, you're fucked either way
 				fear_state = PHOBIA_STATE_FIGHTORFLIGHT
 				to_chat(owner, "<span class ='userdanger'>YOU HAVE TO GET OUT OF HERE! IT'S DANGEROUS!</span>")
 				owner.add_movespeed_modifier(MOVESPEED_ID_PHOBIA, TRUE, 100, override=TRUE, multiplicative_slowdown = -0.4)//while terrified, get a speed boost
 				owner.emote("scream")
 				if(prob(stress * 10))
 					fearscore = 27 //we don't get the adrenaline rush, and keel over like a baby immediately
-				psychotic_brawling = new(null)
-				psychotic_brawling.teach(owner, TRUE)
 				owner.adjustStaminaLoss(-75)
 				owner.SetStun(0)
 				owner.SetKnockdown(0)
@@ -158,7 +154,6 @@
 				owner.visible_message("<span class ='danger'>[owner] collapses into a fetal position and cowers in fear!</span>", "<span class ='userdanger'>I'm done for...</span>")
 				owner.Paralyze(80)
 				owner.Jitter(8)
-				psychotic_brawling.remove(owner)
 				stress++
 				if(prob(stress * 10))
 					fearscore = 36 //we immediately keel over and faint
@@ -166,7 +161,6 @@
 			if(fear_state <= PHOBIA_STATE_TERROR)
 				fear_state = PHOBIA_STATE_FAINT
 				owner.remove_movespeed_modifier(MOVESPEED_ID_PHOBIA, TRUE) //in the case that we get so scared by enough bullshit nearby we skip the last stage
-				psychotic_brawling.remove(owner)//ditto
 				owner.Sleeping(300)
 				owner.visible_message("<span class ='danger'>[owner] faints in fear!.</span>", "<span class ='userdanger'>It's too much! you faint!</span>")
 				if(prob(stress * 3))
@@ -253,8 +247,6 @@
 
 /datum/brain_trauma/mild/phobia/on_lose()
 	owner.remove_movespeed_modifier(MOVESPEED_ID_PHOBIA, TRUE)
-	if(psychotic_brawling)
-		QDEL_NULL(psychotic_brawling)
 	..()
 
 // Defined phobia types for badminry, not included in the RNG trauma pool to avoid diluting.

--- a/code/modules/jobs/job_types/gimmick.dm
+++ b/code/modules/jobs/job_types/gimmick.dm
@@ -87,7 +87,6 @@
 	outfit = /datum/outfit/job/gimmick/hobo
 	access = list(ACCESS_MAINT_TUNNELS)
 	minimal_access = list(ACCESS_MAINT_TUNNELS)
-	total_positions = 2 //MonkeStation Edit: Gimmick Latejoin
 	gimmick = TRUE
 	chat_color = "#929292"
 	departments = NONE		//being hobo is not a real job
@@ -128,7 +127,6 @@
 	var/chosen_drugs = pick(possible_drugs)
 	var/obj/item/storage/pill_bottle/I = new chosen_drugs(src)
 	H.equip_to_slot_or_del(I,ITEM_SLOT_BACKPACK)
-	var/datum/martial_art/psychotic_brawling/junkie = new //this fits well, but i'm unsure about it, cuz this martial art is so fucking rng dependent i swear...
 	junkie.teach(H)
 	ADD_TRAIT(H, TRAIT_APPRAISAL, JOB_TRAIT)
 

--- a/code/modules/jobs/job_types/gimmick.dm
+++ b/code/modules/jobs/job_types/gimmick.dm
@@ -127,7 +127,6 @@
 	var/chosen_drugs = pick(possible_drugs)
 	var/obj/item/storage/pill_bottle/I = new chosen_drugs(src)
 	H.equip_to_slot_or_del(I,ITEM_SLOT_BACKPACK)
-	junkie.teach(H)
 	ADD_TRAIT(H, TRAIT_APPRAISAL, JOB_TRAIT)
 
 

--- a/monkestation/_maps/RandomRooms/10x10/SECONDARYAIWORSHIPROOM10x10.dmm
+++ b/monkestation/_maps/RandomRooms/10x10/SECONDARYAIWORSHIPROOM10x10.dmm
@@ -133,7 +133,6 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/template_noop)
 "qv" = (
-/obj/effect/landmark/start/randommaint/hobo,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria,
 /area/template_noop)
@@ -249,7 +248,6 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/template_noop)
 "KD" = (
-/obj/effect/landmark/start/randommaint/hobo,
 /turf/open/floor/plating,
 /area/template_noop)
 "KL" = (
@@ -380,7 +378,6 @@
 /area/template_noop)
 "ZA" = (
 /obj/effect/decal/cleanable/oil/slippery,
-/obj/effect/landmark/start/randommaint/hobo,
 /turf/open/floor/plating,
 /area/template_noop)
 "ZG" = (

--- a/monkestation/_maps/RandomRooms/10x5/DRUGDEALERHOBOS.dmm
+++ b/monkestation/_maps/RandomRooms/10x5/DRUGDEALERHOBOS.dmm
@@ -128,7 +128,6 @@
 /area/template_noop)
 "R" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/randommaint/hobo,
 /turf/open/floor/plating,
 /area/template_noop)
 "Y" = (

--- a/monkestation/code/game/objects/items/granters.dm
+++ b/monkestation/code/game/objects/items/granters.dm
@@ -15,7 +15,9 @@
 					"How do we keep coming back to the same stations, even after they get entirely destroyed?",
 					"The AI is just a brain in a box...",
 					"This is all a simulation...",
-					"Why did Nanotrasen hire that confirmed infiltrator for another shift...")
+					"Why did Nanotrasen hire that confirmed infiltrator for another shift...",
+					"The year 25XX has arrived. A horde of ashwalkers. Are rushing from lavaland. Tiding rates skyrocketed! Space Station 13 is ruined! Therefore, Central Command called Mr. Nanotrasen's relative \"John\". For the massacre of the ashwalkers, John is a killer machine. Wipe out all 17 of the ashwalkers! However, in lavaland, there was a secret project in progress! A project to transform the deceased captain into an ultimate weapon!",
+					"Floor Pills unlock the secrets of the universe...")
 
 /obj/item/book/granter/martial/psychotic_brawl/onlearned(mob/living/carbon/user)
 	..()

--- a/monkestation/code/game/objects/items/granters.dm
+++ b/monkestation/code/game/objects/items/granters.dm
@@ -1,0 +1,25 @@
+/obj/item/book/granter/martial/psychotic_brawl
+	martial = /datum/martial_art/psychotic_brawling
+	name = "damp roll of paper"
+	martialname = "psychotic brawling"
+	desc = "An ancient roll of toilet paper passed down from debtor to debtor full of insane rants and conspiracies."
+	greet = "<span class='sciradio'>They're puttin' chemicals into the water that turn the frickin' frogmen into Nanotrasen slaves! Your mind shatters from this knowledge, but you know how to fight them now.</span>"
+	icon = 'icons/obj/wizard.dmi'
+	icon_state = "scroll2"
+	remarks = list("In 2384, meridian time personnel met in Washington to change Space Time...",
+					"Where IS the ceiling?",
+					"Am I constantly laying down from this perspective?",
+					"Only Cubic Harmonics can save the galaxy. Cubic Harmonics will pacify all cultists...",
+					"Why DOES that moth just appear and disappear...",
+					"Who even is Mr.Nanotrasen Himself?",
+					"How do we keep coming back to the same stations, even after they get entirely destroyed?",
+					"The AI is just a brain in a box...",
+					"This is all a simulation...",
+					"Why did Nanotrasen hire that confirmed infiltrator for another shift...")
+
+/obj/item/book/granter/martial/psychotic_brawl/onlearned(mob/living/carbon/user)
+	..()
+	if(oneuse == TRUE)
+		desc = "It's completely blank."
+		name = "empty scroll"
+		icon_state = "blankscroll"

--- a/monkestation/code/modules/uplink/uplink_items.dm
+++ b/monkestation/code/modules/uplink/uplink_items.dm
@@ -6,3 +6,12 @@
 	item = /obj/item/clothing/shoes/magboots/boomboots
 	cost = 20
 	restricted_roles = list("Clown")
+
+/datum/uplink_item/role_restricted/psycho_scroll
+	name = "The Rants of the Debtor"
+	desc = "This roll of toilet paper has writings on it that will allow you to master the art of the Psychotic Brawl, but beware the cost to your own sanity."
+	item = /obj/item/book/granter/martial/psychotic_brawl
+	cost = 8
+	restricted_roles = list("Debtor")
+	surplus = 0
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Debtors may no longer be selected as latejoin jobs.

Debtors no longer start with Psychotic Brawling.

Traitor Debtors have access to an 8 TC scroll that teaches them the art of the psychotic brawl.

Reduces the number of Debtor slots in maps.


## Why It's Good For The Game

Psychotic Brawling is very much bait for bad players and confusion for new players.
So lets just make it what it should have been in the first place, an antagonist martial art.

## Changelog

:cl:
add: 'The Rants of the Debtor', an 8 TC Psychotic Brawling Scroll
remove: Debtors may no longer spawn as latejoin characters
remove: Debtors no longer get Psychotic Brawling by default
remove: Removes a number of hobo spawns in maps. We had THREE on one map.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
