### PR TITLE
Small Circuitry Additions/Tweaks

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_circuit.dm
+++ b/code/__DEFINES/dcs/signals/signals_circuit.dm
@@ -39,3 +39,8 @@
 	/// Cancels the attack chain, but without performing any other action.
 	#define COMSIG_CANCEL_USB_CABLE_ATTACK (1<<2)
 
+/// Sent when a QSI teleports itself/the mobs
+#define COMSIG_SWAPPER_USED "swapper_used"
+
+/// Sent when a Sound Synth plays its sound
+#define COMSIG_SOUNDSYNTH_USED "soundsynth_used"

--- a/code/game/objects/items/devices/sound_synth.dm
+++ b/code/game/objects/items/devices/sound_synth.dm
@@ -1,6 +1,6 @@
 /*
         Ported from /vg/station:
-        https://github.com/vgstation-coders/vgstation13/blob/Bleeding-Edge/code/game/objects/items/devices/sound_synth.dm
+        https://github.com/vgstation-coders/vgstation13/blob/Bleeding-Edge/code/game/objects/items/devices/soundsynth.dm
 */
 
 /obj/item/soundsynth
@@ -48,6 +48,12 @@
     "Oohing" = "selected_sound=sound/effects/audience-ooh.ogg&shiftpitch=0&volume=80"
     )
 
+/obj/item/soundsynth/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/shell, list(
+		new /obj/item/circuit_component/soundsynth()
+	), SHELL_CAPACITY_SMALL)
+
 /obj/item/soundsynth/verb/pick_sound()
     set category = "Object"
     set name = "Select Sound Playback"
@@ -61,9 +67,11 @@
     volume = text2num(assblast["volume"])
 
 /obj/item/soundsynth/attack_self(mob/user as mob)
-    if(spam_flag + 2 SECONDS < world.timeofday)
-        playsound(src, selected_sound, volume, shiftpitch)
-        spam_flag = world.timeofday
+	if(spam_flag + 2 SECONDS < world.timeofday)
+		playsound(src, selected_sound, volume, shiftpitch)
+		SEND_SIGNAL(src, COMSIG_SOUNDSYNTH_USED)
+		spam_flag = world.timeofday
+
 
 /obj/item/soundsynth/AltClick(mob/living/carbon/user)
 	pick_sound()
@@ -75,3 +83,54 @@
         M.playsound_local(get_turf(src), selected_sound, volume, shiftpitch)
         spam_flag = world.timeofday
         //to_chat(M, selected_sound) //this doesn't actually go to their chat very much at all.
+
+/obj/item/circuit_component/soundsynth
+	display_name = "Sound Synthesizer"
+	display_desc = "Play funny sounds."
+
+	var/datum/port/input/soundtoplay
+	var/datum/port/input/play
+	var/datum/port/output/played
+
+/obj/item/circuit_component/soundsynth/Initialize(mapload)
+	. = ..()
+	soundtoplay = add_input_port("Sound", PORT_TYPE_STRING)
+	play = add_input_port("Play Sound", PORT_TYPE_SIGNAL)
+	played = add_output_port("Sound Played", PORT_TYPE_SIGNAL)
+
+/obj/item/circuit_component/soundsynth/Destroy()
+	soundtoplay = null
+	play = null
+	played = null
+	return ..()
+
+/obj/item/circuit_component/soundsynth/register_shell(atom/movable/shell)
+	RegisterSignal(shell, COMSIG_SOUNDSYNTH_USED, .proc/on_soundsynth_used)
+
+/obj/item/circuit_component/soundsynth/unregister_shell(atom/movable/shell)
+	UnregisterSignal(shell, COMSIG_SOUNDSYNTH_USED)
+
+/**
+ * Called when the Sound Synth is used
+ */
+/obj/item/circuit_component/soundsynth/proc/on_soundsynth_used(atom/source, mob/user)
+	SIGNAL_HANDLER
+	played.set_output(COMPONENT_SIGNAL)
+
+/obj/item/circuit_component/soundsynth/input_received(datum/port/input/port)
+	. = ..()
+	if(.)
+		return
+
+	var/obj/item/soundsynth/shell = parent.shell
+	if(!shell)
+		return
+	if(COMPONENT_TRIGGERED_BY(play, port))
+		if(shell?.spam_flag + 2 SECONDS < world.timeofday)
+			SEND_SIGNAL(src, COMSIG_SOUNDSYNTH_USED)
+			var/list/assblast = params2list(shell?.sound_list[soundtoplay.input_value])
+			shell?.selected_sound = assblast["selected_sound"]
+			shell?.shiftpitch = text2num(assblast["shiftpitch"])
+			shell?.volume = text2num(assblast["volume"])
+			playsound(shell, shell?.selected_sound, shell?.volume, shell?.shiftpitch)
+			shell?.spam_flag = world.timeofday

--- a/code/game/objects/items/devices/sound_synth.dm
+++ b/code/game/objects/items/devices/sound_synth.dm
@@ -1,6 +1,6 @@
 /*
         Ported from /vg/station:
-        https://github.com/vgstation-coders/vgstation13/blob/Bleeding-Edge/code/game/objects/items/devices/soundsynth.dm
+        https://github.com/vgstation-coders/vgstation13/blob/Bleeding-Edge/code/game/objects/items/devices/sound_synth.dm
 */
 
 /obj/item/soundsynth

--- a/code/game/objects/items/devices/swapper.dm
+++ b/code/game/objects/items/devices/swapper.dm
@@ -13,6 +13,12 @@
 	var/next_use = 0
 	var/obj/item/swapper/linked_swapper
 
+/obj/item/swapper/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/shell, list(
+		new /obj/item/circuit_component/swapper()
+	), SHELL_CAPACITY_SMALL)
+
 /obj/item/swapper/Destroy()
 	if(linked_swapper)
 		linked_swapper.linked_swapper = null //*inception music*
@@ -101,10 +107,13 @@
 	if(QDELETED(linked_swapper) || world.time < linked_swapper.cooldown)
 		return
 
+
 	var/atom/movable/A = get_teleportable_container()
 	var/atom/movable/B = linked_swapper.get_teleportable_container()
 	var/target_A = A.drop_location()
 	var/target_B = B.drop_location()
+
+	SEND_SIGNAL(src, COMSIG_SWAPPER_USED)
 
 	//TODO: add a sound effect or visual effect
 	if(do_teleport(A, target_B, channel = TELEPORT_CHANNEL_QUANTUM))
@@ -114,3 +123,57 @@
 			to_chat(M, "<span class='warning'>[linked_swapper] activates, and you find yourself somewhere else.</span>")
 			log_combat(user, B, "swapped to [AREACOORD(B)]")
 			log_game("[key_name(B)] has been swapped to [AREACOORD(B)]! Quantum Spin Inverter activated by [key_name(user)].")
+
+
+/*
+Circuitry Stuff Below Here
+*/
+/obj/item/circuit_component/swapper
+	display_name = "QSI"
+	display_desc = "Used to activate and detect the usage of the Quantum Spin Inverter."
+
+	var/datum/port/input/swap
+	var/datum/port/input/breaklink
+	var/datum/port/output/swapped /// Called when the QSI is pressed
+
+/obj/item/circuit_component/swapper/Initialize(mapload)
+	. = ..()
+	swap = add_input_port("Activate", PORT_TYPE_SIGNAL)
+	breaklink = add_input_port("Break Link", PORT_TYPE_SIGNAL)
+	swapped = add_output_port("Swapped", PORT_TYPE_SIGNAL)
+
+/obj/item/circuit_component/swapper/Destroy()
+	swap = null
+	breaklink = null
+	swapped = null
+	return ..()
+
+/obj/item/circuit_component/swapper/register_shell(atom/movable/shell)
+	RegisterSignal(shell, COMSIG_SWAPPER_USED, .proc/on_swapper_used)
+
+/obj/item/circuit_component/swapper/unregister_shell(atom/movable/shell)
+	UnregisterSignal(shell, COMSIG_SWAPPER_USED)
+
+/**
+ * Called when the QSI is used
+ */
+/obj/item/circuit_component/swapper/proc/on_swapper_used(atom/source, mob/user)
+	SIGNAL_HANDLER
+	swapped.set_output(COMPONENT_SIGNAL)
+
+/obj/item/circuit_component/swapper/input_received(datum/port/input/port)
+	. = ..()
+	if(.)
+		return
+
+	var/obj/item/swapper/shell = parent.shell
+	if(!shell)
+		return
+	if(COMPONENT_TRIGGERED_BY(swap, port))
+		shell.attack_self(shell)
+	else if(COMPONENT_TRIGGERED_BY(breaklink, port))
+		if(!QDELETED(shell?.linked_swapper))
+			shell?.linked_swapper.linked_swapper = null
+			shell?.linked_swapper.update_icon()
+			shell?.linked_swapper = null
+		shell?.update_icon()

--- a/code/modules/vehicles/secway.dm
+++ b/code/modules/vehicles/secway.dm
@@ -10,6 +10,7 @@
 
 /obj/vehicle/ridden/secway/Initialize(mapload)
 	. = ..()
+	AddComponent(/datum/component/shell, list(new /obj/item/circuit_component/secway()), SHELL_CAPACITY_SMALL)
 	var/datum/component/riding/D = LoadComponent(/datum/component/riding)
 	D.vehicle_move_delay = 1.5
 	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 4), TEXT_EAST = list(0, 4), TEXT_WEST = list( 0, 4)))
@@ -52,3 +53,60 @@
 			M.bullet_act(P)
 		return TRUE
 	return ..()
+
+//Largely copied from Drone but this would be so awesome
+/obj/item/circuit_component/secway
+	display_name = "Secway"
+	display_desc = "Vroom Vroom!"
+
+	/// The inputs to allow for the Secway to move
+	var/datum/port/input/north
+	var/datum/port/input/east
+	var/datum/port/input/south
+	var/datum/port/input/west
+
+	// Done like this so that travelling diagonally is more simple
+	COOLDOWN_DECLARE(north_delay)
+	COOLDOWN_DECLARE(east_delay)
+	COOLDOWN_DECLARE(south_delay)
+	COOLDOWN_DECLARE(west_delay)
+
+	/// Delay between each movement
+	var/move_delay = 0.75
+
+/obj/item/circuit_component/secway/Initialize(mapload)
+	. = ..()
+	north = add_input_port("Move North", PORT_TYPE_SIGNAL)
+	east = add_input_port("Move East", PORT_TYPE_SIGNAL)
+	south = add_input_port("Move South", PORT_TYPE_SIGNAL)
+	west = add_input_port("Move West", PORT_TYPE_SIGNAL)
+
+/obj/item/circuit_component/secway/input_received(datum/port/input/port)
+	. = ..()
+	if(.)
+		return
+
+	var/obj/vehicle/ridden/secway/shell = parent.shell
+	if(!istype(shell))
+		return
+
+	var/direction
+
+	if(COMPONENT_TRIGGERED_BY(north, port) && COOLDOWN_FINISHED(src, north_delay))
+		direction = NORTH
+		COOLDOWN_START(src, north_delay, move_delay)
+	else if(COMPONENT_TRIGGERED_BY(east, port) && COOLDOWN_FINISHED(src, east_delay))
+		direction = EAST
+		COOLDOWN_START(src, east_delay, move_delay)
+	else if(COMPONENT_TRIGGERED_BY(south, port) && COOLDOWN_FINISHED(src, south_delay))
+		direction = SOUTH
+		COOLDOWN_START(src, south_delay, move_delay)
+	else if(COMPONENT_TRIGGERED_BY(west, port) && COOLDOWN_FINISHED(src, west_delay))
+		direction = WEST
+		COOLDOWN_START(src, west_delay, move_delay)
+
+	if(!direction)
+		return
+
+	if(shell.Process_Spacemove(direction))
+		step(shell, direction)

--- a/code/modules/wiremod/shell/assembly.dm
+++ b/code/modules/wiremod/shell/assembly.dm
@@ -13,6 +13,7 @@
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 
 	securable = FALSE //This item should only ever be used as an assembly and the shell datum uses screwdriver_act, might as well make it permanently unsecured
+	attachable = TRUE //Circuitry is already very weak, letting it attach to doors and stuff would allow a lot of much cooler things to be done.
 
 	var/datum/port/output/pulse_out
 


### PR DESCRIPTION
# About The Pull Request

Made the Modular Assembly shell attachable to wires (i.e. Door wires, grenade wires), letting you do more fun things with circuitry/this shell that feels reasonable to have.

Made the Sound Synthesizer able to be used as a circuit shell (cooldown still exists w/ circuits so you can only spam the normal amount) (Inputs: What sound to play, play the sound. Outputs: When a sound is played)

Quantum Spin Inverters are also a shell, I don't know how often they'd come up, though fun can still be had with them when they do. (Inputs: Activate the QSI, Break the QSI's link. Outputs: When the QSI teleports)

And the big one, Secways are also shells now. They are set up similarly to Drones, letting you control their movement. The real star of this show is the MMI component, letting you make sentient Secways. In fact you can put mmi components in all of these, which can make for some really fun gimmicks and bits. (Inputs: Move North, West, South, East)

## Why It's Good For The Game

Gives circuitry some more fun uses, even if its not a huge amount.

## Changelog

:cl:
add: Sound Synthesizers, QSIs, and Secways are now able to be circuit shells
add: Modular Assemblies can now be attached to wires
/:cl:
