### PR TITLE
Makes Off-Station Bodies a Smidge More Obvious

### DIFF
--- a/code/controllers/subsystem/zclear.dm
+++ b/code/controllers/subsystem/zclear.dm
@@ -100,7 +100,7 @@ SUBSYSTEM_DEF(zclear)
 				//Zombie level detected.
 				announced_zombie_levels["[level.z_value]"] = TRUE
 				if(level.orbital_body)
-					priority_announce("Nanotrasen long ranged sensors have indicated that all sentient life forms at priority waypoint [level.orbital_body.name] have ceased life functions. Command is recommended to establish a rescue operation to recover the bodies. Due to the nature of the threat at this location, security personnel armed with lethal weaponry is recommended to accompany the rescue team.", "Nanotrasen Long Range Sensors")
+					priority_announce("All sentient life forms at [level.orbital_body.name] have perished. You are recommended to establish a rescue operation to recover the bodies.", "Nanotrasen Long Range Sensors", 'sound/misc/notice1.ogg') // MONKESTATION EDIT
 			continue
 		//Level is free, do the wiping thing.
 		LAZYREMOVE(autowipe, level)
@@ -223,7 +223,7 @@ SUBSYSTEM_DEF(zclear)
 						nullspaced_mob_names += " - [M.name]\n"
 						valid = TRUE
 				if(valid)
-					priority_announce("Sensors indicate that multiple crewmembers have been lost at an abandoned station. They can potentially be recovered by flying to the nearest derelict station and locating their bodies.\n[nullspaced_mob_names]")
+					priority_announce("A mass casualty has occured on your nearest priority waypoint. You are reccomended to fly out and rescue the following personnel: \n[nullspaced_mob_names]", "Nanotrasen Long Range Sensors", 'sound/misc/notice1.ogg') // MONKESTATION EDIT
 	cleardata.process_num ++
 
 /*

--- a/code/controllers/subsystem/zclear.dm
+++ b/code/controllers/subsystem/zclear.dm
@@ -223,7 +223,7 @@ SUBSYSTEM_DEF(zclear)
 						nullspaced_mob_names += " - [M.name]\n"
 						valid = TRUE
 				if(valid)
-					priority_announce("A mass casualty has occured on your nearest priority waypoint. You are reccomended to fly out and rescue the following personnel: \n[nullspaced_mob_names]", "Nanotrasen Long Range Sensors", 'sound/misc/notice1.ogg') // MONKESTATION EDIT
+					priority_announce("A mass casualty has occured on your nearest priority waypoint. You are recommended to fly out and rescue the following personnel: \n[nullspaced_mob_names]", "Nanotrasen Long Range Sensors", 'sound/misc/notice1.ogg') // MONKESTATION EDIT
 	cleardata.process_num ++
 
 /*

--- a/code/controllers/subsystem/zclear.dm
+++ b/code/controllers/subsystem/zclear.dm
@@ -100,7 +100,7 @@ SUBSYSTEM_DEF(zclear)
 				//Zombie level detected.
 				announced_zombie_levels["[level.z_value]"] = TRUE
 				if(level.orbital_body)
-					priority_announce("All sentient life forms at [level.orbital_body.name] have perished. You are recommended to establish a rescue operation to recover the bodies.", "Nanotrasen Long Range Sensors", 'sound/misc/notice1.ogg') // MONKESTATION EDIT
+					priority_announce("All sentient life forms at [level.orbital_body.name] have perished. You are recommended to establish a rescue operation to recover the bodies.", "Exploration Crew Monitor", 'sound/misc/notice1.ogg') // MONKESTATION EDIT
 			continue
 		//Level is free, do the wiping thing.
 		LAZYREMOVE(autowipe, level)
@@ -223,7 +223,7 @@ SUBSYSTEM_DEF(zclear)
 						nullspaced_mob_names += " - [M.name]\n"
 						valid = TRUE
 				if(valid)
-					priority_announce("A mass casualty has occured on your nearest priority waypoint. You are recommended to fly out and rescue the following personnel: \n[nullspaced_mob_names]", "Nanotrasen Long Range Sensors", 'sound/misc/notice1.ogg') // MONKESTATION EDIT
+					priority_announce("A mass casualty has occured on your nearest priority waypoint. You are recommended to fly out and rescue the following personnel: \n[nullspaced_mob_names]", "Exploration Crew Monitor", 'sound/misc/notice1.ogg') // MONKESTATION EDIT
 	cleardata.process_num ++
 
 /*


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Let's cut to the chase, the off-station death announcements are way too fat and way too quiet for how important they are. This PR excises the fat from the explanation text and makes the sound actually stick the hell out.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As-is, people just.. don't. Pay attention. This hits the nail with a sledgehammer, as is required.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Changelog

:cl:
tweak: Dying off-station now is much more obvious to everyone else, assuming they don't just tune it out while listening to music or something.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
