### PR TITLE
Magician item rework

### DIFF
--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -202,11 +202,11 @@
 	. = ..()
 	if(istype(W, /obj/item/upgradewand))
 		var/obj/item/upgradewand/wand = W
-		if(!wand.used && kidnappingcoefficient == initial(kidnappingcoefficient))
+		if(!wand.used)
 			wand.used = TRUE
-			kidnappingcoefficient = 0.5
-			capacity = 4
-			maximum_size = 4
+			kidnappingcoefficient *= 0.5
+			capacity += 2
+			maximum_size += 2
 			to_chat(user, "<span_class='notice'>You upgrade the [src] with the [wand].</span>")
 			playsound(user, 'sound/weapons/emitter2.ogg', 25, 1, -1)
 

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -103,9 +103,9 @@
 	. = ..()
 	if(istype(attacking_item, /obj/item/upgradewand))
 		var/obj/item/upgradewand/wand = attacking_item
-		if(!wand.used && range == initial(range))
+		if(!wand.used)
 			wand.used = TRUE
-			range = 6
+			range += 3
 			to_chat(user, "<span_class='notice'>You upgrade the [src] with the [wand].</span>")
 			playsound(user, 'sound/weapons/emitter2.ogg', 25, 1, -1)
 

--- a/code/modules/jobs/job_types/gimmick.dm
+++ b/code/modules/jobs/job_types/gimmick.dm
@@ -78,7 +78,6 @@
 	shoes = /obj/item/clothing/shoes/laceup
 	gloves = /obj/item/clothing/gloves/color/white
 	l_hand = /obj/item/cane
-	backpack_contents = list(/obj/item/choice_beacon/magic=1)
 	can_be_admin_equipped = TRUE
 
 /datum/job/gimmick/hobo

--- a/monkestation/code/modules/uplink/uplink_items.dm
+++ b/monkestation/code/modules/uplink/uplink_items.dm
@@ -15,3 +15,10 @@
 	restricted_roles = list("Debtor")
 	surplus = 0
 
+/datum/uplink_item/role_restricted/arcane_beacon
+	name = "Beacon of Magical Items"
+	desc = "This beacon allows you to choose a rare magitech item that will make your performance truly unforgettable."
+	item = /obj/item/choice_beacon/magic
+	cost = 5
+	restricted_roles = list("Stage Magician")
+	surplus = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

The Beacon of Magical Items is now a 5 TC traitor item.

The Beacon of Magical Items is removed from roundstart Stage Magicians.

The Upgrade Wand may now upgrade the magic gloves and tophat more than once, if you are willing to spend the TC.

## Why It's Good For The Game

To be blunt, Stage Magician is 110% shitter bait and I have only ONCE seen their special role items used for actual crew entertainment.
Now they can just get them when they're antagonists, so we can stop dealing with this issue.

Plus you can hold more people in your hat, who could hate that?

## Changelog

:cl:
add: The Beacon of Magical Items is now a 5 TC traitor item.
del: The Beacon of Magical Items is removed from roundstart Stage Magicians.
balance: The Upgrade Wand may now upgrade the magic gloves and tophat more than once, if you are willing to spend the TC.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
