### PR TITLE
Adds a Cancel Option to Radio HotKey Say

### DIFF
--- a/monkestation/code/datums/keybinding/living.dm
+++ b/monkestation/code/datums/keybinding/living.dm
@@ -38,7 +38,7 @@
 
 	var/selected_channel = input(L, "Choose a channel", "Radio Channel") in channel_options
 	if(selected_channel)
-		var/spoken_text = input(L, "Speaking into [selected_channel]", "Radio Communication")
+		var/spoken_text = input(L, "Speaking into [selected_channel]", "Radio Communication") as text|null
 		switch(selected_channel) //This feels like jank. But it probably is the best method I can do.
 			if("General", "Red Team", "Blue Team")
 				selected_channel = ";"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request



## Why It's Good For The Game
There is a cancel button now for your say chat after radio hotkey.


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots</summary>

![image](https://user-images.githubusercontent.com/101475356/170849913-96f0b865-48b2-44b6-9989-032c3fbb2b44.png)

</details>

## Changelog

:cl:
add: Added a cancel button when using radio hotkey say
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
