### PR TITLE
Holestation Medical Redo

### DIFF
--- a/_maps/map_files/HoleStation/holestation.dmm
+++ b/_maps/map_files/HoleStation/holestation.dmm
@@ -3179,6 +3179,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
 "ams" = (
@@ -3313,11 +3316,22 @@
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
 "amT" = (
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
+/obj/structure/table,
+/obj/item/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/turf/open/floor/plasteel/white,
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/plating,
 /area/medical/medbay/balcony)
 "amU" = (
 /obj/machinery/computer/upload/ai{
@@ -5571,16 +5585,12 @@
 /turf/open/floor/plasteel/dark/airless,
 /area/science/research)
 "avk" = (
-/obj/structure/closet/l3closet,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
 	},
-/obj/structure/cable/yellow,
-/obj/machinery/power/apc/auto_name/south{
-	pixel_x = 1
-	},
-/turf/open/floor/noslip/white,
-/area/medical/virology)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "avm" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "Cabin_1";
@@ -7802,10 +7812,6 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/heater,
 /turf/open/floor/plating,
 /area/engine/atmos)
-"aEf" = (
-/obj/vehicle/ridden/wheelchair,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "aEh" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -14017,6 +14023,15 @@
 	},
 /turf/open/openspace,
 /area/maintenance/central)
+"btX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "buh" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable/yellow{
@@ -14066,53 +14081,12 @@
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/miningdock)
 "bym" = (
-/obj/structure/chair/office/light{
+/obj/machinery/dna_scannernew,
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/landmark/start/geneticist,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"bAD" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/obj/item/radio/intercom{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"bBi" = (
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_exterior";
-	name = "Virology Exterior Airlock";
-	req_access_txt = "39"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/doorButtons/access_button{
-	idDoor = "virology_airlock_exterior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	req_access_txt = "39";
-	pixel_y = 24;
-	pixel_x = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "bBE" = (
 /obj/structure/sign/departments/restroom{
 	pixel_x = 32
@@ -14135,13 +14109,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"bFu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "bGl" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -14285,19 +14252,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"bZa" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
-"bZA" = (
-/obj/effect/turf_decal/tile/blue/tile_marquee,
-/obj/effect/turf_decal/tile/neutral/tile_marquee{
-	dir = 1
+"bYO" = (
+/obj/machinery/computer/pandemic,
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/effect/landmark/start/emt,
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "caf" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -14306,26 +14271,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"cgk" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
+"ccA" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
+	dir = 8
 	},
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 14
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -4;
-	pixel_y = 9
-	},
-/obj/item/wrench/medical,
-/obj/machinery/firealarm/directional/south,
+/obj/structure/chair/stool,
 /turf/open/floor/plating,
-/area/medical/medbay/balcony)
+/area/maintenance/central/secondary)
+"cfU" = (
+/obj/machinery/smartfridge/organ,
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/sleeper)
 "chn" = (
 /obj/machinery/light{
 	dir = 4
@@ -14405,6 +14364,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"crt" = (
+/obj/structure/table,
+/obj/item/storage/box/beakers{
+	pixel_y = 2
+	},
+/obj/item/storage/box/syringes{
+	pixel_x = -3
+	},
+/obj/machinery/reagentgrinder{
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "ctQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -14414,14 +14386,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"cur" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-10"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
 "cvf" = (
 /obj/machinery/door/airlock/silver,
 /obj/structure/cable/yellow{
@@ -14500,6 +14464,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"cHf" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
+"cHh" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "cIn" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -14518,11 +14497,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cJw" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "cNb" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/firealarm/directional/north,
@@ -14560,6 +14534,15 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar/atrium)
+"cPK" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
+"cUf" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/medical/sleeper)
 "cUn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -14575,6 +14558,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"cWy" = (
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "cWC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/caution/stand_clear{
@@ -14612,15 +14599,30 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"dcg" = (
+"ddb" = (
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_interior";
+	name = "Virology Interior Airlock";
+	req_access_txt = "39"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/doorButtons/access_button{
+	idDoor = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_y = 24;
+	req_access_txt = "39"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "ddh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -14640,6 +14642,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dex" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "deN" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -14651,14 +14664,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"dgM" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/virologist,
-/obj/effect/turf_decal/tile/green/tile_marquee{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "dhm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14683,10 +14688,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"dic" = (
-/obj/machinery/vending/wardrobe/gene_wardrobe,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "dka" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -14708,6 +14709,26 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"doP" = (
+/obj/structure/table/glass,
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = 10;
+	pixel_y = 8
+	},
+/obj/item/storage/box/disks{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -8
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "doZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/wood,
@@ -14722,10 +14743,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/research)
-"dsZ" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/medical/virology)
 "dtM" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -14750,18 +14767,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"duf" = (
-/obj/machinery/doorButtons/airlock_controller{
-	idExterior = "virology_airlock_exterior";
-	idInterior = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Console";
-	pixel_x = -24;
-	req_access_txt = "39"
+"dul" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
-/area/medical/virology)
+/area/medical/genetics)
 "dwI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -14772,6 +14783,30 @@
 	dir = 4
 	},
 /area/hallway/primary/central)
+"dyG" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "dyY" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -14784,17 +14819,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"dAt" = (
-/obj/structure/table/optable,
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 1
-	},
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = -28
-	},
-/turf/open/floor/noslip/dark,
-/area/medical/sleeper)
 "dCe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -14908,27 +14932,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"dWy" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/brute{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/brute,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/machinery/door/window/northright{
-	name = "First-Aid Supplies";
-	red_alert_access = 1;
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "dZb" = (
 /obj/structure/table,
 /obj/item/storage/bag/tray,
@@ -14969,25 +14972,6 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/miningdock)
-"dZI" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/machinery/door/window/eastleft{
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "ecX" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -15096,17 +15080,6 @@
 	},
 /turf/open/openspace,
 /area/maintenance/central)
-"eph" = (
-/obj/effect/turf_decal/monke/siding/green,
-/obj/structure/window/reinforced,
-/obj/effect/landmark/blobstart,
-/mob/living/carbon/monkey,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/virology)
 "epL" = (
 /obj/effect/turf_decal/tile/bar/tile_marquee,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -15218,13 +15191,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"eBr" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "eCa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -15261,6 +15227,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"eGB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "eHp" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -15276,6 +15247,11 @@
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"eIa" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "eJU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -15283,6 +15259,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"eLm" = (
+/turf/closed/wall/r_wall,
+/area/medical/sleeper)
 "eLx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -15314,12 +15293,24 @@
 	},
 /turf/open/floor/wood,
 /area/chapel/main)
+"eNN" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/medical/virology)
 "ePK" = (
 /obj/machinery/door/airlock/grunge,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"eTd" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/disposalpipe/trunk,
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/turf/open/openspace/airless,
+/area/space/nearstation)
 "eTp" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -15406,11 +15397,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fjs" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "fkJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -15457,16 +15443,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"ftn" = (
-/obj/machinery/dna_scannernew,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
-"fuI" = (
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/virology)
 "fvt" = (
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/tile/bar/tile_marquee,
@@ -15493,6 +15469,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fyJ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
 "fAJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -15510,6 +15491,14 @@
 /obj/item/storage/backpack/duffelbag/sec/surgery,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"fAK" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-10"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "fAR" = (
 /obj/structure/railing{
 	dir = 8
@@ -15557,18 +15546,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
-"fFH" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
 "fHt" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
@@ -15686,6 +15663,23 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"fVY" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "fXs" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -15698,15 +15692,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"fXK" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "gad" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -15778,21 +15763,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ghK" = (
+/mob/living/carbon/monkey,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/virology)
+"gif" = (
+/obj/vehicle/ridden/wheelchair,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "gmh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"gnF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/primary/central)
 "goZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -15817,13 +15808,6 @@
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
-"guM" = (
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "gvS" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -15861,6 +15845,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"gAK" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gCB" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -15878,17 +15870,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/library)
-"gHN" = (
-/obj/effect/turf_decal/tile/blue/tile_marquee{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/tile_marquee,
-/obj/machinery/iv_drip,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "gJA" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -15946,6 +15927,15 @@
 	},
 /turf/open/openspace,
 /area/maintenance/central/secondary)
+"gLj" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "gLH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable/yellow{
@@ -16069,10 +16059,17 @@
 	},
 /turf/open/floor/wood,
 /area/security/brig)
-"htB" = (
-/obj/machinery/smartfridge/chemistry/virology/preloaded,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+"hwb" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "hwG" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
@@ -16106,17 +16103,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
-"hCd" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/disposalpipe/trunk,
-/obj/structure/disposaloutlet{
-	dir = 1
-	},
-/turf/open/openspace/airless,
-/area/space/nearstation)
-"hCT" = (
-/turf/closed/wall/r_wall,
-/area/medical/virology)
 "hEQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -16124,17 +16110,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"hGv" = (
-/obj/machinery/computer/pandemic,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "hHr" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -16179,18 +16154,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"hMw" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
 "hNN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -16241,6 +16204,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"hSe" = (
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "hSQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -16264,6 +16234,19 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/hallway/secondary/service)
+"ibL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "icY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -16304,11 +16287,13 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "iop" = (
-/obj/machinery/computer/scan_consolenew{
-	dir = 4
+/obj/effect/turf_decal/monke/siding/green,
+/obj/machinery/door/window/southright{
+	req_access_txt = "39"
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/virology)
 "ipf" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
@@ -16379,15 +16364,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen/coldroom)
-"iul" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "ivd" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -16518,12 +16494,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"iIB" = (
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "iKj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/monke/siding/white{
@@ -16541,6 +16511,25 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"iOi" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/machinery/door/window/eastleft{
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "iPG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -16573,11 +16562,35 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"iSA" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "iTP" = (
 /obj/structure/closet/radiation,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/engine/storage)
+"iTX" = (
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/virology)
 "iUF" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -16606,18 +16619,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
-"jcu" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "jcI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -16829,6 +16830,16 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plasteel,
 /area/engine/storage)
+"jys" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
 "jAv" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
@@ -16850,36 +16861,19 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/storage)
+"jEh" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "jEl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/science/lab)
-"jEm" = (
-/mob/living/carbon/monkey,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/virology)
-"jFM" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "jGi" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -16910,6 +16904,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"jKU" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-5"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "jMp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -16917,6 +16926,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"jNk" = (
+/obj/structure/table,
+/obj/structure/reagent_dispensers/virusfood{
+	pixel_x = 30
+	},
+/obj/item/clothing/gloves/color/latex,
+/obj/item/healthanalyzer,
+/obj/item/clothing/glasses/hud/health,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "jNW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/lattice/catwalk,
@@ -16951,15 +16970,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jTK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "jUl" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable/yellow{
@@ -17062,15 +17072,6 @@
 	},
 /turf/open/floor/engine/airless/light,
 /area/space/nearstation)
-"kfP" = (
-/turf/closed/wall,
-/area/medical/medbay/balcony)
-"kgA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "kjW" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -17096,6 +17097,9 @@
 /obj/machinery/door/window/westleft,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"kmx" = (
+/turf/closed/wall,
+/area/medical/virology)
 "kmK" = (
 /obj/machinery/door/airlock/engineering,
 /obj/machinery/door/firedoor/heavy,
@@ -17142,6 +17146,40 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/hallway/secondary/service)
+"koz" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/effect/landmark/start/geneticist,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
+"koZ" = (
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
+"kpg" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"kpz" = (
+/obj/machinery/iv_drip,
+/obj/structure/bed/roller,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "kre" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/railing/corner{
@@ -17180,24 +17218,13 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
-"kti" = (
-/obj/machinery/iv_drip,
-/obj/structure/bed/roller,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
-"kwX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
+"ktV" = (
+/turf/closed/wall,
+/area/medical/genetics)
+"kxx" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "kxP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -17214,12 +17241,31 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"kyJ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+"kyR" = (
+/obj/machinery/sleeper{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
+/obj/machinery/power/apc/auto_name/south{
+	pixel_x = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-9"
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
+"kDW" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "kFC" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -17231,7 +17277,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/vault,
 /turf/open/floor/plating,
 /area/security/nuke_storage)
-"kFH" = (
+"kHt" = (
 /obj/machinery/stasis,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -17260,22 +17306,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"kLy" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Cloning";
-	req_access_txt = "5; 68"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "kOD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -17332,36 +17362,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"kVu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
-"kVJ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-5"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
 "kWD" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -17387,6 +17387,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/vault,
 /turf/open/floor/plating,
 /area/security/nuke_storage)
+"kZx" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "laF" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/monke/siding/thinplating/dark{
@@ -17424,6 +17430,24 @@
 	},
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
+"lcJ" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/infections{
+	pixel_y = 7;
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/syringe/antiviral,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"ldb" = (
+/obj/machinery/clonepod/prefilled,
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
 "ldx" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -17438,6 +17462,16 @@
 /obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ldZ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/firealarm/directional/east,
+/turf/open/openspace,
+/area/maintenance/central/secondary)
 "lgc" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -17452,6 +17486,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"lhZ" = (
+/obj/structure/closet/l3closet,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_x = 1
+	},
+/turf/open/floor/noslip/white,
+/area/medical/virology)
 "lku" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -17480,21 +17525,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"lvS" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
-"lvZ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+"lvJ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/firealarm/directional/east,
-/turf/open/openspace,
-/area/maintenance/central/secondary)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "lwA" = (
 /obj/structure/table/glass,
 /obj/machinery/recharger,
@@ -17505,41 +17544,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"lyC" = (
-/obj/effect/turf_decal/tile/green,
-/obj/structure/cable/yellow{
-	icon_state = "6-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "lyR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/hallway/secondary/entry)
-"lzL" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
 "lAP" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/structure/cable/yellow{
@@ -17659,10 +17669,6 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/miningdock)
-"lXm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/genetics)
 "lXz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -17674,6 +17680,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"lZT" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/openspace,
+/area/maintenance/central/secondary)
 "mbN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -17690,6 +17712,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
+"mep" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Cloning";
+	req_access_txt = "5; 68"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "meW" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -17733,19 +17771,15 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mwo" = (
-/obj/effect/turf_decal/stripes/line{
+"mvH" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/chair/stool,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
 "myI" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -17759,6 +17793,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"myK" = (
+/turf/closed/wall,
+/area/medical/medbay/balcony)
 "myQ" = (
 /mob/living/simple_animal/bot/secbot{
 	arrest_type = 1;
@@ -17774,19 +17811,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"myW" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/monke/siding/thinplating/light{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "mDF" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -17797,19 +17821,23 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/storage)
-"mJr" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+"mFy" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/monke/siding/thinplating/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"mMW" = (
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
+"mKi" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/ameridiner,
 /area/medical/sleeper)
 "mNs" = (
 /obj/effect/landmark/start/shaft_miner,
@@ -17818,6 +17846,27 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/miningdock)
+"mTg" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
+"mUA" = (
+/obj/effect/turf_decal/tile/blue/tile_marquee,
+/obj/effect/turf_decal/tile/neutral/tile_marquee{
+	dir = 1
+	},
+/obj/effect/landmark/start/emt,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "mWJ" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -17873,27 +17922,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"njP" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
+"ngZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
-"nno" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "nnW" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -17944,54 +17985,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"nvG" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"nxT" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/infections{
-	pixel_y = 7;
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/syringe/antiviral,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "nDD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/hallway/secondary/exit)
-"nEX" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "nEZ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -18011,6 +18010,19 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"nFN" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "nHG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -18056,6 +18068,29 @@
 	},
 /turf/open/openspace,
 /area/maintenance/central/secondary)
+"nKC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
+"nKW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "nMP" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -18073,22 +18108,24 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/main)
-"nSo" = (
-/obj/structure/table,
-/obj/structure/reagent_dispensers/virusfood{
-	pixel_x = 30
-	},
-/obj/item/clothing/gloves/color/latex,
-/obj/item/healthanalyzer,
-/obj/item/clothing/glasses/hud/health,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "nSD" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/multiz/layer4,
 /obj/machinery/atmospherics/pipe/multiz/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft/secondary)
+"nTK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "nVh" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -18100,6 +18137,16 @@
 	},
 /turf/open/openspace,
 /area/maintenance/starboard/aft/secondary)
+"nVN" = (
+/obj/effect/turf_decal/tile/blue/tile_marquee{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "nWu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -18134,25 +18181,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"nZW" = (
+/mob/living/simple_animal/pet/hamster/vector,
+/obj/effect/turf_decal/tile/green/tile_marquee{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "oak" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/multiz/layer4,
 /obj/machinery/atmospherics/pipe/multiz/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"obJ" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "oej" = (
 /obj/structure/chair{
 	dir = 8
@@ -18173,10 +18214,33 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/openspace,
 /area/maintenance/fore)
-"ofO" = (
-/mob/living/simple_animal/pet/hamster/vector,
-/obj/effect/turf_decal/tile/green/tile_marquee{
+"ofB" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
+"ogd" = (
+/obj/effect/turf_decal/tile/green{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-9"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -18205,14 +18269,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ojJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "okZ" = (
@@ -18257,14 +18313,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"opL" = (
-/obj/effect/turf_decal/monke/siding/green,
-/obj/machinery/door/window/southright{
-	req_access_txt = "39"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/virology)
 "orI" = (
 /obj/structure/chair/pew/right,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -18307,12 +18355,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "ovj" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "ovO" = (
@@ -18349,6 +18395,18 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"oAq" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "oBG" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -18417,6 +18475,14 @@
 	},
 /turf/open/floor/mineral/plastitanium/airless,
 /area/space/nearstation)
+"oEv" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/shower{
+	pixel_y = 12
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/noslip/white,
+/area/medical/virology)
 "oFh" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/multiz,
@@ -18571,16 +18637,26 @@
 	},
 /turf/open/openspace,
 /area/maintenance/starboard/aft/secondary)
-"pbe" = (
-/obj/effect/turf_decal/tile/blue/tile_marquee{
+"pai" = (
+/obj/effect/turf_decal/tile/blue/tile_marquee,
+/obj/effect/turf_decal/tile/neutral/tile_marquee{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral/tile_marquee,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /turf/open/floor/plasteel/ameridiner,
 /area/medical/sleeper)
+"pdK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "pfe" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -18628,10 +18704,14 @@
 	},
 /turf/open/floor/engine/airless/light,
 /area/space/nearstation)
-"poj" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/medical/sleeper)
+"pop" = (
+/obj/machinery/vending/wardrobe/viro_wardrobe,
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "pse" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -18669,15 +18749,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"pxz" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
+"pyC" = (
+/turf/closed/wall/r_wall,
+/area/medical/virology)
 "pzf" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -18719,14 +18793,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/library)
-"pDh" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "pFq" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable/yellow{
@@ -18759,13 +18825,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
-"pNT" = (
-/obj/machinery/smartfridge/organ,
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
 "pNV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -18799,6 +18858,13 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"pTo" = (
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "pUO" = (
 /obj/effect/turf_decal/loading_area,
 /obj/structure/cable/yellow{
@@ -18812,13 +18878,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"pUR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
+"pVz" = (
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
+/area/medical/medbay/balcony)
 "pVL" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -18851,6 +18917,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"pYW" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "qbM" = (
 /obj/structure/chair/pew/left,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -18875,10 +18957,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"qhJ" = (
-/obj/machinery/clonepod/prefilled,
-/turf/open/floor/plasteel/dark,
-/area/medical/genetics)
 "qhU" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -18891,6 +18969,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"qiL" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "qjN" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -18948,15 +19033,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
-"qqu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "qry" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable/yellow{
@@ -18991,17 +19067,6 @@
 	},
 /turf/open/openspace,
 /area/maintenance/starboard/aft/secondary)
-"qCM" = (
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
 "qEv" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/monke/siding/thinplating{
@@ -19049,16 +19114,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
-"qPu" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/monke/siding/thinplating/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "qQt" = (
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 4
@@ -19084,14 +19139,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"qZs" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/dark,
-/area/medical/genetics)
-"qZP" = (
-/turf/closed/wall,
-/area/medical/virology)
 "rao" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -19107,9 +19154,6 @@
 /obj/structure/lattice/catwalk/over,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
-"rbh" = (
-/turf/closed/wall,
-/area/medical/genetics)
 "rbn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/iv_drip,
@@ -19131,6 +19175,15 @@
 	},
 /turf/open/floor/mineral/plastitanium/airless,
 /area/space/nearstation)
+"rhE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "rjK" = (
 /obj/effect/landmark/start/cook,
 /obj/structure/cable/yellow{
@@ -19144,22 +19197,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"rlZ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/openspace,
-/area/maintenance/central/secondary)
 "rno" = (
 /obj/machinery/door/airlock/command,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -19211,6 +19248,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"rsn" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/brute{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/machinery/door/window/northright{
+	name = "First-Aid Supplies";
+	red_alert_access = 1;
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "ruo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -19223,28 +19281,15 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "rwl" = (
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_interior";
-	name = "Virology Interior Airlock";
-	req_access_txt = "39"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/doorButtons/access_button{
-	idDoor = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_y = 24;
-	req_access_txt = "39"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/monke/siding/green,
+/obj/structure/window/reinforced,
+/obj/effect/landmark/blobstart,
+/mob/living/carbon/monkey,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/ameridiner,
 /area/medical/virology)
 "rwP" = (
 /obj/effect/landmark/start/cook,
@@ -19266,35 +19311,6 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/hallway/secondary/service)
-"rBB" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/o2{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/o2,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner/east,
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
-"rEd" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "rFc" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -19342,6 +19358,10 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"rMA" = (
+/obj/machinery/vending/wardrobe/gene_wardrobe,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "rNA" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -19444,18 +19464,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"rUR" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/south{
-	pixel_x = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-9"
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "rVK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -19470,40 +19478,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"rWA" = (
-/obj/effect/turf_decal/tile/blue/tile_marquee,
-/obj/effect/turf_decal/tile/neutral/tile_marquee{
-	dir = 1
-	},
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
-"rWU" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
 "rXm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
+"rXG" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/medical/sleeper)
 "rXP" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -19711,6 +19695,25 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/library)
+"suS" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/monke/siding/blue/corner{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "svm" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
@@ -19780,10 +19783,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"sIh" = (
-/obj/machinery/firealarm/directional/south,
-/turf/open/openspace,
-/area/maintenance/central/secondary)
 "sOh" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -19800,17 +19799,6 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"sQg" = (
-/obj/structure/closet/l3closet,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/noslip/white,
-/area/medical/virology)
 "sQi" = (
 /obj/machinery/door/firedoor,
 /obj/structure/lattice/catwalk,
@@ -19863,10 +19851,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"sWX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/virology)
 "sXf" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -19891,18 +19875,32 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"tco" = (
-/obj/effect/turf_decal/stripes/line{
+"sXA" = (
+/obj/effect/turf_decal/tile/green,
+/obj/structure/cable/yellow{
+	icon_state = "6-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/railing{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"taE" = (
+/obj/machinery/vending/wallmed{
+	pixel_x = 24
 	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
+/obj/machinery/rnd/production/techfab/department/medical,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "tfx" = (
 /obj/effect/turf_decal/trimline/blue/warning,
 /obj/machinery/holopad,
@@ -19951,6 +19949,10 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"thZ" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/openspace,
+/area/maintenance/central/secondary)
 "tix" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
@@ -20219,24 +20221,8 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
-"tRj" = (
-/obj/machinery/vending/wallmed{
-	pixel_x = 24
-	},
-/obj/machinery/rnd/production/techfab/department/medical,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
-"tRP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/chair/stool,
+"tQO" = (
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "tSm" = (
@@ -20280,6 +20266,26 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plasteel,
 /area/security/main)
+"tVa" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -4;
+	pixel_y = 9
+	},
+/obj/item/wrench/medical,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "tYX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -20330,12 +20336,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"uml" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "una" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
@@ -20350,6 +20350,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"unh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/genetics)
 "unv" = (
 /obj/effect/turf_decal/tile/bar/tile_marquee,
 /obj/structure/cable/yellow{
@@ -20376,6 +20380,18 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/security/nuke_storage)
+"urk" = (
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/sleeper)
 "utc" = (
 /obj/machinery/vending/snack/random,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -20445,11 +20461,6 @@
 	},
 /turf/open/floor/wood,
 /area/chapel/main)
-"uDf" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "uGl" = (
 /obj/structure/railing{
 	dir = 1
@@ -20468,19 +20479,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"uGS" = (
-/obj/structure/table,
-/obj/item/storage/box/beakers{
-	pixel_y = 2
-	},
-/obj/item/storage/box/syringes{
-	pixel_x = -3
-	},
-/obj/machinery/reagentgrinder{
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "uKr" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -20492,22 +20490,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/office)
-"uKB" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "uLw" = (
 /obj/machinery/light{
 	dir = 8
@@ -20518,17 +20500,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
-"uMJ" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
-"uRY" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "uTz" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -20541,12 +20512,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"uTH" = (
-/obj/vehicle/ridden/wheelchair,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "uUR" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -20560,27 +20525,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"uVJ" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = -4;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "uWm" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -20654,6 +20598,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"vdA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/virology)
 "vgI" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -20667,11 +20615,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"vgZ" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/medical/virology)
 "vhH" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -20690,10 +20633,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"vjx" = (
-/obj/machinery/vending/wardrobe/viro_wardrobe,
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+"vkw" = (
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/virologist,
+/obj/effect/turf_decal/tile/green/tile_marquee{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -20721,6 +20664,12 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main)
+"vtD" = (
+/obj/machinery/shower{
+	pixel_y = 12
+	},
+/turf/open/floor/noslip/dark,
+/area/medical/genetics)
 "vuf" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -20741,6 +20690,13 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/storage)
+"vya" = (
+/obj/machinery/computer/cloning{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
 "vyp" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/effect/turf_decal/stripes/line,
@@ -20751,30 +20707,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"vyR" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = -7;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 7;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = -4;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "vzD" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -20814,6 +20746,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"vFU" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "vHq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/caution/stand_clear{
@@ -20831,6 +20775,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
+"vMm" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "vMI" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -20851,6 +20808,34 @@
 /obj/item/reagent_containers/blood/OPlus,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"vNq" = (
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_exterior";
+	name = "Virology Exterior Airlock";
+	req_access_txt = "39"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/doorButtons/access_button{
+	idDoor = "virology_airlock_exterior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	req_access_txt = "39";
+	pixel_y = 24;
+	pixel_x = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "vOz" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
@@ -20879,19 +20864,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/wood,
 /area/library)
-"vUF" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/auto_name/north,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "vWE" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -20960,6 +20932,12 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/storage)
+"weh" = (
+/obj/machinery/computer/scan_consolenew{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "weF" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -20979,26 +20957,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark/side,
 /area/ai_monitored/security/armory)
-"weG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/central)
-"wfm" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "wfM" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/structure/cable/yellow{
@@ -21009,20 +20967,16 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/storage)
-"wgB" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/shower{
-	pixel_y = 12
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/noslip/white,
-/area/medical/virology)
 "whi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"whs" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "wix" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -21040,10 +20994,12 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"wkV" = (
-/obj/effect/spawner/structure/window,
+"wmN" = (
+/obj/vehicle/ridden/wheelchair,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
-/area/medical/sleeper)
+/area/maintenance/central/secondary)
 "wnF" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -21075,6 +21031,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"wsD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "wsR" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -21117,13 +21079,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wyy" = (
-/obj/machinery/computer/cloning{
-	dir = 4
+"wze" = (
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/medical/genetics)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "wBP" = (
 /obj/machinery/computer/objective{
 	dir = 8
@@ -21137,12 +21103,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
+"wCL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/primary/central)
 "wDK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/library/lounge)
+"wDY" = (
+/obj/structure/table/optable,
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 1
+	},
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -28
+	},
+/turf/open/floor/noslip/dark,
+/area/medical/sleeper)
 "wEa" = (
 /obj/machinery/firealarm/directional/east,
 /obj/item/kirbyplants/random,
@@ -21151,12 +21137,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wES" = (
-/obj/machinery/shower{
-	pixel_y = 12
-	},
-/turf/open/floor/noslip/dark,
-/area/medical/genetics)
 "wIW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -21207,8 +21187,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"wOy" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+"wPj" = (
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "virology_airlock_exterior";
+	idInterior = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Console";
+	pixel_x = -24;
+	req_access_txt = "39"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "wUb" = (
@@ -21219,6 +21207,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/research)
+"wVn" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "wVS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -21268,11 +21272,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/security/nuke_storage)
-"xfr" = (
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+"xfs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "xhh" = (
@@ -21286,6 +21288,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"xhE" = (
+/obj/effect/turf_decal/tile/blue/tile_marquee{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/obj/machinery/iv_drip,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "xic" = (
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -21323,6 +21336,19 @@
 	dir = 8
 	},
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"xmX" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "xnb" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -21347,6 +21373,12 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
+"xnF" = (
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
 "xoy" = (
 /obj/machinery/door/airlock/maintenance/external,
 /obj/structure/cable/yellow{
@@ -21430,6 +21462,17 @@
 	dir = 4
 	},
 /area/ai_monitored/turret_protected/ai_upload)
+"xzt" = (
+/obj/structure/closet/l3closet,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/noslip/white,
+/area/medical/virology)
 "xAM" = (
 /obj/structure/table/wood,
 /obj/item/toy/figure/syndie{
@@ -21470,25 +21513,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"xDp" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/monke/siding/blue/corner{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
 "xDq" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/structure/cable/yellow{
@@ -21588,21 +21612,6 @@
 /obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"xJq" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-9"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "xKW" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -21651,10 +21660,6 @@
 /obj/machinery/vending/modularpc,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"xSU" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "xTd" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -21693,26 +21698,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"yap" = (
-/obj/structure/table/glass,
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = 10;
-	pixel_y = 8
+"xZI" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/monke/siding/thinplating/light{
+	dir = 8
 	},
-/obj/item/storage/box/disks{
-	pixel_x = -6;
-	pixel_y = 9
+/obj/structure/cable/yellow{
+	icon_state = "6-8"
 	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 5;
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -8
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "yas" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -21741,6 +21739,11 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"yda" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/medical/virology)
 "yeI" = (
 /obj/effect/turf_decal/tile/bar/tile_marquee,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -56603,7 +56606,7 @@ sdW
 gPD
 hNN
 edh
-nvG
+kpg
 axZ
 wwk
 sgi
@@ -57117,7 +57120,7 @@ avX
 avX
 adV
 aIu
-weG
+jys
 dxg
 dxg
 dwI
@@ -57631,7 +57634,7 @@ aLu
 aNg
 aWm
 acg
-gnF
+wCL
 aTY
 aTY
 aTY
@@ -57882,7 +57885,7 @@ aEv
 aFL
 aLu
 aqb
-bFu
+avk
 aXC
 aLB
 aIv
@@ -58142,10 +58145,10 @@ auJ
 aJx
 aQk
 aLu
-ovj
+mvH
 aCE
-iIB
-pUR
+xnF
+ovj
 aVH
 aLg
 rFc
@@ -58396,7 +58399,7 @@ avE
 avE
 aHL
 aIP
-kyJ
+wsD
 aEJ
 aLu
 aNr
@@ -58921,7 +58924,7 @@ aGL
 aum
 aZi
 aZT
-ojJ
+gAK
 aCj
 aaB
 aaB
@@ -121888,7 +121891,7 @@ aaD
 aaD
 aVX
 pfe
-sIh
+thZ
 ajR
 ajR
 aHA
@@ -122132,9 +122135,9 @@ aOH
 kmc
 aTv
 gKP
-rlZ
+lZT
 bOm
-lvZ
+ldZ
 bOm
 bOm
 bOm
@@ -122388,22 +122391,22 @@ agb
 iqd
 ipz
 aTv
-xfr
-kVu
+hSe
+nKW
 aKd
 aTv
-mwo
-tco
-tco
+ibL
+nTK
+nTK
 aTv
 aTv
 aTv
 aTv
 aTv
 aTv
-wfm
-tRP
-dcg
+cHf
+ccA
+btX
 iHz
 tuZ
 fCL
@@ -122645,7 +122648,7 @@ afB
 xHV
 kJd
 aTv
-cJw
+cPK
 xOb
 aWE
 aTv
@@ -122653,10 +122656,10 @@ aaD
 aaD
 aaD
 aTv
-qhJ
-wyy
-ftn
-iop
+ldb
+vya
+bym
+weh
 aTv
 aTv
 aTv
@@ -122904,19 +122907,19 @@ aFs
 ajR
 ajR
 aTv
-jFM
+ofB
 aTv
 aTv
 aTv
 aTv
 aTv
-wES
-qZs
-kgA
-bym
-yap
+vtD
+fyJ
+dul
+koz
+doP
 aTv
-xSU
+whs
 avv
 dyY
 aTv
@@ -123160,20 +123163,20 @@ opB
 adD
 aUd
 ajR
-uTH
+wmN
 dyY
 rbn
 aTv
 aCX
 aCX
-kfP
-lXm
-rbh
-vUF
-guM
-dic
+myK
+unh
+ktV
+nFN
+pTo
+rMA
 aTv
-uRY
+tQO
 avv
 dyY
 aTv
@@ -123417,18 +123420,18 @@ agg
 adD
 aUd
 ajR
-aEf
-kwX
-kti
+gif
+ngZ
+kpz
 aTv
 aCX
 aCX
-nEX
-cgk
-rbh
-kLy
-rbh
-lXm
+xmX
+tVa
+ktV
+mep
+ktV
+unh
 aTv
 aTv
 aTv
@@ -123675,18 +123678,18 @@ aFs
 aUd
 ajR
 aTv
-kwX
-lvS
+ngZ
+xfs
 aTv
 aCX
 aCX
-rEd
-fjs
-uMJ
-njP
-rBB
-dZI
-uKB
+hwb
+eIa
+pVz
+mTg
+amT
+iOi
+wVn
 aTv
 aEP
 pVL
@@ -123931,19 +123934,19 @@ aFs
 aFs
 aAp
 ajR
-uDf
+cHh
 dyY
-bZa
+eGB
 aTv
 aCX
 aCX
-obJ
-pxz
-kVJ
-rWU
-fFH
-amT
-dWy
+kDW
+gLj
+jKU
+fVY
+vFU
+koZ
+rsn
 aTv
 aAU
 xcr
@@ -124189,18 +124192,18 @@ arj
 arj
 ajR
 aPU
-jcu
-qqu
+oAq
+pdK
 att
-qCM
-lzL
-xDp
-cur
-tRj
-hCT
-bBi
-hCT
-hCT
+wze
+pYW
+suS
+fAK
+taE
+pyC
+vNq
+pyC
+pyC
 ajR
 aAb
 pVL
@@ -124449,15 +124452,15 @@ ajR
 ajR
 ajR
 ajR
-wkV
-qPu
-myW
-wkV
-hCT
-hCT
-lyC
-mJr
-sQg
+cUf
+mFy
+xZI
+cUf
+pyC
+pyC
+sXA
+dex
+xzt
 ajR
 aJa
 xcr
@@ -124705,16 +124708,16 @@ arj
 arj
 arj
 arj
-mMW
-iul
-fXK
-eBr
-rUR
-hCT
-wgB
-uml
-xJq
-avk
+eLm
+jEh
+lvJ
+qiL
+kyR
+pyC
+oEv
+kZx
+ogd
+lhZ
 ajR
 agW
 tDu
@@ -124962,16 +124965,16 @@ arj
 arj
 arj
 aAp
-mMW
-nno
-rWA
-pbe
-pNT
-hCT
-sWX
-qZP
-rwl
-qZP
+eLm
+nKC
+pai
+nVN
+cfU
+pyC
+vdA
+kmx
+ddb
+kmx
 ajR
 ajR
 aIq
@@ -125219,18 +125222,18 @@ arj
 arj
 arj
 aAp
-mMW
-pDh
-gHN
-bZA
-dAt
-hCT
-fuI
-eph
-jTK
-duf
-vjx
-hCT
+eLm
+mKi
+xhE
+mUA
+wDY
+pyC
+iTX
+rwl
+rhE
+wPj
+pop
+pyC
 aUd
 aUd
 ajR
@@ -125476,18 +125479,18 @@ arj
 arj
 arj
 aAp
-mMW
-kFH
-vyR
-uVJ
-hMw
-hCT
-jEm
-opL
-wOy
-ofO
-htB
-hCT
+eLm
+kHt
+dyG
+iSA
+urk
+pyC
+ghK
+iop
+kxx
+nZW
+cWy
+pyC
 aAp
 aAp
 aAp
@@ -125733,18 +125736,18 @@ arj
 arj
 arj
 aAp
-mMW
-mMW
-poj
-poj
-mMW
-hCT
-hCT
-hCT
-bAD
-dgM
-nxT
-dsZ
+eLm
+eLm
+rXG
+rXG
+eLm
+pyC
+pyC
+pyC
+vMm
+vkw
+lcJ
+eNN
 arj
 arj
 arj
@@ -125996,12 +125999,12 @@ aUd
 aAp
 arj
 arj
-hCd
-vgZ
-hGv
-uGS
-nSo
-hCT
+eTd
+yda
+bYO
+crt
+jNk
+pyC
 arj
 arj
 arj
@@ -126254,11 +126257,11 @@ aAp
 arj
 arj
 arj
-hCT
-hCT
-dsZ
-hCT
-hCT
+pyC
+pyC
+eNN
+pyC
+pyC
 arj
 arj
 arj

--- a/_maps/map_files/HoleStation/holestation.dmm
+++ b/_maps/map_files/HoleStation/holestation.dmm
@@ -3316,23 +3316,9 @@
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
 "amT" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/o2{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/o2,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner/east,
+/obj/vehicle/ridden/wheelchair,
 /turf/open/floor/plating,
-/area/medical/medbay/balcony)
+/area/maintenance/central/secondary)
 "amU" = (
 /obj/machinery/computer/upload/ai{
 	dir = 4
@@ -5585,12 +5571,12 @@
 /turf/open/floor/plasteel/dark/airless,
 /area/science/research)
 "avk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "avm" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "Cabin_1";
@@ -6635,6 +6621,13 @@
 /obj/effect/turf_decal/monke/siding/wood,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"azl" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "azm" = (
 /obj/structure/altar_of_gods,
 /obj/item/storage/book/bible{
@@ -10980,9 +10973,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aPU" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "aPV" = (
@@ -13914,6 +13913,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"bbs" = (
+/turf/closed/wall,
+/area/medical/virology)
 "bbE" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -13964,6 +13966,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
+"bgV" = (
+/obj/effect/turf_decal/tile/blue/tile_marquee{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "bim" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -13976,6 +13988,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
+"bjO" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "bll" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -14023,15 +14048,6 @@
 	},
 /turf/open/openspace,
 /area/maintenance/central)
-"btX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "buh" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable/yellow{
@@ -14043,6 +14059,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"bui" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "buq" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -14081,12 +14105,23 @@
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/miningdock)
 "bym" = (
-/obj/machinery/dna_scannernew,
-/obj/machinery/light{
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
+"bzF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
-/area/medical/genetics)
+/area/medical/virology)
 "bBE" = (
 /obj/structure/sign/departments/restroom{
 	pixel_x = 32
@@ -14129,6 +14164,17 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bJx" = (
+/obj/structure/table/optable,
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 1
+	},
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -28
+	},
+/turf/open/floor/noslip/dark,
+/area/medical/sleeper)
 "bJL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/carpet,
@@ -14149,6 +14195,17 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
+"bLW" = (
+/obj/effect/turf_decal/tile/blue/tile_marquee,
+/obj/effect/turf_decal/tile/neutral/tile_marquee{
+	dir = 1
+	},
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "bOa" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -14252,17 +14309,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"bYO" = (
-/obj/machinery/computer/pandemic,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "caf" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -14271,20 +14317,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"ccA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/chair/stool,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
-"cfU" = (
-/obj/machinery/smartfridge/organ,
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
 "chn" = (
 /obj/machinery/light{
 	dir = 4
@@ -14355,6 +14387,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
+"coC" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "cqm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -14364,17 +14409,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"crt" = (
+"crx" = (
 /obj/structure/table,
-/obj/item/storage/box/beakers{
-	pixel_y = 2
+/obj/structure/reagent_dispensers/virusfood{
+	pixel_x = 30
 	},
-/obj/item/storage/box/syringes{
-	pixel_x = -3
-	},
-/obj/machinery/reagentgrinder{
-	pixel_y = 4
-	},
+/obj/item/clothing/gloves/color/latex,
+/obj/item/healthanalyzer,
+/obj/item/clothing/glasses/hud/health,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "ctQ" = (
@@ -14464,21 +14506,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"cHf" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
-"cHh" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "cIn" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -14534,15 +14561,28 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar/atrium)
-"cPK" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
+"cSg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"cUf" = (
-/obj/effect/spawner/structure/window,
+"cTN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/medical/sleeper)
+/area/maintenance/central/secondary)
 "cUn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -14558,10 +14598,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"cWy" = (
-/obj/machinery/smartfridge/chemistry/virology/preloaded,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "cWC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/caution/stand_clear{
@@ -14579,6 +14615,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/exploration_dock)
+"cXw" = (
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "cXT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/monke/siding/white/corner,
@@ -14599,30 +14642,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"ddb" = (
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_interior";
-	name = "Virology Interior Airlock";
-	req_access_txt = "39"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/doorButtons/access_button{
-	idDoor = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_y = 24;
-	req_access_txt = "39"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "ddh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -14632,6 +14651,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"deh" = (
+/obj/structure/table/glass,
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = 10;
+	pixel_y = 8
+	},
+/obj/item/storage/box/disks{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -8
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "dew" = (
 /obj/machinery/bluespace_beacon,
 /obj/effect/turf_decal/plaque{
@@ -14642,17 +14681,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dex" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "deN" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -14709,25 +14737,11 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"doP" = (
-/obj/structure/table/glass,
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = 10;
-	pixel_y = 8
+"dmN" = (
+/obj/machinery/shower{
+	pixel_y = 12
 	},
-/obj/item/storage/box/disks{
-	pixel_x = -6;
-	pixel_y = 9
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 5;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -8
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/noslip/dark,
 /area/medical/genetics)
 "doZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -14767,12 +14781,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"dul" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "dwI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -14783,30 +14791,6 @@
 	dir = 4
 	},
 /area/hallway/primary/central)
-"dyG" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = -7;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 7;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = -4;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "dyY" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -14862,6 +14846,17 @@
 /obj/effect/landmark/start/depsec/supply,
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/storage)
+"dJU" = (
+/obj/machinery/computer/pandemic,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "dMh" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -14932,6 +14927,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"dVf" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "dZb" = (
 /obj/structure/table,
 /obj/item/storage/bag/tray,
@@ -15227,11 +15227,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"eGB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "eHp" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -15247,11 +15242,6 @@
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"eIa" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "eJU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -15259,9 +15249,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"eLm" = (
-/turf/closed/wall/r_wall,
-/area/medical/sleeper)
 "eLx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -15293,24 +15280,12 @@
 	},
 /turf/open/floor/wood,
 /area/chapel/main)
-"eNN" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/medical/virology)
 "ePK" = (
 /obj/machinery/door/airlock/grunge,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
-"eTd" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/disposalpipe/trunk,
-/obj/structure/disposaloutlet{
-	dir = 1
-	},
-/turf/open/openspace/airless,
-/area/space/nearstation)
 "eTp" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -15319,6 +15294,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"eXJ" = (
+/turf/closed/wall,
+/area/medical/medbay/balcony)
 "eYL" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Fabrication"
@@ -15342,6 +15320,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fcx" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "fdI" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
@@ -15397,6 +15386,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fki" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/medical/virology)
 "fkJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -15469,11 +15463,18 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fyJ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/dark,
-/area/medical/genetics)
+"fxo" = (
+/obj/machinery/stasis,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
+"fzA" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "fAJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -15491,14 +15492,6 @@
 /obj/item/storage/backpack/duffelbag/sec/surgery,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"fAK" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-10"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
 "fAR" = (
 /obj/structure/railing{
 	dir = 8
@@ -15510,6 +15503,10 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/wood,
 /area/library)
+"fAZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/virology)
 "fCL" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -15541,6 +15538,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"fDM" = (
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_interior";
+	name = "Virology Interior Airlock";
+	req_access_txt = "39"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/doorButtons/access_button{
+	idDoor = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_y = 24;
+	req_access_txt = "39"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "fEi" = (
 /obj/effect/landmark/start/exploration,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -15589,6 +15610,15 @@
 	},
 /turf/open/floor/mineral/plastitanium/airless,
 /area/space/nearstation)
+"fKc" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "fKe" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -15634,6 +15664,22 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/warehouse)
+"fRR" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "fTM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/wood,
@@ -15663,23 +15709,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"fVY" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
 "fXs" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -15747,6 +15776,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"ggi" = (
+/mob/living/carbon/monkey,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/virology)
 "ggZ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -15763,27 +15803,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ghK" = (
-/mob/living/carbon/monkey,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/virology)
-"gif" = (
-/obj/vehicle/ridden/wheelchair,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "gmh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"gog" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "goZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -15808,6 +15841,20 @@
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
+"grN" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/infections{
+	pixel_y = 7;
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/syringe/antiviral,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "gvS" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -15843,14 +15890,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"gAK" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gCB" = (
@@ -15927,15 +15966,6 @@
 	},
 /turf/open/openspace,
 /area/maintenance/central/secondary)
-"gLj" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "gLH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable/yellow{
@@ -16059,17 +16089,6 @@
 	},
 /turf/open/floor/wood,
 /area/security/brig)
-"hwb" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "hwG" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
@@ -16204,13 +16223,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"hSe" = (
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "hSQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -16234,19 +16246,27 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/hallway/secondary/service)
-"ibL" = (
-/obj/effect/turf_decal/stripes/line{
+"hZz" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/chair/stool,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "icY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -16288,11 +16308,22 @@
 /area/hydroponics)
 "iop" = (
 /obj/effect/turf_decal/monke/siding/green,
-/obj/machinery/door/window/southright{
-	req_access_txt = "39"
+/obj/structure/window/reinforced,
+/obj/effect/landmark/blobstart,
+/mob/living/carbon/monkey,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/ameridiner,
+/area/medical/virology)
+"ioy" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/shower{
+	pixel_y = 12
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/noslip/white,
 /area/medical/virology)
 "ipf" = (
 /obj/effect/turf_decal/stripes/line,
@@ -16411,6 +16442,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"iyd" = (
+/obj/structure/closet/l3closet,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_x = 1
+	},
+/turf/open/floor/noslip/white,
+/area/medical/virology)
 "izU" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/structure/cable/yellow{
@@ -16511,25 +16553,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"iOi" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/machinery/door/window/eastleft{
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "iPG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -16562,35 +16585,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"iSA" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = -4;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "iTP" = (
 /obj/structure/closet/radiation,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/engine/storage)
-"iTX" = (
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/virology)
 "iUF" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -16659,6 +16658,15 @@
 	},
 /turf/open/openspace,
 /area/maintenance/central)
+"jdX" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
 "jeU" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -16682,6 +16690,21 @@
 	},
 /turf/open/openspace,
 /area/maintenance/central)
+"jhe" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-5"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "jhh" = (
 /obj/structure/sink{
 	dir = 4;
@@ -16830,16 +16853,12 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plasteel,
 /area/engine/storage)
-"jys" = (
-/obj/effect/spawner/structure/window/reinforced,
+"jzX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/central)
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "jAv" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
@@ -16861,15 +16880,6 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/storage)
-"jEh" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "jEl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
@@ -16892,6 +16902,16 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/science/research)
+"jHg" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/monke/siding/thinplating/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "jHN" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -16904,21 +16924,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"jKU" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-5"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
 "jMp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -16926,16 +16931,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"jNk" = (
-/obj/structure/table,
-/obj/structure/reagent_dispensers/virusfood{
-	pixel_x = 30
-	},
-/obj/item/clothing/gloves/color/latex,
-/obj/item/healthanalyzer,
-/obj/item/clothing/glasses/hud/health,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "jNW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/lattice/catwalk,
@@ -16970,6 +16965,11 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jTe" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "jUl" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable/yellow{
@@ -17097,9 +17097,6 @@
 /obj/machinery/door/window/westleft,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"kmx" = (
-/turf/closed/wall,
-/area/medical/virology)
 "kmK" = (
 /obj/machinery/door/airlock/engineering,
 /obj/machinery/door/firedoor/heavy,
@@ -17146,40 +17143,6 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/hallway/secondary/service)
-"koz" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/effect/landmark/start/geneticist,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
-"koZ" = (
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
-"kpg" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"kpz" = (
-/obj/machinery/iv_drip,
-/obj/structure/bed/roller,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "kre" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/railing/corner{
@@ -17218,13 +17181,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
-"ktV" = (
-/turf/closed/wall,
-/area/medical/genetics)
-"kxx" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "kxP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -17241,31 +17197,21 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"kyR" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/south{
-	pixel_x = 1
-	},
+"kEw" = (
 /obj/structure/cable/yellow{
-	icon_state = "0-9"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
-"kDW" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/monke/siding/blue{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/railing{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "kFC" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -17277,14 +17223,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/vault,
 /turf/open/floor/plating,
 /area/security/nuke_storage)
-"kHt" = (
-/obj/machinery/stasis,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "kJd" = (
 /obj/structure/cable/yellow{
 	icon_state = "5-8"
@@ -17313,6 +17251,11 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
+"kPi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "kPo" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L9"
@@ -17387,12 +17330,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/vault,
 /turf/open/floor/plating,
 /area/security/nuke_storage)
-"kZx" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+"kYZ" = (
+/obj/machinery/computer/cloning{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
 "laF" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/monke/siding/thinplating/dark{
@@ -17430,24 +17374,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
-"lcJ" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/infections{
-	pixel_y = 7;
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/syringe/antiviral,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"ldb" = (
-/obj/machinery/clonepod/prefilled,
-/turf/open/floor/plasteel/dark,
-/area/medical/genetics)
 "ldx" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -17462,16 +17388,6 @@
 /obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ldZ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/firealarm/directional/east,
-/turf/open/openspace,
-/area/maintenance/central/secondary)
 "lgc" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -17486,17 +17402,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"lhZ" = (
-/obj/structure/closet/l3closet,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/power/apc/auto_name/south{
-	pixel_x = 1
-	},
-/turf/open/floor/noslip/white,
-/area/medical/virology)
 "lku" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -17505,6 +17410,16 @@
 /obj/effect/landmark/start/research_director,
 /turf/open/floor/plasteel,
 /area/science/lab)
+"lkD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
 "lmf" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/cable/yellow{
@@ -17525,15 +17440,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"lvJ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+"luv" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "lwA" = (
 /obj/structure/table/glass,
 /obj/machinery/recharger,
@@ -17629,6 +17543,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"lQf" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/firealarm/directional/east,
+/turf/open/openspace,
+/area/maintenance/central/secondary)
 "lQJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/caution/stand_clear{
@@ -17657,6 +17581,19 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft/secondary)
+"lUy" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "lWB" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -17680,22 +17617,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"lZT" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/openspace,
-/area/maintenance/central/secondary)
 "mbN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -17712,22 +17633,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
-"mep" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Cloning";
-	req_access_txt = "5; 68"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "meW" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -17737,6 +17642,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/openspace,
 /area/maintenance/central)
+"mgj" = (
+/obj/effect/turf_decal/tile/blue/tile_marquee{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/obj/machinery/iv_drip,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "miy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -17771,15 +17687,18 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mvH" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+"mwX" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "myI" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -17793,9 +17712,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"myK" = (
-/turf/closed/wall,
-/area/medical/medbay/balcony)
 "myQ" = (
 /mob/living/simple_animal/bot/secbot{
 	arrest_type = 1;
@@ -17811,6 +17727,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"mBe" = (
+/obj/machinery/dna_scannernew,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
+"mCu" = (
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "mDF" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -17821,24 +17751,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/storage)
-"mFy" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/monke/siding/thinplating/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
-"mKi" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "mNs" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -17846,27 +17758,34 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/miningdock)
-"mTg" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+"mVC" = (
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_exterior";
+	name = "Virology Exterior Airlock";
+	req_access_txt = "39"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/doorButtons/access_button{
+	idDoor = "virology_airlock_exterior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	req_access_txt = "39";
+	pixel_y = 24;
+	pixel_x = 6
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
-"mUA" = (
-/obj/effect/turf_decal/tile/blue/tile_marquee,
-/obj/effect/turf_decal/tile/neutral/tile_marquee{
-	dir = 1
-	},
-/obj/effect/landmark/start/emt,
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
+/area/medical/virology)
 "mWJ" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -17897,6 +17816,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"nbU" = (
+/turf/closed/wall/r_wall,
+/area/medical/virology)
 "ncn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -17904,6 +17826,27 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"ndP" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
+"neN" = (
+/obj/structure/table,
+/obj/item/storage/box/beakers{
+	pixel_y = 2
+	},
+/obj/item/storage/box/syringes{
+	pixel_x = -3
+	},
+/obj/machinery/reagentgrinder{
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"nfK" = (
+/turf/closed/wall/r_wall,
+/area/medical/sleeper)
 "ngo" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -17922,19 +17865,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"ngZ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "nnW" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -17963,6 +17893,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"npe" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "nrD" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -18010,16 +17957,19 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"nFN" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
+"nFT" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Cloning";
+	req_access_txt = "5; 68"
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -18068,29 +18018,6 @@
 	},
 /turf/open/openspace,
 /area/maintenance/central/secondary)
-"nKC" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
-"nKW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "nMP" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -18114,18 +18041,6 @@
 /obj/machinery/atmospherics/pipe/multiz/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft/secondary)
-"nTK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "nVh" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -18137,16 +18052,6 @@
 	},
 /turf/open/openspace,
 /area/maintenance/starboard/aft/secondary)
-"nVN" = (
-/obj/effect/turf_decal/tile/blue/tile_marquee{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/tile_marquee,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "nWu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -18181,19 +18086,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"nZW" = (
-/mob/living/simple_animal/pet/hamster/vector,
-/obj/effect/turf_decal/tile/green/tile_marquee{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "oak" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/multiz/layer4,
 /obj/machinery/atmospherics/pipe/multiz/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"obD" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-10"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
+"ocp" = (
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/sleeper)
 "oej" = (
 /obj/structure/chair{
 	dir = 8
@@ -18214,36 +18132,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/openspace,
 /area/maintenance/fore)
-"ofB" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
-"ogd" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-9"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "ogk" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -18257,6 +18145,26 @@
 /obj/machinery/advanced_airlock_controller/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"oiq" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -4;
+	pixel_y = 9
+	},
+/obj/item/wrench/medical,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "oiV" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -18271,6 +18179,10 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ojb" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "okZ" = (
 /obj/effect/turf_decal/monke/siding/white/corner{
 	dir = 4
@@ -18284,6 +18196,24 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"olb" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "onr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/caution/stand_clear{
@@ -18313,6 +18243,12 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"opI" = (
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
 "orI" = (
 /obj/structure/chair/pew/right,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -18395,18 +18331,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"oAq" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "oBG" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -18475,14 +18399,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/airless,
 /area/space/nearstation)
-"oEv" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/shower{
-	pixel_y = 12
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/noslip/white,
-/area/medical/virology)
 "oFh" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/multiz,
@@ -18589,6 +18505,14 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"oTB" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/disposalpipe/trunk,
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/turf/open/openspace/airless,
+/area/space/nearstation)
 "oUu" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -18615,6 +18539,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
+"oVB" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/monke/siding/thinplating/light{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
+"oVF" = (
+/obj/machinery/iv_drip,
+/obj/structure/bed/roller,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "oWT" = (
 /obj/machinery/vendor/exploration,
 /obj/effect/turf_decal/tile/green{
@@ -18637,26 +18579,14 @@
 	},
 /turf/open/openspace,
 /area/maintenance/starboard/aft/secondary)
-"pai" = (
-/obj/effect/turf_decal/tile/blue/tile_marquee,
-/obj/effect/turf_decal/tile/neutral/tile_marquee{
+"peL" = (
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/virologist,
+/obj/effect/turf_decal/tile/green/tile_marquee{
 	dir = 1
 	},
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
-"pdK" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "pfe" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -18704,14 +18634,6 @@
 	},
 /turf/open/floor/engine/airless/light,
 /area/space/nearstation)
-"pop" = (
-/obj/machinery/vending/wardrobe/viro_wardrobe,
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "pse" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -18749,8 +18671,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"pyC" = (
-/turf/closed/wall/r_wall,
+"pyu" = (
+/obj/machinery/vending/wardrobe/viro_wardrobe,
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "pzf" = (
 /obj/structure/lattice/catwalk,
@@ -18858,13 +18785,6 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"pTo" = (
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "pUO" = (
 /obj/effect/turf_decal/loading_area,
 /obj/structure/cable/yellow{
@@ -18878,13 +18798,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"pVz" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
 "pVL" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -18917,22 +18830,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"pYW" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
+"qbc" = (
+/turf/closed/wall,
+/area/medical/genetics)
 "qbM" = (
 /obj/structure/chair/pew/left,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -18940,6 +18840,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
+"qcr" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/medical/sleeper)
 "qdf" = (
 /obj/structure/dresser,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -18957,6 +18861,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"qgQ" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "qhU" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -18969,13 +18883,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"qiL" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "qjN" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -19056,6 +18963,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/ai_monitored/turret_protected/ai_upload)
+"qwJ" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/openspace,
+/area/maintenance/central/secondary)
+"qxr" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/medical/sleeper)
 "qAg" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -19067,6 +18982,9 @@
 	},
 /turf/open/openspace,
 /area/maintenance/starboard/aft/secondary)
+"qCY" = (
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/virology)
 "qEv" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/monke/siding/thinplating{
@@ -19175,15 +19093,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/airless,
 /area/space/nearstation)
-"rhE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "rjK" = (
 /obj/effect/landmark/start/cook,
 /obj/structure/cable/yellow{
@@ -19235,6 +19144,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"rro" = (
+/obj/machinery/clonepod/prefilled,
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
 "rrQ" = (
 /obj/machinery/holopad,
 /obj/structure/cable/yellow{
@@ -19248,27 +19161,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"rsn" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/brute{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/brute,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/machinery/door/window/northright{
-	name = "First-Aid Supplies";
-	red_alert_access = 1;
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "ruo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -19281,15 +19173,19 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "rwl" = (
-/obj/effect/turf_decal/monke/siding/green,
-/obj/structure/window/reinforced,
-/obj/effect/landmark/blobstart,
-/mob/living/carbon/monkey,
 /obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-9"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/ameridiner,
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "rwP" = (
 /obj/effect/landmark/start/cook,
@@ -19298,6 +19194,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"rxJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "rAU" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -19358,10 +19260,6 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"rMA" = (
-/obj/machinery/vending/wardrobe/gene_wardrobe,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "rNA" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -19464,6 +19362,17 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"rUZ" = (
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "rVK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -19484,10 +19393,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
-"rXG" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/medical/sleeper)
 "rXP" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -19499,6 +19404,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/research)
+"rZA" = (
+/obj/structure/closet/l3closet,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/noslip/white,
+/area/medical/virology)
 "rZE" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -19624,6 +19540,14 @@
 	dir = 4
 	},
 /area/ai_monitored/turret_protected/ai_upload)
+"soh" = (
+/obj/effect/turf_decal/tile/blue/tile_marquee,
+/obj/effect/turf_decal/tile/neutral/tile_marquee{
+	dir = 1
+	},
+/obj/effect/landmark/start/emt,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "sow" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -19646,6 +19570,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/research)
+"squ" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/effect/landmark/start/geneticist,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "sqS" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -19685,6 +19616,13 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/storage)
+"stM" = (
+/mob/living/simple_animal/pet/hamster/vector,
+/obj/effect/turf_decal/tile/green/tile_marquee{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "suQ" = (
 /obj/structure/railing{
 	dir = 8
@@ -19695,25 +19633,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/library)
-"suS" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/monke/siding/blue/corner{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
 "svm" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
@@ -19727,6 +19646,12 @@
 	},
 /turf/open/floor/mineral/plastitanium/airless,
 /area/space/nearstation)
+"svM" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "swN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -19771,6 +19696,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"sEm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "sEp" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -19875,32 +19809,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"sXA" = (
-/obj/effect/turf_decal/tile/green,
-/obj/structure/cable/yellow{
-	icon_state = "6-8"
+"teY" = (
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "virology_airlock_exterior";
+	idInterior = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Console";
+	pixel_x = -24;
+	req_access_txt = "39"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"taE" = (
-/obj/machinery/vending/wallmed{
-	pixel_x = 24
-	},
-/obj/machinery/rnd/production/techfab/department/medical,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
 "tfx" = (
 /obj/effect/turf_decal/trimline/blue/warning,
 /obj/machinery/holopad,
@@ -19949,10 +19869,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"thZ" = (
-/obj/machinery/firealarm/directional/south,
-/turf/open/openspace,
-/area/maintenance/central/secondary)
 "tix" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
@@ -19969,6 +19885,27 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit)
+"tkj" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/brute{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/machinery/door/window/northright{
+	name = "First-Aid Supplies";
+	red_alert_access = 1;
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "tlI" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -20086,6 +20023,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"tzs" = (
+/obj/machinery/vending/wardrobe/gene_wardrobe,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "tzP" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -20097,6 +20038,13 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"tBj" = (
+/obj/machinery/smartfridge/organ,
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/sleeper)
 "tDt" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -20124,6 +20072,12 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/maintenance/central/secondary)
+"tFc" = (
+/obj/machinery/computer/scan_consolenew{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "tHV" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/start/botanist,
@@ -20205,6 +20159,38 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"tMy" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
+"tNI" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/monke/siding/blue/corner{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "tPt" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -20221,10 +20207,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
-"tQO" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "tSm" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -20266,26 +20248,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plasteel,
 /area/security/main)
-"tVa" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 14
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -4;
-	pixel_y = 9
-	},
-/obj/item/wrench/medical,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "tYX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -20350,10 +20312,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"unh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/genetics)
 "unv" = (
 /obj/effect/turf_decal/tile/bar/tile_marquee,
 /obj/structure/cable/yellow{
@@ -20380,18 +20338,17 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/security/nuke_storage)
-"urk" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
+"usY" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/monke/siding/blue{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/structure/railing{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "utc" = (
 /obj/machinery/vending/snack/random,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -20418,6 +20375,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"uvu" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/openspace,
+/area/maintenance/central/secondary)
 "uwi" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -20500,6 +20473,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
+"uNf" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/south{
+	pixel_x = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-9"
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "uTz" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -20580,6 +20565,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"vbu" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "vcv" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L13"
@@ -20598,10 +20588,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"vdA" = (
-/obj/effect/spawner/structure/window/reinforced,
+"vdB" = (
+/obj/machinery/vending/wallmed{
+	pixel_x = 24
+	},
+/obj/machinery/rnd/production/techfab/department/medical,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
+"vff" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/medical/virology)
+/area/maintenance/central/secondary)
 "vgI" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -20615,6 +20623,14 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"vhp" = (
+/obj/effect/turf_decal/monke/siding/green,
+/obj/machinery/door/window/southright{
+	req_access_txt = "39"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/virology)
 "vhH" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -20633,14 +20649,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"vkw" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/virologist,
-/obj/effect/turf_decal/tile/green/tile_marquee{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "vlp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -20664,17 +20672,15 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main)
-"vtD" = (
-/obj/machinery/shower{
-	pixel_y = 12
-	},
-/turf/open/floor/noslip/dark,
-/area/medical/genetics)
 "vuf" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"vwc" = (
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "vwT" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -20690,13 +20696,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/storage)
-"vya" = (
-/obj/machinery/computer/cloning{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/medical/genetics)
 "vyp" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/effect/turf_decal/stripes/line,
@@ -20707,6 +20706,28 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vzi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
+"vzj" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "vzD" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -20729,6 +20750,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"vCb" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "vFn" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -20746,18 +20780,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"vFU" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
 "vHq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/caution/stand_clear{
@@ -20775,19 +20797,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
-"vMm" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/obj/item/radio/intercom{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "vMI" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -20808,34 +20817,18 @@
 /obj/item/reagent_containers/blood/OPlus,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"vNq" = (
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_exterior";
-	name = "Virology Exterior Airlock";
-	req_access_txt = "39"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/doorButtons/access_button{
-	idDoor = "virology_airlock_exterior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	req_access_txt = "39";
-	pixel_y = 24;
-	pixel_x = 6
-	},
+"vNB" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
-/area/medical/virology)
+/area/medical/medbay/balcony)
 "vOz" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
@@ -20845,6 +20838,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"vQT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "vQV" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -20864,6 +20864,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/wood,
 /area/library)
+"vUC" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "vWE" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -20932,12 +20936,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/storage)
-"weh" = (
-/obj/machinery/computer/scan_consolenew{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "weF" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -20957,6 +20955,29 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark/side,
 /area/ai_monitored/security/armory)
+"weO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/genetics)
+"wfs" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/machinery/door/window/eastleft{
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "wfM" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/structure/cable/yellow{
@@ -20973,10 +20994,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"whs" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "wix" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -20994,7 +21011,7 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"wmN" = (
+"wmZ" = (
 /obj/vehicle/ridden/wheelchair,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/cobweb,
@@ -21031,12 +21048,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"wsD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/morgue)
 "wsR" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -21079,17 +21090,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wze" = (
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
+"wzr" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/medical/virology)
 "wBP" = (
 /obj/machinery/computer/objective{
 	dir = 8
@@ -21103,32 +21107,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
-"wCL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+"wCr" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/hallway/primary/central)
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "wDK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/library/lounge)
-"wDY" = (
-/obj/structure/table/optable,
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 1
-	},
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = -28
-	},
-/turf/open/floor/noslip/dark,
-/area/medical/sleeper)
 "wEa" = (
 /obj/machinery/firealarm/directional/east,
 /obj/item/kirbyplants/random,
@@ -21187,18 +21184,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"wPj" = (
-/obj/machinery/doorButtons/airlock_controller{
-	idExterior = "virology_airlock_exterior";
-	idInterior = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Console";
-	pixel_x = -24;
-	req_access_txt = "39"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "wUb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/tile/red,
@@ -21207,22 +21192,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/research)
-"wVn" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "wVS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -21231,6 +21200,15 @@
 	dir = 8
 	},
 /area/ai_monitored/turret_protected/ai_upload)
+"wVZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/primary/central)
 "wWu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -21242,6 +21220,19 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"wYV" = (
+/obj/effect/turf_decal/tile/green,
+/obj/structure/cable/yellow{
+	icon_state = "6-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "wZN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -21272,11 +21263,46 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/security/nuke_storage)
-"xfs" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
+"xfZ" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
+"xhc" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "xhh" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -21288,17 +21314,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"xhE" = (
-/obj/effect/turf_decal/tile/blue/tile_marquee{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/tile_marquee,
-/obj/machinery/iv_drip,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "xic" = (
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -21336,19 +21351,6 @@
 	dir = 8
 	},
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"xmX" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "xnb" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -21373,12 +21375,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
-"xnF" = (
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "xoy" = (
 /obj/machinery/door/airlock/maintenance/external,
 /obj/structure/cable/yellow{
@@ -21439,6 +21435,21 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"xwf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "xwq" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -21462,17 +21473,6 @@
 	dir = 4
 	},
 /area/ai_monitored/turret_protected/ai_upload)
-"xzt" = (
-/obj/structure/closet/l3closet,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/noslip/white,
-/area/medical/virology)
 "xAM" = (
 /obj/structure/table/wood,
 /obj/item/toy/figure/syndie{
@@ -21612,6 +21612,18 @@
 /obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
+"xJn" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
+"xKp" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "xKW" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -21698,19 +21710,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"xZI" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/monke/siding/thinplating/light{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
+"xZv" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "yas" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -21739,11 +21744,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"yda" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/medical/virology)
 "yeI" = (
 /obj/effect/turf_decal/tile/bar/tile_marquee,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -56606,7 +56606,7 @@ sdW
 gPD
 hNN
 edh
-kpg
+kEw
 axZ
 wwk
 sgi
@@ -57120,7 +57120,7 @@ avX
 avX
 adV
 aIu
-jys
+lkD
 dxg
 dxg
 dwI
@@ -57634,7 +57634,7 @@ aLu
 aNg
 aWm
 acg
-wCL
+wVZ
 aTY
 aTY
 aTY
@@ -57885,7 +57885,7 @@ aEv
 aFL
 aLu
 aqb
-avk
+vQT
 aXC
 aLB
 aIv
@@ -58145,9 +58145,9 @@ auJ
 aJx
 aQk
 aLu
-mvH
+jdX
 aCE
-xnF
+opI
 ovj
 aVH
 aLg
@@ -58399,7 +58399,7 @@ avE
 avE
 aHL
 aIP
-wsD
+rxJ
 aEJ
 aLu
 aNr
@@ -58924,7 +58924,7 @@ aGL
 aum
 aZi
 aZT
-gAK
+luv
 aCj
 aaB
 aaB
@@ -121891,7 +121891,7 @@ aaD
 aaD
 aVX
 pfe
-thZ
+qwJ
 ajR
 ajR
 aHA
@@ -122135,9 +122135,9 @@ aOH
 kmc
 aTv
 gKP
-lZT
+uvu
 bOm
-ldZ
+lQf
 bOm
 bOm
 bOm
@@ -122391,22 +122391,22 @@ agb
 iqd
 ipz
 aTv
-hSe
-nKW
+cXw
+xwf
 aKd
 aTv
-ibL
-nTK
-nTK
+wCr
+mwX
+mwX
 aTv
 aTv
 aTv
 aTv
 aTv
 aTv
-cHf
-ccA
-btX
+qgQ
+vzi
+vff
 iHz
 tuZ
 fCL
@@ -122648,7 +122648,7 @@ afB
 xHV
 kJd
 aTv
-cPK
+vbu
 xOb
 aWE
 aTv
@@ -122656,10 +122656,10 @@ aaD
 aaD
 aaD
 aTv
-ldb
-vya
-bym
-weh
+rro
+kYZ
+mBe
+tFc
 aTv
 aTv
 aTv
@@ -122907,19 +122907,19 @@ aFs
 ajR
 ajR
 aTv
-ofB
+vzj
 aTv
 aTv
 aTv
 aTv
 aTv
-vtD
-fyJ
-dul
-koz
-doP
+dmN
+ndP
+jzX
+squ
+deh
 aTv
-whs
+fzA
 avv
 dyY
 aTv
@@ -123163,20 +123163,20 @@ opB
 adD
 aUd
 ajR
-wmN
+wmZ
 dyY
 rbn
 aTv
 aCX
 aCX
-myK
-unh
-ktV
-nFN
-pTo
-rMA
+eXJ
+weO
+qbc
+vCb
+avk
+tzs
 aTv
-tQO
+ojb
 avv
 dyY
 aTv
@@ -123420,18 +123420,18 @@ agg
 adD
 aUd
 ajR
-gif
-ngZ
-kpz
+amT
+cTN
+oVF
 aTv
 aCX
 aCX
-xmX
-tVa
-ktV
-mep
-ktV
-unh
+lUy
+oiq
+qbc
+nFT
+qbc
+weO
 aTv
 aTv
 aTv
@@ -123678,18 +123678,18 @@ aFs
 aUd
 ajR
 aTv
-ngZ
-xfs
+cTN
+kPi
 aTv
 aCX
 aCX
-hwb
-eIa
-pVz
-mTg
-amT
-iOi
-wVn
+usY
+xJn
+xKp
+tMy
+olb
+wfs
+fRR
 aTv
 aEP
 pVL
@@ -123934,19 +123934,19 @@ aFs
 aFs
 aAp
 ajR
-cHh
+dVf
 dyY
-eGB
+jTe
 aTv
 aCX
 aCX
-kDW
-gLj
-jKU
-fVY
-vFU
-koZ
-rsn
+coC
+fKc
+jhe
+npe
+vNB
+mCu
+tkj
 aTv
 aAU
 xcr
@@ -124191,19 +124191,19 @@ arj
 arj
 arj
 ajR
+xZv
 aPU
-oAq
-pdK
+cSg
 att
-wze
-pYW
-suS
-fAK
-taE
-pyC
-vNq
-pyC
-pyC
+rUZ
+xfZ
+tNI
+obD
+vdB
+nbU
+mVC
+nbU
+nbU
 ajR
 aAb
 pVL
@@ -124452,15 +124452,15 @@ ajR
 ajR
 ajR
 ajR
-cUf
-mFy
-xZI
-cUf
-pyC
-pyC
-sXA
-dex
-xzt
+qxr
+jHg
+oVB
+qxr
+nbU
+nbU
+wYV
+fcx
+rZA
 ajR
 aJa
 xcr
@@ -124708,16 +124708,16 @@ arj
 arj
 arj
 arj
-eLm
-jEh
-lvJ
-qiL
-kyR
-pyC
-oEv
-kZx
-ogd
-lhZ
+nfK
+bym
+sEm
+azl
+uNf
+nbU
+ioy
+svM
+rwl
+iyd
 ajR
 agW
 tDu
@@ -124965,16 +124965,16 @@ arj
 arj
 arj
 aAp
-eLm
-nKC
-pai
-nVN
-cfU
-pyC
-vdA
-kmx
-ddb
-kmx
+nfK
+bui
+bLW
+bgV
+tBj
+nbU
+fAZ
+bbs
+fDM
+bbs
 ajR
 ajR
 aIq
@@ -125222,18 +125222,18 @@ arj
 arj
 arj
 aAp
-eLm
-mKi
-xhE
-mUA
-wDY
-pyC
-iTX
-rwl
-rhE
-wPj
-pop
-pyC
+nfK
+gog
+mgj
+soh
+bJx
+nbU
+qCY
+iop
+bzF
+teY
+pyu
+nbU
 aUd
 aUd
 ajR
@@ -125479,18 +125479,18 @@ arj
 arj
 arj
 aAp
-eLm
-kHt
-dyG
-iSA
-urk
-pyC
-ghK
-iop
-kxx
-nZW
-cWy
-pyC
+nfK
+fxo
+xhc
+hZz
+ocp
+nbU
+ggi
+vhp
+vUC
+stM
+vwc
+nbU
 aAp
 aAp
 aAp
@@ -125736,18 +125736,18 @@ arj
 arj
 arj
 aAp
-eLm
-eLm
-rXG
-rXG
-eLm
-pyC
-pyC
-pyC
-vMm
-vkw
-lcJ
-eNN
+nfK
+nfK
+qcr
+qcr
+nfK
+nbU
+nbU
+nbU
+bjO
+peL
+grN
+wzr
 arj
 arj
 arj
@@ -125999,12 +125999,12 @@ aUd
 aAp
 arj
 arj
-eTd
-yda
-bYO
-crt
-jNk
-pyC
+oTB
+fki
+dJU
+neN
+crx
+nbU
 arj
 arj
 arj
@@ -126257,11 +126257,11 @@ aAp
 arj
 arj
 arj
-pyC
-pyC
-eNN
-pyC
-pyC
+nbU
+nbU
+wzr
+nbU
+nbU
 arj
 arj
 arj
@@ -127545,7 +127545,7 @@ arj
 arj
 arj
 arj
-adu
+arj
 arj
 arj
 arj

--- a/_maps/map_files/HoleStation/holestation.dmm
+++ b/_maps/map_files/HoleStation/holestation.dmm
@@ -2713,6 +2713,12 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "akA" = (
@@ -2758,6 +2764,9 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
@@ -3164,6 +3173,12 @@
 /area/engine/atmos)
 "amr" = (
 /obj/structure/chair,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/central)
 "ams" = (
@@ -3181,12 +3196,6 @@
 "amu" = (
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"amv" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "amw" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -3304,12 +3313,12 @@
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
 "amT" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/shower{
-	pixel_y = 12
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/turf/open/floor/noslip/white,
-/area/medical/virology)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "amU" = (
 /obj/machinery/computer/upload/ai{
 	dir = 4
@@ -3758,6 +3767,12 @@
 "aot" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -5082,6 +5097,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "atu" = (
@@ -5333,6 +5350,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/medical/office)
 "auo" = (
@@ -5551,7 +5571,15 @@
 /turf/open/floor/plasteel/dark/airless,
 /area/science/research)
 "avk" = (
-/turf/closed/wall,
+/obj/structure/closet/l3closet,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_x = 1
+	},
+/turf/open/floor/noslip/white,
 /area/medical/virology)
 "avm" = (
 /obj/machinery/door/airlock/grunge{
@@ -6258,10 +6286,6 @@
 	},
 /turf/open/floor/grass,
 /area/crew_quarters/dorms)
-"axP" = (
-/obj/machinery/smartfridge/chemistry/virology/preloaded,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "axT" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
@@ -6623,6 +6647,12 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
@@ -7387,6 +7417,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "aCF" = (
@@ -7766,6 +7802,10 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/heater,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"aEf" = (
+/obj/vehicle/ridden/wheelchair,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "aEh" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -8965,6 +9005,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "aIw" = (
@@ -9238,6 +9282,9 @@
 "aJx" = (
 /obj/effect/landmark/start/chaplain,
 /obj/effect/turf_decal/tile/blue/tile_full,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "aJy" = (
@@ -9385,8 +9432,15 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen/coldroom)
 "aKd" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
@@ -9734,6 +9788,8 @@
 	req_access_txt = "6"
 	},
 /obj/effect/turf_decal/monke/siding/thinplating/light,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "aLC" = (
@@ -10220,6 +10276,7 @@
 /obj/machinery/camera/autoname{
 	dir = 6
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "aNC" = (
@@ -10709,6 +10766,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "aPm" = (
@@ -10729,6 +10792,12 @@
 /obj/effect/landmark/start/chief_medical_officer,
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
@@ -10857,6 +10926,9 @@
 /mob/living/simple_animal/pet/cat/Runtime,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
@@ -12280,6 +12352,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "aUv" = (
@@ -12869,6 +12944,12 @@
 /obj/machinery/power/apc/auto_name/south{
 	pixel_x = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "aWD" = (
@@ -12878,6 +12959,12 @@
 "aWE" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-9"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
@@ -13085,6 +13172,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/medical/office)
 "aXy" = (
@@ -13108,6 +13198,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "aXD" = (
@@ -13607,11 +13699,18 @@
 /obj/effect/turf_decal/monke/siding/thinplating/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/medical/office)
 "aZi" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/chemist,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/medical/office)
 "aZj" = (
@@ -13769,6 +13868,8 @@
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/southleft,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/medical/office)
 "aZU" = (
@@ -13869,10 +13970,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
-"bkd" = (
-/obj/vehicle/ridden/wheelchair,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "bll" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -13904,13 +14001,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bni" = (
-/obj/effect/turf_decal/monke/siding/green,
-/obj/machinery/door/window/southright{
-	req_access_txt = "39"
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/virology)
 "bqt" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -13976,13 +14066,51 @@
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/miningdock)
 "bym" = (
-/obj/structure/table,
-/obj/structure/reagent_dispensers/virusfood{
-	pixel_x = 30
+/obj/structure/chair/office/light{
+	dir = 8
 	},
-/obj/item/clothing/gloves/color/latex,
-/obj/item/healthanalyzer,
-/obj/item/clothing/glasses/hud/health,
+/obj/effect/landmark/start/geneticist,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
+"bAD" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"bBi" = (
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_exterior";
+	name = "Virology Exterior Airlock";
+	req_access_txt = "39"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/doorButtons/access_button{
+	idDoor = "virology_airlock_exterior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	req_access_txt = "39";
+	pixel_y = 24;
+	pixel_x = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bBE" = (
@@ -14007,6 +14135,13 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"bFu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "bGl" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -14047,18 +14182,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
-"bMu" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/openspace,
-/area/maintenance/central/secondary)
 "bOa" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -14162,6 +14285,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"bZa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
+"bZA" = (
+/obj/effect/turf_decal/tile/blue/tile_marquee,
+/obj/effect/turf_decal/tile/neutral/tile_marquee{
+	dir = 1
+	},
+/obj/effect/landmark/start/emt,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "caf" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -14170,9 +14306,26 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"cfs" = (
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/virology)
+"cgk" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -4;
+	pixel_y = 9
+	},
+/obj/item/wrench/medical,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "chn" = (
 /obj/machinery/light{
 	dir = 4
@@ -14185,10 +14338,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"chJ" = (
-/obj/machinery/vending/wardrobe/gene_wardrobe,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "chX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -14232,17 +14381,6 @@
 	},
 /turf/open/openspace,
 /area/maintenance/port/aft)
-"ckt" = (
-/obj/machinery/doorButtons/airlock_controller{
-	idExterior = "virology_airlock_exterior";
-	idInterior = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Console";
-	pixel_x = -24;
-	req_access_txt = "39"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "ckA" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -14276,6 +14414,14 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"cur" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-10"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "cvf" = (
 /obj/machinery/door/airlock/silver,
 /obj/structure/cable/yellow{
@@ -14295,13 +14441,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"cvu" = (
-/obj/effect/turf_decal/tile/blue/tile_marquee{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/tile_marquee,
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "cvH" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -14379,6 +14518,11 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"cJw" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "cNb" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/firealarm/directional/north,
@@ -14393,12 +14537,6 @@
 	},
 /turf/open/openspace,
 /area/maintenance/central)
-"cNk" = (
-/obj/vehicle/ridden/wheelchair,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "cNA" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -14474,6 +14612,15 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"dcg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "ddh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -14504,6 +14651,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"dgM" = (
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/virologist,
+/obj/effect/turf_decal/tile/green/tile_marquee{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "dhm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14528,26 +14683,10 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"dhQ" = (
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
+"dic" = (
+/obj/machinery/vending/wardrobe/gene_wardrobe,
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
-"diA" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
+/area/medical/genetics)
 "dka" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -14583,6 +14722,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/research)
+"dsZ" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/medical/virology)
 "dtM" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -14607,6 +14750,18 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"duf" = (
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "virology_airlock_exterior";
+	idInterior = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Console";
+	pixel_x = -24;
+	req_access_txt = "39"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "dwI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -14629,17 +14784,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"dzz" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/monke/siding/thinplating/light{
-	dir = 8
+"dAt" = (
+/obj/structure/table/optable,
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 1
 	},
-/turf/open/floor/plasteel/ameridiner,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -28
+	},
+/turf/open/floor/noslip/dark,
 /area/medical/sleeper)
-"dAr" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/medical/genetics)
 "dCe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -14718,10 +14873,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
-"dRI" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/medical/sleeper)
 "dTx" = (
 /obj/machinery/light{
 	dir = 1
@@ -14757,6 +14908,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"dWy" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/brute{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/machinery/door/window/northright{
+	name = "First-Aid Supplies";
+	red_alert_access = 1;
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "dZb" = (
 /obj/structure/table,
 /obj/item/storage/bag/tray,
@@ -14797,6 +14969,25 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/miningdock)
+"dZI" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/machinery/door/window/eastleft{
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "ecX" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -14863,14 +15054,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"ejk" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/disposalpipe/trunk,
-/obj/structure/disposaloutlet{
-	dir = 1
-	},
-/turf/open/openspace/airless,
-/area/space/nearstation)
 "ekG" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/cable/yellow{
@@ -14913,6 +15096,17 @@
 	},
 /turf/open/openspace,
 /area/maintenance/central)
+"eph" = (
+/obj/effect/turf_decal/monke/siding/green,
+/obj/structure/window/reinforced,
+/obj/effect/landmark/blobstart,
+/mob/living/carbon/monkey,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/virology)
 "epL" = (
 /obj/effect/turf_decal/tile/bar/tile_marquee,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -14921,15 +15115,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/lounge)
-"epU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "erX" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -15025,24 +15210,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/library/lounge)
-"ezJ" = (
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_interior";
-	name = "Virology Interior Airlock";
-	req_access_txt = "39"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/doorButtons/access_button{
-	idDoor = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_y = 24;
-	req_access_txt = "39"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "ezN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -15051,6 +15218,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"eBr" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "eCa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -15167,49 +15341,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"eZl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
-"eZv" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
-"fam" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = -7;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 7;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = -4;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "faO" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -15220,15 +15351,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fdB" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
 "fdI" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
@@ -15284,6 +15406,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fjs" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "fkJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -15330,6 +15457,16 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"ftn" = (
+/obj/machinery/dna_scannernew,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
+"fuI" = (
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/virology)
 "fvt" = (
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/tile/bar/tile_marquee,
@@ -15356,13 +15493,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fxG" = (
-/obj/machinery/computer/cloning{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/medical/genetics)
 "fAJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -15427,6 +15557,18 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
+"fFH" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "fHt" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
@@ -15544,10 +15686,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"fWG" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/medical/virology)
 "fXs" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -15560,6 +15698,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"fXK" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "gad" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -15631,16 +15778,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"gkY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/genetics)
 "gmh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"gnF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/primary/central)
 "goZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -15665,6 +15817,13 @@
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
+"guM" = (
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "gvS" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -15719,6 +15878,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/library)
+"gHN" = (
+/obj/effect/turf_decal/tile/blue/tile_marquee{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/obj/machinery/iv_drip,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "gJA" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -15811,10 +15981,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"gPH" = (
-/obj/machinery/firealarm/directional/south,
-/turf/open/openspace,
-/area/maintenance/central/secondary)
 "gRj" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -15833,13 +15999,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet)
-"gVk" = (
-/obj/machinery/vending/wallmed{
-	pixel_x = 24
-	},
-/obj/machinery/rnd/production/techfab/department/medical,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
 "gZR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -15881,27 +16040,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hja" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/brute{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/brute,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/machinery/door/window/northright{
-	name = "First-Aid Supplies";
-	red_alert_access = 1;
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "hjk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -15919,18 +16057,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet)
-"hpz" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
-"hqi" = (
-/obj/machinery/computer/scan_consolenew{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "htx" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -15943,6 +16069,10 @@
 	},
 /turf/open/floor/wood,
 /area/security/brig)
+"htB" = (
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "hwG" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
@@ -15976,6 +16106,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
+"hCd" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/disposalpipe/trunk,
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/turf/open/openspace/airless,
+/area/space/nearstation)
+"hCT" = (
+/turf/closed/wall/r_wall,
+/area/medical/virology)
 "hEQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -15983,14 +16124,17 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"hEY" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 24
+"hGv" = (
+/obj/machinery/computer/pandemic,
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "hHr" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -16035,6 +16179,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"hMw" = (
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/sleeper)
 "hNN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -16067,13 +16223,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hPv" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "hPK" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
@@ -16149,39 +16298,17 @@
 	},
 /turf/open/floor/plating,
 /area/security/nuke_storage)
-"iip" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/obj/machinery/power/apc/auto_name/south{
-	pixel_x = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-9"
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
-"iiM" = (
-/obj/machinery/clonepod/prefilled,
-/turf/open/floor/plasteel/dark,
-/area/medical/genetics)
 "ikV" = (
 /obj/structure/window/reinforced/spawner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"inY" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-5"
+"iop" = (
+/obj/machinery/computer/scan_consolenew{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
-"iop" = (
-/turf/closed/wall/r_wall,
-/area/medical/virology)
+/area/medical/genetics)
 "ipf" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
@@ -16252,6 +16379,15 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen/coldroom)
+"iul" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "ivd" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -16382,6 +16518,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"iIB" = (
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
 "iKj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/monke/siding/white{
@@ -16393,26 +16535,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"iLM" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-9"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "iNl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"iNK" = (
-/obj/machinery/iv_drip,
-/obj/structure/bed/roller,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "iPG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -16478,6 +16606,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
+"jcu" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "jcI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -16499,6 +16639,9 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/office)
@@ -16609,9 +16752,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"jpk" = (
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "jqs" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -16714,10 +16854,32 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/science/lab)
-"jEB" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
+"jEm" = (
+/mob/living/carbon/monkey,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/virology)
+"jFM" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/medical/sleeper)
+/area/maintenance/central/secondary)
 "jGi" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -16748,10 +16910,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"jJk" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "jMp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -16793,6 +16951,15 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jTK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "jUl" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable/yellow{
@@ -16862,16 +17029,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"kdP" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Cloning";
-	req_access_txt = "5; 68"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "kdQ" = (
 /obj/effect/turf_decal/monke/siding/thinplating/dark{
 	dir = 4
@@ -16905,28 +17062,13 @@
 	},
 /turf/open/floor/engine/airless/light,
 /area/space/nearstation)
-"kgj" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
+"kfP" = (
+/turf/closed/wall,
+/area/medical/medbay/balcony)
+"kgA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -6;
-	pixel_y = 14
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -4;
-	pixel_y = 9
-	},
-/obj/item/wrench/medical,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
-"kjr" = (
-/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "kjW" = (
@@ -16941,21 +17083,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/storage)
-"kle" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/monke/siding/blue/corner{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
 "kmc" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -16993,11 +17120,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet)
-"knh" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "knW" = (
 /obj/effect/turf_decal/tile/bar/tile_marquee,
 /obj/structure/cable/yellow{
@@ -17052,17 +17174,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ksB" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "ksG" = (
 /obj/machinery/door/airlock/grunge,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"kti" = (
+/obj/machinery/iv_drip,
+/obj/structure/bed/roller,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
+"kwX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "kxP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -17079,6 +17214,12 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"kyJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "kFC" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -17090,6 +17231,14 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/vault,
 /turf/open/floor/plating,
 /area/security/nuke_storage)
+"kFH" = (
+/obj/machinery/stasis,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "kJd" = (
 /obj/structure/cable/yellow{
 	icon_state = "5-8"
@@ -17111,6 +17260,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"kLy" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Cloning";
+	req_access_txt = "5; 68"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "kOD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -17167,6 +17332,36 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"kVu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
+"kVJ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-5"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "kWD" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -17229,11 +17424,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
-"ldt" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/medical/virology)
 "ldx" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -17270,15 +17460,6 @@
 /obj/effect/landmark/start/research_director,
 /turf/open/floor/plasteel,
 /area/science/lab)
-"lkZ" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "lmf" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/cable/yellow{
@@ -17299,32 +17480,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"lnP" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
-"lvm" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/effect/turf_decal/stripes/line,
+"lvS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"lvB" = (
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/autoname,
-/obj/machinery/door/airlock/maintenance_hatch,
+"lvZ" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/firealarm/directional/east,
+/turf/open/openspace,
 /area/maintenance/central/secondary)
 "lwA" = (
 /obj/structure/table/glass,
@@ -17336,12 +17505,41 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"lyC" = (
+/obj/effect/turf_decal/tile/green,
+/obj/structure/cable/yellow{
+	icon_state = "6-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "lyR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/hallway/secondary/entry)
+"lzL" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "lAP" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/structure/cable/yellow{
@@ -17363,16 +17561,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"lFi" = (
-/obj/effect/turf_decal/monke/siding/green,
-/obj/structure/window/reinforced,
-/obj/effect/landmark/blobstart,
-/mob/living/carbon/monkey,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/virology)
 "lFz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/closed/wall/r_wall,
@@ -17471,6 +17659,10 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/miningdock)
+"lXm" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/genetics)
 "lXz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -17541,13 +17733,19 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mrR" = (
-/mob/living/simple_animal/pet/hamster/vector,
-/obj/effect/turf_decal/tile/green/tile_marquee{
-	dir = 1
+"mwo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "myI" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -17576,6 +17774,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"myW" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/monke/siding/thinplating/light{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "mDF" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -17586,6 +17797,20 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/storage)
+"mJr" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"mMW" = (
+/turf/closed/wall/r_wall,
+/area/medical/sleeper)
 "mNs" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -17630,13 +17855,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"ncY" = (
-/obj/machinery/smartfridge/organ,
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
 "ngo" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -17655,16 +17873,26 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"nkv" = (
-/obj/structure/table/optable,
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 1
+"njP" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_y = -28
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/noslip/dark,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
+"nno" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel/ameridiner,
 /area/medical/sleeper)
 "nnW" = (
 /obj/structure/cable/yellow{
@@ -17716,31 +17944,54 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"nyO" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/virologist,
-/obj/effect/turf_decal/tile/green/tile_marquee{
+"nvG" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"nBI" = (
-/turf/closed/wall,
-/area/medical/genetics)
-"nCQ" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/north,
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"nxT" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/infections{
+	pixel_y = 7;
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/syringe/antiviral,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "nDD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/closed/wall,
 /area/hallway/secondary/exit)
+"nEX" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "nEZ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -17760,11 +18011,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"nGx" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "nHG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -17810,14 +18056,6 @@
 	},
 /turf/open/openspace,
 /area/maintenance/central/secondary)
-"nMi" = (
-/obj/effect/turf_decal/tile/blue/tile_marquee,
-/obj/effect/turf_decal/tile/neutral/tile_marquee{
-	dir = 1
-	},
-/obj/effect/landmark/start/emt,
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "nMP" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -17825,9 +18063,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"nOh" = (
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "nOF" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -17838,6 +18073,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/main)
+"nSo" = (
+/obj/structure/table,
+/obj/structure/reagent_dispensers/virusfood{
+	pixel_x = 30
+	},
+/obj/item/clothing/gloves/color/latex,
+/obj/item/healthanalyzer,
+/obj/item/clothing/glasses/hud/health,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "nSD" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/multiz/layer4,
@@ -17855,19 +18100,6 @@
 	},
 /turf/open/openspace,
 /area/maintenance/starboard/aft/secondary)
-"nVu" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "nWu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -17908,6 +18140,19 @@
 /obj/machinery/atmospherics/pipe/multiz/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"obJ" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "oej" = (
 /obj/structure/chair{
 	dir = 8
@@ -17928,6 +18173,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/openspace,
 /area/maintenance/fore)
+"ofO" = (
+/mob/living/simple_animal/pet/hamster/vector,
+/obj/effect/turf_decal/tile/green/tile_marquee{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "ogk" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -17953,6 +18205,14 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ojJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "okZ" = (
@@ -17997,6 +18257,14 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"opL" = (
+/obj/effect/turf_decal/monke/siding/green,
+/obj/machinery/door/window/southright{
+	req_access_txt = "39"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/virology)
 "orI" = (
 /obj/structure/chair/pew/right,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -18039,6 +18307,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "ovj" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "ovO" = (
@@ -18075,17 +18349,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"oBg" = (
-/obj/structure/closet/l3closet,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/power/apc/auto_name/south{
-	pixel_x = 1
-	},
-/turf/open/floor/noslip/white,
-/area/medical/virology)
 "oBG" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -18223,18 +18486,6 @@
 	dir = 4
 	},
 /area/science/research)
-"oOj" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
 "oPB" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -18309,12 +18560,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
-"oZa" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "oZf" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -18326,16 +18571,16 @@
 	},
 /turf/open/openspace,
 /area/maintenance/starboard/aft/secondary)
-"pbc" = (
-/obj/machinery/shower{
-	pixel_y = 12
+"pbe" = (
+/obj/effect/turf_decal/tile/blue/tile_marquee{
+	dir = 1
 	},
-/turf/open/floor/noslip/dark,
-/area/medical/genetics)
-"pej" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "pfe" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -18383,9 +18628,9 @@
 	},
 /turf/open/floor/engine/airless/light,
 /area/space/nearstation)
-"pnW" = (
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel/ameridiner,
+"poj" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
 /area/medical/sleeper)
 "pse" = (
 /obj/effect/turf_decal/tile/blue{
@@ -18424,6 +18669,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"pxz" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "pzf" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -18440,9 +18694,6 @@
 	},
 /turf/open/openspace,
 /area/maintenance/central)
-"pzt" = (
-/turf/closed/wall,
-/area/medical/medbay/balcony)
 "pBm" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
@@ -18468,6 +18719,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/library)
+"pDh" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "pFq" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable/yellow{
@@ -18488,27 +18747,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/nuke_storage)
-"pHj" = (
-/obj/effect/turf_decal/tile/green,
-/obj/structure/cable/yellow{
-	icon_state = "6-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"pIb" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/infections{
-	pixel_y = 7;
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/syringe/antiviral,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "pJi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -18521,6 +18759,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
+"pNT" = (
+/obj/machinery/smartfridge/organ,
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/sleeper)
 "pNV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -18547,16 +18792,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"pQo" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/monke/siding/thinplating/light{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6-8"
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "pQy" = (
 /obj/effect/turf_decal/tile/neutral/tile_marquee,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -18564,25 +18799,6 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"pTk" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/machinery/door/window/eastleft{
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "pUO" = (
 /obj/effect/turf_decal/loading_area,
 /obj/structure/cable/yellow{
@@ -18596,6 +18812,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"pUR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
 "pVL" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -18652,6 +18875,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"qhJ" = (
+/obj/machinery/clonepod/prefilled,
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
 "qhU" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -18721,6 +18948,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
+"qqu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "qry" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable/yellow{
@@ -18755,6 +18991,17 @@
 	},
 /turf/open/openspace,
 /area/maintenance/starboard/aft/secondary)
+"qCM" = (
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "qEv" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/monke/siding/thinplating{
@@ -18802,6 +19049,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"qPu" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/monke/siding/thinplating/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "qQt" = (
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 4
@@ -18827,6 +19084,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"qZs" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
+"qZP" = (
+/turf/closed/wall,
+/area/medical/virology)
 "rao" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -18842,15 +19107,15 @@
 /obj/structure/lattice/catwalk/over,
 /turf/open/floor/plating,
 /area/hallway/primary/central)
+"rbh" = (
+/turf/closed/wall,
+/area/medical/genetics)
 "rbn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/iv_drip,
 /obj/structure/bed/roller,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"rbD" = (
-/turf/closed/wall/r_wall,
-/area/medical/sleeper)
 "rcy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -18866,22 +19131,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/airless,
 /area/space/nearstation)
-"reA" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = 26
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
-"rgx" = (
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "rjK" = (
 /obj/effect/landmark/start/cook,
 /obj/structure/cable/yellow{
@@ -18895,6 +19144,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"rlZ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/openspace,
+/area/maintenance/central/secondary)
 "rno" = (
 /obj/machinery/door/airlock/command,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -18958,14 +19223,28 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "rwl" = (
-/mob/living/carbon/monkey,
-/obj/effect/turf_decal/tile/green{
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_interior";
+	name = "Virology Interior Airlock";
+	req_access_txt = "39"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/doorButtons/access_button{
+	idDoor = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_y = 24;
+	req_access_txt = "39"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/light{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel/ameridiner,
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "rwP" = (
 /obj/effect/landmark/start/cook,
@@ -18987,6 +19266,35 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/hallway/secondary/service)
+"rBB" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
+"rEd" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "rFc" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -18997,12 +19305,6 @@
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel/white,
 /area/medical/office)
-"rGX" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "rIr" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -19142,6 +19444,18 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"rUR" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/south{
+	pixel_x = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-9"
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "rVK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -19156,6 +19470,34 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"rWA" = (
+/obj/effect/turf_decal/tile/blue/tile_marquee,
+/obj/effect/turf_decal/tile/neutral/tile_marquee{
+	dir = 1
+	},
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
+"rWU" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "rXm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -19173,13 +19515,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/research)
-"rZA" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/effect/landmark/start/geneticist,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "rZE" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -19282,21 +19617,6 @@
 	dir = 4
 	},
 /area/hallway/secondary/entry)
-"slz" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
-"slY" = (
-/obj/structure/closet/l3closet,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/open/floor/noslip/white,
-/area/medical/virology)
 "smV" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -19430,16 +19750,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"szQ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/firealarm/directional/east,
-/turf/open/openspace,
-/area/maintenance/central/secondary)
 "sBA" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -19470,6 +19780,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"sIh" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/openspace,
+/area/maintenance/central/secondary)
 "sOh" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -19486,6 +19800,17 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"sQg" = (
+/obj/structure/closet/l3closet,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/noslip/white,
+/area/medical/virology)
 "sQi" = (
 /obj/machinery/door/firedoor,
 /obj/structure/lattice/catwalk,
@@ -19496,18 +19821,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/openspace,
 /area/maintenance/central/secondary)
-"sRz" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
 "sTg" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -19550,6 +19863,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"sWX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/virology)
 "sXf" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -19574,6 +19891,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"tco" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "tfx" = (
 /obj/effect/turf_decal/trimline/blue/warning,
 /obj/machinery/holopad,
@@ -19744,16 +20073,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"txn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "txM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -19776,11 +20095,6 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"tAL" = (
-/obj/machinery/vending/wardrobe/viro_wardrobe,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "tDt" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -19877,24 +20191,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"tLQ" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/o2{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/o2,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner/east,
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "tLX" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/cable/yellow{
@@ -19907,20 +20203,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"tMt" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
-"tMW" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "tPt" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -19937,6 +20219,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
+"tRj" = (
+/obj/machinery/vending/wallmed{
+	pixel_x = 24
+	},
+/obj/machinery/rnd/production/techfab/department/medical,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
+"tRP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "tSm" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -19978,19 +20280,6 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plasteel,
 /area/security/main)
-"tUW" = (
-/obj/structure/table,
-/obj/item/storage/box/beakers{
-	pixel_y = 2
-	},
-/obj/item/storage/box/syringes{
-	pixel_x = -3
-	},
-/obj/machinery/reagentgrinder{
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "tYX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -20008,18 +20297,6 @@
 /obj/machinery/advanced_airlock_controller/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
-"uaj" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/balcony)
-"uaF" = (
-/obj/effect/turf_decal/tile/blue/tile_marquee{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/tile_marquee,
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
 "ucL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -20053,6 +20330,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"uml" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "una" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
@@ -20114,37 +20397,11 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
-"uuo" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/balcony)
 "uut" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"uuy" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "uwi" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -20188,6 +20445,11 @@
 	},
 /turf/open/floor/wood,
 /area/chapel/main)
+"uDf" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "uGl" = (
 /obj/structure/railing{
 	dir = 1
@@ -20206,6 +20468,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"uGS" = (
+/obj/structure/table,
+/obj/item/storage/box/beakers{
+	pixel_y = 2
+	},
+/obj/item/storage/box/syringes{
+	pixel_x = -3
+	},
+/obj/machinery/reagentgrinder{
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "uKr" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -20217,6 +20492,22 @@
 	},
 /turf/open/floor/plating,
 /area/medical/office)
+"uKB" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "uLw" = (
 /obj/machinery/light{
 	dir = 8
@@ -20227,23 +20518,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
-"uTp" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-10"
+"uMJ" = (
+/obj/machinery/light{
+	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/balcony)
-"uTr" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/monke/siding/blue{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
+"uRY" = (
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/medical/medbay/balcony)
+/area/maintenance/central/secondary)
 "uTz" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -20256,6 +20541,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"uTH" = (
+/obj/vehicle/ridden/wheelchair,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "uUR" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -20269,12 +20560,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"uVq" = (
-/obj/machinery/stasis,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+"uVJ" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 8;
+	pixel_y = 6
 	},
-/obj/machinery/firealarm/directional/east,
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/plasteel/ameridiner,
 /area/medical/sleeper)
 "uWm" = (
@@ -20363,6 +20667,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"vgZ" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/medical/virology)
 "vhH" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -20381,6 +20690,14 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"vjx" = (
+/obj/machinery/vending/wardrobe/viro_wardrobe,
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "vlp" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -20388,10 +20705,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"voU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/virology)
 "vsf" = (
 /obj/effect/turf_decal/monke/siding/wood{
 	dir = 4
@@ -20401,28 +20714,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"vsh" = (
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_exterior";
-	name = "Virology Exterior Airlock";
-	req_access_txt = "39"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/doorButtons/access_button{
-	idDoor = "virology_airlock_exterior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	req_access_txt = "39";
-	pixel_y = 24;
-	pixel_x = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "vsI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -20460,6 +20751,30 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vyR" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "vzD" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -20482,41 +20797,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
-"vAL" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/glass/bottle/charcoal{
-	pixel_x = -4;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
-"vAU" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/obj/item/radio/intercom{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"vBI" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "vFn" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -20551,13 +20831,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
-"vHs" = (
-/obj/machinery/dna_scannernew,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "vMI" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -20606,6 +20879,19 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/wood,
 /area/library)
+"vUF" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "vWE" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -20693,6 +20979,26 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark/side,
 /area/ai_monitored/security/armory)
+"weG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/central)
+"wfm" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "wfM" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/structure/cable/yellow{
@@ -20703,6 +21009,14 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/storage)
+"wgB" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/shower{
+	pixel_y = 12
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/noslip/white,
+/area/medical/virology)
 "whi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -20726,6 +21040,10 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"wkV" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/medical/sleeper)
 "wnF" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -20770,11 +21088,6 @@
 /obj/structure/railing/corner,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"wtk" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "wtq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -20804,6 +21117,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wyy" = (
+/obj/machinery/computer/cloning{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
 "wBP" = (
 /obj/machinery/computer/objective{
 	dir = 8
@@ -20831,6 +21151,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wES" = (
+/obj/machinery/shower{
+	pixel_y = 12
+	},
+/turf/open/floor/noslip/dark,
+/area/medical/genetics)
 "wIW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -20861,19 +21187,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"wKe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/chair/stool,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "wMa" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -20894,6 +21207,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"wOy" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "wUb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/tile/red,
@@ -20902,13 +21219,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/research)
-"wUV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/chair/stool,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "wVS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -20958,6 +21268,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/security/nuke_storage)
+"xfr" = (
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "xhh" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -21132,14 +21449,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
-"xAY" = (
-/obj/machinery/computer/pandemic,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "xBw" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -21161,14 +21470,25 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"xCT" = (
-/obj/effect/turf_decal/tile/blue/tile_marquee,
-/obj/effect/turf_decal/tile/neutral/tile_marquee{
+"xDp" = (
+/obj/structure/railing/corner{
 	dir = 1
 	},
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/plasteel/ameridiner,
-/area/medical/sleeper)
+/obj/effect/turf_decal/monke/siding/blue/corner{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "xDq" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/structure/cable/yellow{
@@ -21268,6 +21588,21 @@
 /obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
+"xJq" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-9"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "xKW" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -21297,9 +21632,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "xQh" = (
@@ -21319,6 +21651,10 @@
 /obj/machinery/vending/modularpc,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"xSU" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "xTd" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -21357,6 +21693,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"yap" = (
+/obj/structure/table/glass,
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = 10;
+	pixel_y = 8
+	},
+/obj/item/storage/box/disks{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -8
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "yas" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -21413,26 +21769,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"yjK" = (
-/obj/structure/table/glass,
-/obj/item/storage/pill_bottle/mutadone{
-	pixel_x = 10;
-	pixel_y = 8
-	},
-/obj/item/storage/box/disks{
-	pixel_x = -6;
-	pixel_y = 9
-	},
-/obj/item/storage/box/monkeycubes{
-	pixel_x = 5;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -8
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "ykV" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -56267,7 +56603,7 @@ sdW
 gPD
 hNN
 edh
-xWM
+nvG
 axZ
 wwk
 sgi
@@ -56781,7 +57117,7 @@ avX
 avX
 adV
 aIu
-dwI
+weG
 dxg
 dxg
 dwI
@@ -57295,7 +57631,7 @@ aLu
 aNg
 aWm
 acg
-aTY
+gnF
 aTY
 aTY
 aTY
@@ -57546,7 +57882,7 @@ aEv
 aFL
 aLu
 aqb
-auJ
+bFu
 aXC
 aLB
 aIv
@@ -57806,10 +58142,10 @@ auJ
 aJx
 aQk
 aLu
-rGX
-aCE
-pej
 ovj
+aCE
+iIB
+pUR
 aVH
 aLg
 rFc
@@ -58060,7 +58396,7 @@ avE
 avE
 aHL
 aIP
-auJ
+kyJ
 aEJ
 aLu
 aNr
@@ -58585,7 +58921,7 @@ aGL
 aum
 aZi
 aZT
-bmu
+ojJ
 aCj
 aaB
 aaB
@@ -121552,7 +121888,7 @@ aaD
 aaD
 aVX
 pfe
-gPH
+sIh
 ajR
 ajR
 aHA
@@ -121796,9 +122132,9 @@ aOH
 kmc
 aTv
 gKP
-bMu
+rlZ
 bOm
-szQ
+lvZ
 bOm
 bOm
 bOm
@@ -122052,22 +122388,22 @@ agb
 iqd
 ipz
 aTv
-rgx
-epU
-txn
+xfr
+kVu
+aKd
 aTv
-wKe
-eZl
-eZl
-aTv
-aTv
+mwo
+tco
+tco
 aTv
 aTv
 aTv
 aTv
-uuy
-wUV
-xOb
+aTv
+aTv
+wfm
+tRP
+dcg
 iHz
 tuZ
 fCL
@@ -122309,18 +122645,18 @@ afB
 xHV
 kJd
 aTv
-nGx
-avv
+cJw
+xOb
 aWE
 aTv
 aaD
 aaD
 aaD
 aTv
-iiM
-fxG
-vHs
-hqi
+qhJ
+wyy
+ftn
+iop
 aTv
 aTv
 aTv
@@ -122568,19 +122904,19 @@ aFs
 ajR
 ajR
 aTv
-lvB
+jFM
 aTv
 aTv
 aTv
 aTv
 aTv
-pbc
-dAr
-jpk
-rZA
-yjK
+wES
+qZs
+kgA
+bym
+yap
 aTv
-jJk
+xSU
 avv
 dyY
 aTv
@@ -122824,20 +123160,20 @@ opB
 adD
 aUd
 ajR
-cNk
-aKd
+uTH
+dyY
 rbn
 aTv
 aCX
 aCX
-pzt
-gkY
-nBI
-eZv
-kjr
-chJ
+kfP
+lXm
+rbh
+vUF
+guM
+dic
 aTv
-vBI
+uRY
 avv
 dyY
 aTv
@@ -123081,18 +123417,18 @@ agg
 adD
 aUd
 ajR
-bkd
-hPv
-iNK
+aEf
+kwX
+kti
 aTv
 aCX
 aCX
-nVu
-kgj
-nBI
-kdP
-nBI
-gkY
+nEX
+cgk
+rbh
+kLy
+rbh
+lXm
 aTv
 aTv
 aTv
@@ -123339,18 +123675,18 @@ aFs
 aUd
 ajR
 aTv
-hPv
-wtk
+kwX
+lvS
 aTv
 aCX
 aCX
-uTr
-knh
-tMt
-fdB
-tLQ
-pTk
-uuo
+rEd
+fjs
+uMJ
+njP
+rBB
+dZI
+uKB
 aTv
 aEP
 pVL
@@ -123595,19 +123931,19 @@ aFs
 aFs
 aAp
 ajR
-lvm
-aKd
-ksB
+uDf
+dyY
+bZa
 aTv
 aCX
 aCX
-lnP
-lkZ
-inY
-diA
-hpz
-uaj
-hja
+obJ
+pxz
+kVJ
+rWU
+fFH
+amT
+dWy
 aTv
 aAU
 xcr
@@ -123853,18 +124189,18 @@ arj
 arj
 ajR
 aPU
-amv
-slz
+jcu
+qqu
 att
-dhQ
-sRz
-kle
-uTp
-gVk
-iop
-vsh
-iop
-iop
+qCM
+lzL
+xDp
+cur
+tRj
+hCT
+bBi
+hCT
+hCT
 ajR
 aAb
 pVL
@@ -124113,15 +124449,15 @@ ajR
 ajR
 ajR
 ajR
-dRI
-dzz
-pQo
-dRI
-iop
-iop
-pHj
-tMW
-slY
+wkV
+qPu
+myW
+wkV
+hCT
+hCT
+lyC
+mJr
+sQg
 ajR
 aJa
 xcr
@@ -124369,16 +124705,16 @@ arj
 arj
 arj
 arj
-rbD
-reA
-oZa
-pnW
-iip
-iop
-amT
-nOh
-iLM
-oBg
+mMW
+iul
+fXK
+eBr
+rUR
+hCT
+wgB
+uml
+xJq
+avk
 ajR
 agW
 tDu
@@ -124626,16 +124962,16 @@ arj
 arj
 arj
 aAp
-rbD
-nCQ
-xCT
-cvu
-ncY
-iop
-voU
-avk
-ezJ
-avk
+mMW
+nno
+rWA
+pbe
+pNT
+hCT
+sWX
+qZP
+rwl
+qZP
 ajR
 ajR
 aIq
@@ -124883,18 +125219,18 @@ arj
 arj
 arj
 aAp
-rbD
-hEY
-uaF
-nMi
-nkv
-iop
-cfs
-lFi
-nOh
-ckt
-tAL
-iop
+mMW
+pDh
+gHN
+bZA
+dAt
+hCT
+fuI
+eph
+jTK
+duf
+vjx
+hCT
 aUd
 aUd
 ajR
@@ -125140,18 +125476,18 @@ arj
 arj
 arj
 aAp
-rbD
-uVq
-fam
-vAL
-oOj
-iop
-rwl
-bni
-nOh
-mrR
-axP
-iop
+mMW
+kFH
+vyR
+uVJ
+hMw
+hCT
+jEm
+opL
+wOy
+ofO
+htB
+hCT
 aAp
 aAp
 aAp
@@ -125397,18 +125733,18 @@ arj
 arj
 arj
 aAp
-rbD
-rbD
-jEB
-jEB
-rbD
-iop
-iop
-iop
-vAU
-nyO
-pIb
-fWG
+mMW
+mMW
+poj
+poj
+mMW
+hCT
+hCT
+hCT
+bAD
+dgM
+nxT
+dsZ
 arj
 arj
 arj
@@ -125660,12 +125996,12 @@ aUd
 aAp
 arj
 arj
-ejk
-ldt
-xAY
-tUW
-bym
-iop
+hCd
+vgZ
+hGv
+uGS
+nSo
+hCT
 arj
 arj
 arj
@@ -125918,11 +126254,11 @@ aAp
 arj
 arj
 arj
-iop
-iop
-fWG
-iop
-iop
+hCT
+hCT
+dsZ
+hCT
+hCT
 arj
 arj
 arj

--- a/_maps/map_files/HoleStation/holestation.dmm
+++ b/_maps/map_files/HoleStation/holestation.dmm
@@ -552,13 +552,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "acg" = (
-/obj/structure/closet/secure_closet/CMO,
-/obj/effect/turf_decal/tile/blue/tile_side{
-	dir = 8
-	},
-/obj/structure/window,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/medbay/lobby)
 "ach" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -1199,19 +1195,6 @@
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/miningdock)
-"aeP" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/machinery/computer/camera_advanced/base_construction,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/construction/mining/aux_base)
 "aeU" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -2722,15 +2705,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "akz" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/area/medical/medbay/lobby)
 "akA" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/reagent_dispensers/fueltank,
@@ -2768,9 +2749,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "akH" = (
-/obj/structure/window,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/obj/machinery/suit_storage_unit/cmo,
+/obj/effect/turf_decal/tile/blue/tile_marquee{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "akI" = (
 /obj/effect/spawner/room/threexthree,
 /turf/open/floor/plating,
@@ -3173,12 +3160,9 @@
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
 "amr" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/obj/effect/turf_decal/tile/blue/tile_side{
-	dir = 4
-	},
+/obj/structure/chair,
 /turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/area/hallway/primary/central)
 "ams" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
@@ -3311,11 +3295,9 @@
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
 "amT" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/construction/mining/aux_base)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "amU" = (
 /obj/machinery/computer/upload/ai{
 	dir = 4
@@ -3420,10 +3402,6 @@
 	},
 /turf/open/floor/engine/light,
 /area/engine/engine_core)
-"ann" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/construction/mining/aux_base)
 "anr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -4230,11 +4208,8 @@
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "aqb" = (
-/obj/machinery/shower{
-	pixel_y = 12
-	},
 /obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/noslip/dark,
+/turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "aqc" = (
 /obj/machinery/mech_bay_recharge_port{
@@ -4501,14 +4476,6 @@
 /obj/item/camera,
 /turf/open/floor/plasteel/cult,
 /area/library)
-"aqY" = (
-/obj/structure/rack,
-/obj/item/storage/box/lights/mixed{
-	pixel_y = 8
-	},
-/obj/item/pipe_dispenser,
-/turf/open/floor/plasteel/techmaint,
-/area/construction/mining/aux_base)
 "arb" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/white,
@@ -4983,13 +4950,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"asR" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/auto_name/west,
-/turf/open/floor/plasteel/techmaint,
-/area/construction/mining/aux_base)
 "asT" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -5100,8 +5060,11 @@
 /turf/open/openspace,
 /area/crew_quarters/bar/lounge)
 "att" = (
-/turf/closed/wall/r_wall,
-/area/construction/mining/aux_base)
+/obj/machinery/door/airlock/medical/glass{
+	name = "Recovery Room"
+	},
+/turf/open/floor/plasteel/white,
+/area/space/nearstation)
 "atu" = (
 /obj/machinery/modular_fabricator/autolathe,
 /obj/machinery/door/firedoor,
@@ -5348,15 +5311,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "aum" = (
-/obj/effect/turf_decal/tile/yellow/tile_marquee,
-/turf/open/floor/plasteel/techmaint,
-/area/medical/medbay)
-"aun" = (
-/obj/effect/turf_decal/monke/siding/thinplating/light{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /turf/open/floor/plasteel/techmaint,
-/area/medical/medbay)
+/area/medical/office)
 "auo" = (
 /obj/structure/window/plasma/reinforced/spawner/west,
 /obj/effect/turf_decal/stripes/line{
@@ -5633,11 +5595,8 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "avv" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/construction/mining/aux_base)
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "avw" = (
 /obj/structure/railing/corner,
 /obj/machinery/door/airlock/maintenance,
@@ -6161,14 +6120,6 @@
 /obj/machinery/atmospherics/pipe/manifold/orange/visible,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"axo" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/closet/toolcloset,
-/turf/open/floor/plasteel/techmaint,
-/area/construction/mining/aux_base)
 "axp" = (
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/suit_storage_unit/atmos,
@@ -6324,11 +6275,16 @@
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hos)
 "axZ" = (
-/obj/docking_port/stationary/public_mining_dock{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/construction/mining/aux_base)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aya" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/cafeteria,
@@ -6567,16 +6523,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"ayU" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/obj/item/stack/rods/fifty,
-/turf/open/floor/plasteel/techmaint,
-/area/construction/mining/aux_base)
 "ayV" = (
 /obj/structure/railing/corner,
 /obj/structure/cable/orange{
@@ -6655,9 +6601,17 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "azn" = (
-/obj/effect/landmark/start/geneticist,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/area/medical/medbay/lobby)
 "azo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -7021,9 +6975,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"aAX" = (
-/turf/open/floor/plating,
-/area/construction/mining/aux_base)
 "aAY" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -7420,12 +7371,13 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "aCE" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/effect/turf_decal/tile/blue,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/area/medical/medbay/lobby)
 "aCF" = (
 /obj/machinery/telecomms/processor/preset_one/birdstation,
 /turf/open/floor/circuit/green/telecomms,
@@ -7487,8 +7439,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aCX" = (
-/turf/closed/wall,
-/area/construction/mining/aux_base)
+/turf/open/openspace,
+/area/space/nearstation)
 "aCY" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plating,
@@ -8192,9 +8144,11 @@
 /obj/effect/turf_decal/monke/siding/thinplating/light{
 	dir = 8
 	},
-/obj/machinery/chem_heater,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/techmaint,
-/area/medical/medbay)
+/area/medical/office)
 "aFH" = (
 /obj/structure/table/wood,
 /obj/item/pen{
@@ -8528,13 +8482,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/central)
 "aGL" = (
-/obj/effect/turf_decal/tile/yellow/tile_marquee,
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/landmark/start/virologist,
+/obj/structure/table/glass,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/plasteel/techmaint,
-/area/medical/medbay)
+/area/medical/office)
 "aGN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -8898,14 +8850,6 @@
 /obj/structure/railing,
 /turf/open/openspace,
 /area/maintenance/port/aft)
-"aId" = (
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/tile/blue/tile_side{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay)
 "aIe" = (
 /obj/effect/turf_decal/monke/siding/wood{
 	dir = 1
@@ -9011,7 +8955,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/area/medical/medbay/lobby)
 "aIw" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
@@ -9032,11 +8976,11 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "aID" = (
-/obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/monke/siding/thinplating/dark{
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/structure/bodycontainer/morgue,
 /turf/open/floor/plating,
 /area/medical/morgue)
 "aIF" = (
@@ -9097,7 +9041,6 @@
 	pixel_y = 24;
 	req_access_txt = "27"
 	},
-/obj/structure/closet/l3closet/virology,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -9434,7 +9377,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "aKe" = (
@@ -9690,37 +9632,18 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "aLg" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/button/door{
+	desc = "A remote control switch for the medbay foyer.";
+	id = "MedbayFoyer";
+	name = "Medbay Doors Control";
+	normaldoorcontrol = 1;
+	req_access_txt = "5";
+	pixel_y = 26
 	},
-/obj/structure/table,
-/obj/item/storage/firstaid/brute{
-	pixel_x = -9;
-	pixel_y = 10
-	},
-/obj/item/storage/firstaid/brute{
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/obj/item/storage/firstaid/brute{
-	pixel_x = -9;
-	pixel_y = 1
-	},
-/obj/item/storage/firstaid/fire{
-	pixel_x = 7;
-	pixel_y = 9
-	},
-/obj/item/storage/firstaid/fire{
-	pixel_x = 7;
-	pixel_y = 5
-	},
-/obj/item/storage/firstaid/fire{
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/obj/effect/turf_decal/tile/blue/tile_marquee,
+/obj/machinery/computer/crew,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/area/medical/office)
 "aLh" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -9749,12 +9672,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/computer/cloning{
-	dir = 4
-	},
 /obj/effect/turf_decal/monke/siding/thinplating/dark{
 	dir = 4
 	},
+/obj/structure/bodycontainer/morgue,
 /turf/open/floor/plating,
 /area/medical/morgue)
 "aLq" = (
@@ -9777,12 +9698,6 @@
 "aLu" = (
 /turf/closed/wall,
 /area/medical/morgue)
-"aLw" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/aux_base,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "aLx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -9803,16 +9718,16 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/monke/siding/thinplating/light,
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
 	req_access_txt = "6"
 	},
+/obj/effect/turf_decal/monke/siding/thinplating/light,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "aLC" = (
 /turf/closed/wall/r_wall,
-/area/medical/medbay)
+/area/crew_quarters/heads/cmo)
 "aLD" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -9905,19 +9820,6 @@
 "aLW" = (
 /turf/closed/wall/r_wall,
 /area/engine/engine_smes)
-"aLX" = (
-/obj/docking_port/stationary{
-	dheight = 4;
-	dir = 4;
-	dwidth = 4;
-	height = 9;
-	id = "aux_base_zone";
-	name = "aux base zone";
-	roundstart_template = /datum/map_template/shuttle/aux_base/default;
-	width = 9
-	},
-/turf/open/floor/plating,
-/area/construction/mining/aux_base)
 "aLY" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4
@@ -10221,16 +10123,23 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "aNg" = (
-/obj/machinery/rnd/production/techfab/department/medical,
-/obj/machinery/firealarm/directional/west,
-/obj/effect/turf_decal/monke/siding/thinplating/light{
-	dir = 6
+/obj/machinery/vending/medical{
+	pixel_x = -2
 	},
-/turf/open/floor/plating,
-/area/medical/medbay)
-"aNl" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/area/medical/medbay/lobby)
+"aNl" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/office)
 "aNm" = (
 /obj/machinery/rnd/server,
 /turf/open/floor/circuit/telecomms/server,
@@ -10251,46 +10160,31 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/tcommsat/relay)
-"aNp" = (
-/obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = 22
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay)
 "aNq" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "aNr" = (
-/obj/machinery/computer/scan_consolenew,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay)
-"aNs" = (
-/obj/machinery/smartfridge/organ,
-/obj/effect/turf_decal/monke/siding/thinplating/light{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay)
-"aNt" = (
-/obj/structure/table/optable,
-/obj/item/defibrillator/loaded,
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/stairs{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay)
+/turf/open/floor/plating,
+/area/medical/medbay/lobby)
+"aNt" = (
+/obj/effect/turf_decal/tile/blue/tile_marquee{
+	dir = 1
+	},
+/obj/machinery/computer/crew,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/auto_name/west,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "aNu" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -10305,16 +10199,18 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "aNy" = (
-/obj/machinery/computer/operating,
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/tile_marquee{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay)
-"aNB" = (
-/turf/closed/wall,
-/area/hallway/secondary/exit)
+/obj/item/radio/intercom{
+	pixel_x = 25
+	},
+/obj/machinery/computer/med_data,
+/obj/machinery/camera/autoname{
+	dir = 6
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "aNC" = (
 /obj/machinery/door/window/survival_pod{
 	req_access_txt = "65"
@@ -10449,16 +10345,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/bridge)
-"aOb" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/machinery/computer/shuttle_flight/mining,
-/turf/open/floor/plasteel/techmaint,
-/area/construction/mining/aux_base)
 "aOc" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
@@ -10806,28 +10692,17 @@
 /turf/open/floor/engine,
 /area/engine/engine_core)
 "aPl" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_x = 3;
-	pixel_y = 4
+/obj/effect/turf_decal/tile/blue/tile_side,
+/obj/machinery/door/airlock/command/glass{
+	name = "Chief Medical Officer";
+	req_access_txt = "40";
+	security_level = 6
 	},
-/obj/effect/turf_decal/monke/siding/thinplating/light{
-	dir = 10
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/item/reagent_containers/medspray/sterilizine{
-	pixel_y = 8;
-	pixel_x = -9
-	},
-/obj/item/reagent_containers/medspray/sterilizine{
-	pixel_y = 1;
-	pixel_x = -9
-	},
-/obj/item/clothing/gloves/color/latex{
-	pixel_y = -3;
-	pixel_x = 2
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay)
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/heads/cmo)
 "aPm" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -10837,10 +10712,18 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "aPn" = (
-/obj/effect/landmark/start/medical_doctor,
-/obj/effect/turf_decal/monke/siding/thinplating/light,
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay)
+/obj/effect/turf_decal/tile/blue/tile_marquee{
+	dir = 1
+	},
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/landmark/start/chief_medical_officer,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "aPp" = (
 /obj/machinery/modular_fabricator/exosuit_fab,
 /turf/open/floor/mineral/plastitanium,
@@ -10959,14 +10842,16 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aPN" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
+/obj/effect/turf_decal/tile/blue/tile_marquee{
+	dir = 1
 	},
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/monke/siding/thinplating/light,
-/turf/open/floor/plasteel/dark,
-/area/medical/medbay)
+/obj/structure/bed/dogbed/runtime,
+/mob/living/simple_animal/pet/cat/Runtime,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "aPO" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 4;
@@ -11009,14 +10894,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aPU" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/closet/toolcloset,
-/obj/machinery/light,
-/turf/open/floor/plasteel/techmaint,
-/area/construction/mining/aux_base)
+/obj/machinery/stasis,
+/turf/open/floor/plasteel/white,
+/area/space/nearstation)
 "aPV" = (
 /obj/structure/ladder,
 /turf/open/floor/plasteel/dark/side,
@@ -11095,9 +10975,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "aQh" = (
-/obj/item/beacon,
+/obj/machinery/door/airlock/medical{
+	name = "Medbay Reception";
+	req_access_txt = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/area/medical/office)
 "aQi" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -11688,7 +11574,7 @@
 /area/engine/engineering)
 "aRW" = (
 /turf/closed/wall,
-/area/medical/medbay)
+/area/medical/medbay/lobby)
 "aRX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -11715,12 +11601,17 @@
 	},
 /area/engine/engine_core)
 "aRZ" = (
-/obj/effect/landmark/start/medical_doctor,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/vending/wallmed{
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/area/medical/medbay/lobby)
 "aSa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -11756,10 +11647,17 @@
 /turf/closed/wall,
 /area/hallway/primary/central)
 "aSe" = (
-/obj/structure/window,
-/obj/machinery/vending/medical,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/obj/effect/turf_decal/tile/blue/tile_marquee{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/CMO,
+/obj/item/gun/syringe,
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/keycard_auth{
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "aSf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -11985,12 +11883,18 @@
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "aSX" = (
-/obj/machinery/smartfridge/chemistry/virology/preloaded,
-/obj/structure/reagent_dispensers/virusfood{
-	pixel_x = 32
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder{
+	pixel_y = 6
 	},
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/storage/box/beakers{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/techmaint,
-/area/medical/medbay)
+/area/medical/office)
 "aSY" = (
 /turf/open/openspace,
 /area/engine/atmos)
@@ -12247,23 +12151,8 @@
 /turf/open/floor/plasteel/cult,
 /area/library)
 "aTY" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular{
-	pixel_y = 9
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_y = 5
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 11
-	},
-/obj/effect/turf_decal/tile/blue/tile_marquee,
-/obj/item/wrench/medical,
 /turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/area/hallway/primary/central)
 "aTZ" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "QMLoad2";
@@ -12379,10 +12268,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "aUu" = (
-/obj/machinery/holopad,
-/obj/effect/landmark/start/chief_medical_officer,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/area/medical/medbay/lobby)
 "aUv" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/cable/yellow{
@@ -12397,21 +12288,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"aUx" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/monke/siding/thinplating/light{
-	dir = 9
-	},
-/obj/machinery/reagentgrinder{
-	pixel_y = 5
-	},
-/obj/item/stack/sheet/mineral/plasma/five,
-/obj/item/storage/box/monkeycubes{
-	pixel_x = -7;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/medical/medbay)
 "aUz" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/components/unary/passive_vent{
@@ -12432,23 +12308,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
-"aUC" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/monke/siding/thinplating/light{
-	dir = 1
-	},
-/obj/item/reagent_containers/syringe{
-	pixel_y = 13;
-	pixel_x = -5
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_y = 6;
-	pixel_x = -9
-	},
-/obj/item/storage/box/beakers,
-/turf/open/floor/plasteel/techmaint,
-/area/medical/medbay)
 "aUD" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -12472,12 +12331,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/nuke_storage)
-"aUI" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/construction/mining/aux_base)
 "aUJ" = (
 /obj/effect/spawner/room/fivexthree,
 /turf/open/floor/plating,
@@ -12499,12 +12352,8 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "aUN" = (
-/obj/effect/turf_decal/monke/siding/thinplating/light{
-	dir = 1
-	},
-/obj/machinery/computer/pandemic,
-/turf/open/floor/plasteel/techmaint,
-/area/medical/medbay)
+/turf/closed/wall,
+/area/crew_quarters/heads/cmo)
 "aUO" = (
 /obj/structure/railing{
 	dir = 1
@@ -12694,18 +12543,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/engine/storage)
-"aVw" = (
-/obj/machinery/door/airlock/mining,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/aux_base,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/plating,
-/area/construction/mining/aux_base)
 "aVy" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
 	dir = 1
@@ -12754,13 +12591,12 @@
 /obj/effect/turf_decal/monke/siding/thinplating/dark{
 	dir = 4
 	},
-/obj/machinery/clonepod/prefilled,
+/obj/structure/bodycontainer/morgue,
 /turf/open/floor/plating,
 /area/medical/morgue)
 "aVH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/medbay)
+/turf/closed/wall,
+/area/medical/office)
 "aVJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-9"
@@ -12945,7 +12781,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/area/medical/medbay/lobby)
 "aWn" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet";
@@ -13019,11 +12855,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/keycard_auth{
-	pixel_y = -24
-	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/area/medical/medbay/lobby)
 "aWD" = (
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel/techmaint,
@@ -13034,8 +12867,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "aWI" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -13238,7 +13071,7 @@
 "aXx" = (
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/techmaint,
-/area/medical/medbay)
+/area/medical/office)
 "aXy" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -13640,33 +13473,17 @@
 	},
 /area/maintenance/disposal/incinerator)
 "aYU" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/o2{
-	pixel_x = -7;
-	pixel_y = 11
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/monke/siding/thinplating/light{
+	dir = 8
 	},
-/obj/item/storage/firstaid/o2{
-	pixel_x = -7;
-	pixel_y = 5
+/obj/effect/turf_decal/monke/siding/thinplating/light{
+	dir = 4
 	},
-/obj/item/storage/firstaid/o2{
-	pixel_x = -7
-	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 8;
-	pixel_y = 11
-	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/tile/blue/tile_marquee,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/obj/machinery/computer/med_data/laptop,
+/turf/open/floor/plating,
+/area/medical/office)
 "aYV" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -13771,34 +13588,17 @@
 /turf/open/openspace,
 /area/engine/engine_room)
 "aZh" = (
-/obj/structure/table/glass,
-/obj/item/folder/white,
-/obj/item/reagent_containers/glass/bottle/epinephrine{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/obj/item/stack/sheet/mineral/plasma{
-	pixel_y = 10
-	},
+/obj/machinery/chem_heater,
 /obj/effect/turf_decal/monke/siding/thinplating/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel/techmaint,
-/area/medical/medbay)
+/area/medical/office)
 "aZi" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/plasteel/techmaint,
-/area/medical/medbay)
+/area/medical/office)
 "aZj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 4
@@ -13812,11 +13612,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "aZk" = (
-/obj/machinery/chem_dispenser{
-	layer = 2.7
+/obj/machinery/chem_dispenser,
+/obj/machinery/camera/autoname{
+	dir = 9
 	},
 /turf/open/floor/plasteel/techmaint,
-/area/medical/medbay)
+/area/medical/office)
 "aZl" = (
 /turf/open/floor/plasteel/dark/side{
 	dir = 9
@@ -13948,13 +13749,13 @@
 "aZR" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/closed/wall,
-/area/medical/medbay)
+/area/medical/office)
 "aZT" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
-/obj/machinery/door/window,
+/obj/machinery/door/window/southleft,
 /turf/open/floor/plating,
-/area/medical/medbay)
+/area/medical/office)
 "aZU" = (
 /obj/machinery/computer/message_monitor{
 	dir = 1
@@ -14222,16 +14023,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
-"bLo" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/mob/living/simple_animal/pet/cat/Runtime,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay)
 "bOa" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -14328,16 +14119,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"bXh" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel/techmaint,
-/area/construction/mining/aux_base)
 "bXI" = (
 /obj/effect/turf_decal/monke/siding/wood{
 	dir = 1
@@ -14701,19 +14482,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"doE" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/construction/mining/aux_base)
 "doZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/wood,
@@ -14753,37 +14521,15 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "dwI" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "medbay_front_door"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/medical/medbay)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/primary/central)
 "dxg" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "medbay_front_door"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
-/area/medical/medbay)
+/area/hallway/primary/central)
 "dyY" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -15383,22 +15129,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fpH" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/openspace,
-/area/maintenance/central/secondary)
 "fqk" = (
 /obj/machinery/door/airlock/command,
 /obj/structure/cable/yellow{
@@ -15688,15 +15418,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"gfr" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay)
 "ggZ" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -16172,12 +15893,8 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "iop" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/camera/autoname{
-	dir = 5
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/construction/mining/aux_base)
+/turf/open/floor/plasteel/white,
+/area/space/nearstation)
 "ipf" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
@@ -16476,11 +16193,14 @@
 /turf/open/floor/mineral/plastitanium/airless,
 /area/space/nearstation)
 "jdI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/area/medical/office)
 "jdV" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -17445,11 +17165,13 @@
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/miningdock)
 "mWJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/machinery/camera/autoname{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/area/hallway/primary/central)
 "mXp" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -17547,30 +17269,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"nCI" = (
-/obj/structure/rack,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/wallframe/camera,
-/obj/item/assault_pod/mining,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/techmaint,
-/area/construction/mining/aux_base)
-"nDy" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/landmark/start/depsec/medical,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay)
 "nDD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -17680,9 +17378,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "nXm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
 /obj/machinery/vending/wallmed{
 	pixel_y = -30
 	},
@@ -17849,18 +17544,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "ovj" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/machinery/computer/med_data{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/area/medical/medbay/lobby)
 "ovO" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -18229,14 +17914,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"pCy" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/stasis,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay)
 "pCQ" = (
 /obj/structure/railing{
 	dir = 8
@@ -18487,24 +18164,6 @@
 	},
 /turf/open/openspace,
 /area/maintenance/starboard/aft/secondary)
-"qCC" = (
-/obj/machinery/door/airlock/mining,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/aux_base,
-/obj/effect/mapping_helpers/airlock/autoname,
-/turf/open/floor/plasteel/techmaint,
-/area/maintenance/central/secondary)
 "qEv" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/monke/siding/thinplating{
@@ -18593,14 +18252,11 @@
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "rbn" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/sleeper{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/area/space/nearstation)
 "rcy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -18725,13 +18381,15 @@
 /turf/open/floor/plasteel/techmaint,
 /area/hallway/secondary/service)
 "rFc" = (
-/obj/structure/cable/yellow,
-/obj/machinery/power/apc/auto_name/south,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/structure/chair/office/light{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/area/medical/office)
 "rIr" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -18962,10 +18620,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "sgi" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/techmaint,
-/area/construction/mining/aux_base)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "shZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -19442,14 +19106,6 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"tBe" = (
-/obj/machinery/computer/security/telescreen/auxbase{
-	dir = 8;
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel/techmaint,
-/area/construction/mining/aux_base)
 "tDt" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -19639,12 +19295,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"udt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/techmaint,
-/area/construction/mining/aux_base)
 "ueQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -19799,12 +19449,16 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uKr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/monke/siding/thinplating/light{
 	dir = 8
 	},
-/obj/effect/landmark/start/emt,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay)
+/obj/effect/turf_decal/monke/siding/thinplating/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/medical/office)
 "uLw" = (
 /obj/machinery/light{
 	dir = 8
@@ -19951,11 +19605,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"vmP" = (
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/techmaint,
-/area/construction/mining/aux_base)
 "vsf" = (
 /obj/effect/turf_decal/monke/siding/wood{
 	dir = 4
@@ -55704,9 +55353,9 @@ gPD
 hNN
 edh
 xWM
-uUR
+axZ
 wwk
-cNA
+sgi
 dIq
 fvO
 aCj
@@ -55961,7 +55610,7 @@ aIu
 aIu
 aIu
 aot
-qSM
+aCj
 aCj
 nXm
 aSd
@@ -56217,11 +55866,11 @@ avX
 avX
 adV
 aIu
-aRW
-dxg
-aVH
 dwI
-aRW
+dxg
+dxg
+dwI
+aSd
 nYT
 aCj
 aQN
@@ -56475,10 +56124,10 @@ aIu
 aKR
 aIu
 amr
-gfr
-aNl
+aTY
+aTY
 mWJ
-aRW
+aSd
 bmu
 aex
 aQN
@@ -56731,11 +56380,11 @@ aLu
 aNg
 aWm
 acg
-aId
-nDy
 aTY
-mWJ
-aRW
+aTY
+aTY
+aTY
+aSd
 hwG
 whi
 aQN
@@ -56989,10 +56638,10 @@ aIv
 aWC
 aRW
 akz
-rbn
+aVH
 aYU
 uKr
-aRW
+aVH
 fTZ
 aXq
 aQN
@@ -57242,14 +56891,14 @@ auJ
 aJx
 aQk
 aLu
-aNp
+ovj
 aCE
 ovj
-pCy
-bLo
+ovj
+aVH
 aLg
 rFc
-aRW
+aVH
 bmu
 aCj
 aQN
@@ -57506,7 +57155,7 @@ aUu
 aQh
 aNl
 jdI
-aRW
+aVH
 etw
 hOT
 bbE
@@ -57755,12 +57404,12 @@ aHL
 aIQ
 aJH
 aLh
-aLu
-aNs
+aUN
+aUN
 aPl
-akH
-aUx
-aun
+aUN
+aUN
+aVH
 aFE
 aZh
 aZR
@@ -58012,11 +57661,11 @@ aHL
 aHL
 aHL
 aHL
-aHL
+aLC
 aNt
 aPn
 akH
-aUC
+aUN
 aGL
 aum
 aZi
@@ -58526,15 +58175,15 @@ anZ
 anZ
 aJi
 aLi
-aLi
-aNB
-aNB
-aNB
-aNB
-aNB
-aNB
-aNB
-aNB
+aLC
+aUN
+aUN
+aUN
+aUN
+aVH
+aVH
+aVH
+aVH
 una
 alL
 aaB
@@ -121240,7 +120889,7 @@ bOm
 bOm
 bOm
 bOm
-fpH
+bOm
 bOm
 bOm
 sQi
@@ -121487,17 +121136,17 @@ aFs
 agb
 iqd
 ipz
-ajR
-ajR
-ajR
+aTv
+avv
+avv
 aKd
-ajR
-ajR
+avv
+avv
+avv
+avv
 aTv
 aTv
 aTv
-aTv
-qCC
 aTv
 aTv
 aTv
@@ -121744,21 +121393,21 @@ aeA
 afB
 xHV
 kJd
-aFs
-aUd
-aLs
-aWE
-aUd
-att
-aeP
+aTv
 avv
-asR
-aUI
-doE
+avv
+aWE
+avv
+avv
+avv
+avv
+aTv
 iop
-vmP
-udt
-aPU
+iop
+iop
+iop
+iop
+iop
 aTv
 aOj
 dyY
@@ -122001,21 +121650,21 @@ aJU
 vSM
 cZh
 aFs
-aFs
-aAp
-aLs
-aLs
-aLs
-att
-aOb
-tBe
-sgi
-nCI
-bXh
-aqY
-ayU
-amT
-axo
+ajR
+ajR
+aTv
+aTv
+aTv
+aTv
+aTv
+aTv
+aTv
+iop
+iop
+iop
+iop
+iop
+iop
 aTv
 aTv
 qry
@@ -122259,20 +121908,20 @@ rQR
 opB
 adD
 aUd
-aAp
-aUd
-aUd
-aUd
-att
+aOc
+iop
+iop
+rbn
+amT
 aCX
 aCX
-ann
-ann
-aVw
-ann
-ann
-aCX
-aCX
+aYD
+iop
+iop
+iop
+iop
+iop
+iop
 aTv
 aEP
 pVL
@@ -122516,20 +122165,20 @@ agg
 agg
 adD
 aUd
-aAp
-aUd
-aUd
-aUd
-att
-aAX
-aAX
-aAX
-aAX
-axZ
-aAX
-aAX
-aAX
-aAX
+aOc
+iop
+iop
+iop
+amT
+aCX
+aCX
+aYD
+iop
+iop
+iop
+iop
+iop
+iop
 aTv
 avk
 rwl
@@ -122773,20 +122422,20 @@ aCo
 acq
 aFs
 aUd
-aAp
-aUd
-aUd
-aUd
-att
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
+aOc
+iop
+iop
+iop
+amT
+aCX
+aCX
+aYD
+iop
+iop
+iop
+iop
+iop
+iop
 aTv
 avk
 xcr
@@ -123030,20 +122679,20 @@ adD
 aFs
 aFs
 aAp
-aAp
-aUd
-aUd
-aUd
-att
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
+aOc
+iop
+iop
+iop
+aYD
+aCX
+aCX
+aYD
+iop
+iop
+iop
+iop
+iop
+iop
 aTv
 aAU
 xcr
@@ -123287,20 +122936,20 @@ arj
 arj
 arj
 arj
-aLs
-aUd
-aUd
-aUd
+aOc
+aPU
+aPU
+iop
 att
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
+iop
+iop
+iop
+iop
+iop
+iop
+iop
+iop
+iop
 aTv
 aAb
 pVL
@@ -123544,21 +123193,21 @@ arj
 arj
 arj
 arj
-aLs
-aLs
-aAp
-aAp
-att
-aAX
-aAX
-aAX
-aAX
-aLX
-aAX
-aAX
-aAX
-aAX
-aLw
+aOc
+aOc
+aOc
+aOc
+aOc
+iop
+iop
+iop
+iop
+iop
+iop
+iop
+iop
+iop
+aTv
 aJa
 xcr
 aVr
@@ -123805,16 +123454,16 @@ arj
 arj
 arj
 arj
-att
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
+aOc
+iop
+iop
+iop
+iop
+iop
+iop
+iop
+iop
+iop
 aTv
 agW
 tDu
@@ -124062,16 +123711,16 @@ arj
 arj
 arj
 aAp
-att
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
+aOc
+iop
+iop
+iop
+iop
+iop
+iop
+iop
+iop
+iop
 aTv
 ajR
 ajR
@@ -124319,17 +123968,17 @@ arj
 arj
 arj
 aAp
-att
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-att
+aOc
+iop
+iop
+iop
+iop
+iop
+iop
+iop
+iop
+iop
+aOc
 aAp
 aUd
 aUd
@@ -124576,17 +124225,17 @@ arj
 arj
 arj
 aAp
-att
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-aAX
-att
+aOc
+iop
+iop
+iop
+iop
+iop
+iop
+iop
+iop
+iop
+aOc
 aAp
 aAp
 aAp
@@ -124833,17 +124482,17 @@ arj
 arj
 arj
 aAp
-att
-att
-att
-att
-att
-att
-att
-att
-att
-att
-att
+aOc
+aOc
+aOc
+aOc
+aOc
+aOc
+aOc
+aOc
+aOc
+aOc
+aOc
 aAp
 arj
 arj

--- a/_maps/map_files/HoleStation/holestation.dmm
+++ b/_maps/map_files/HoleStation/holestation.dmm
@@ -2710,6 +2710,9 @@
 	name = "Medbay";
 	req_access_txt = "5"
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "akA" = (
@@ -3178,6 +3181,12 @@
 "amu" = (
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"amv" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "amw" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -3295,9 +3304,12 @@
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
 "amT" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/space/nearstation)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/shower{
+	pixel_y = 12
+	},
+/turf/open/floor/noslip/white,
+/area/medical/virology)
 "amU" = (
 /obj/machinery/computer/upload/ai{
 	dir = 4
@@ -5060,11 +5072,18 @@
 /turf/open/openspace,
 /area/crew_quarters/bar/lounge)
 "att" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Recovery Room"
+/obj/effect/turf_decal/monke/siding/thinplating/light,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/turf_decal/monke/siding/blue/corner{
+	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/space/nearstation)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "atu" = (
 /obj/machinery/modular_fabricator/autolathe,
 /obj/machinery/door/firedoor,
@@ -5131,9 +5150,6 @@
 "atK" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
@@ -5535,14 +5551,8 @@
 /turf/open/floor/plasteel/dark/airless,
 /area/science/research)
 "avk" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/maintenance/central/secondary)
+/turf/closed/wall,
+/area/medical/virology)
 "avm" = (
 /obj/machinery/door/airlock/grunge{
 	id_tag = "Cabin_1";
@@ -6248,6 +6258,10 @@
 	},
 /turf/open/floor/grass,
 /area/crew_quarters/dorms)
+"axP" = (
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "axT" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
@@ -6895,11 +6909,8 @@
 	},
 /area/engine/engine_core)
 "aAB" = (
-/obj/effect/turf_decal/stripes/box,
-/obj/machinery/power/deck_relay,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aAE" = (
@@ -7440,7 +7451,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "aCX" = (
 /turf/open/openspace,
-/area/space/nearstation)
+/area/medical/medbay/balcony)
 "aCY" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plating,
@@ -10394,10 +10405,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aOj" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "aOk" = (
@@ -10894,9 +10902,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aPU" = (
-/obj/machinery/stasis,
-/turf/open/floor/plasteel/white,
-/area/space/nearstation)
+/obj/structure/closet/secure_closet/medical3,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "aPV" = (
 /obj/structure/ladder,
 /turf/open/floor/plasteel/dark/side,
@@ -11607,9 +11617,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/vending/wallmed{
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "aSa" = (
@@ -12855,6 +12863,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/south{
+	pixel_x = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "aWD" = (
@@ -12862,10 +12876,8 @@
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/miningdock)
 "aWE" = (
-/obj/effect/turf_decal/stripes/box,
-/obj/machinery/power/deck_relay,
 /obj/structure/cable/yellow{
-	icon_state = "0-8"
+	icon_state = "4-9"
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
@@ -13070,6 +13082,9 @@
 /area/tcommsat/server)
 "aXx" = (
 /obj/machinery/chem_master,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/medical/office)
 "aXy" = (
@@ -13854,6 +13869,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
+"bkd" = (
+/obj/vehicle/ridden/wheelchair,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "bll" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -13885,6 +13904,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bni" = (
+/obj/effect/turf_decal/monke/siding/green,
+/obj/machinery/door/window/southright{
+	req_access_txt = "39"
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/virology)
 "bqt" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -13950,17 +13976,15 @@
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/miningdock)
 "bym" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/table,
+/obj/structure/reagent_dispensers/virusfood{
+	pixel_x = 30
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/openspace,
-/area/maintenance/central/secondary)
+/obj/item/clothing/gloves/color/latex,
+/obj/item/healthanalyzer,
+/obj/item/clothing/glasses/hud/health,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "bBE" = (
 /obj/structure/sign/departments/restroom{
 	pixel_x = 32
@@ -14023,6 +14047,18 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
+"bMu" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/openspace,
+/area/maintenance/central/secondary)
 "bOa" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -14134,6 +14170,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"cfs" = (
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/virology)
 "chn" = (
 /obj/machinery/light{
 	dir = 4
@@ -14146,6 +14185,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"chJ" = (
+/obj/machinery/vending/wardrobe/gene_wardrobe,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "chX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -14189,6 +14232,17 @@
 	},
 /turf/open/openspace,
 /area/maintenance/port/aft)
+"ckt" = (
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "virology_airlock_exterior";
+	idInterior = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Console";
+	pixel_x = -24;
+	req_access_txt = "39"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "ckA" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -14241,6 +14295,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"cvu" = (
+/obj/effect/turf_decal/tile/blue/tile_marquee{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "cvH" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -14332,6 +14393,12 @@
 	},
 /turf/open/openspace,
 /area/maintenance/central)
+"cNk" = (
+/obj/vehicle/ridden/wheelchair,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "cNA" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -14461,6 +14528,26 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"dhQ" = (
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
+"diA" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "dka" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -14534,9 +14621,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
@@ -14545,6 +14629,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"dzz" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/monke/siding/thinplating/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
+"dAr" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
 "dCe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -14623,6 +14718,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
+"dRI" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/medical/sleeper)
 "dTx" = (
 /obj/machinery/light{
 	dir = 1
@@ -14764,6 +14863,14 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"ejk" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/disposalpipe/trunk,
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/turf/open/openspace/airless,
+/area/space/nearstation)
 "ekG" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/cable/yellow{
@@ -14814,6 +14921,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/lounge)
+"epU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "erX" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -14909,6 +15025,24 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/library/lounge)
+"ezJ" = (
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_interior";
+	name = "Virology Interior Airlock";
+	req_access_txt = "39"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/doorButtons/access_button{
+	idDoor = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_y = 24;
+	req_access_txt = "39"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "ezN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -15033,6 +15167,49 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"eZl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
+"eZv" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
+"fam" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "faO" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -15043,6 +15220,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fdB" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "fdI" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
@@ -15170,6 +15356,13 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fxG" = (
+/obj/machinery/computer/cloning{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
 "fAJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -15351,6 +15544,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"fWG" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/medical/virology)
 "fXs" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -15434,6 +15631,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"gkY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/genetics)
 "gmh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -15532,18 +15733,20 @@
 /area/hallway/primary/central)
 "gKi" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/firealarm/directional/east,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/openspace,
 /area/maintenance/central/secondary)
@@ -15608,6 +15811,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"gPH" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/openspace,
+/area/maintenance/central/secondary)
 "gRj" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -15626,6 +15833,13 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet)
+"gVk" = (
+/obj/machinery/vending/wallmed{
+	pixel_x = 24
+	},
+/obj/machinery/rnd/production/techfab/department/medical,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "gZR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -15667,6 +15881,27 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hja" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/brute{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/machinery/door/window/northright{
+	name = "First-Aid Supplies";
+	red_alert_access = 1;
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "hjk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -15684,6 +15919,18 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet)
+"hpz" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
+"hqi" = (
+/obj/machinery/computer/scan_consolenew{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "htx" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -15736,6 +15983,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"hEY" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "hHr" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -15812,6 +16067,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hPv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "hPK" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable/yellow{
@@ -15887,14 +16149,39 @@
 	},
 /turf/open/floor/plating,
 /area/security/nuke_storage)
+"iip" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/south{
+	pixel_x = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-9"
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
+"iiM" = (
+/obj/machinery/clonepod/prefilled,
+/turf/open/floor/plasteel/dark,
+/area/medical/genetics)
 "ikV" = (
 /obj/structure/window/reinforced/spawner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"iop" = (
+"inY" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-5"
+	},
 /turf/open/floor/plasteel/white,
-/area/space/nearstation)
+/area/medical/medbay/balcony)
+"iop" = (
+/turf/closed/wall/r_wall,
+/area/medical/virology)
 "ipf" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/yellow{
@@ -16106,12 +16393,26 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"iLM" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-9"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "iNl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"iNK" = (
+/obj/machinery/iv_drip,
+/obj/structure/bed/roller,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "iPG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -16308,6 +16609,9 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"jpk" = (
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "jqs" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -16410,6 +16714,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/science/lab)
+"jEB" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/medical/sleeper)
 "jGi" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -16440,6 +16748,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"jJk" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "jMp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -16550,6 +16862,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
+"kdP" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Cloning";
+	req_access_txt = "5; 68"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "kdQ" = (
 /obj/effect/turf_decal/monke/siding/thinplating/dark{
 	dir = 4
@@ -16583,6 +16905,30 @@
 	},
 /turf/open/floor/engine/airless/light,
 /area/space/nearstation)
+"kgj" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -6;
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -4;
+	pixel_y = 9
+	},
+/obj/item/wrench/medical,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
+"kjr" = (
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "kjW" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -16595,6 +16941,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/storage)
+"kle" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/monke/siding/blue/corner{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "kmc" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -16632,6 +16993,11 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet)
+"knh" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "knW" = (
 /obj/effect/turf_decal/tile/bar/tile_marquee,
 /obj/structure/cable/yellow{
@@ -16686,6 +17052,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ksB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "ksG" = (
 /obj/machinery/door/airlock/grunge,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -16858,6 +17229,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
+"ldt" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/medical/virology)
 "ldx" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -16894,6 +17270,15 @@
 /obj/effect/landmark/start/research_director,
 /turf/open/floor/plasteel,
 /area/science/lab)
+"lkZ" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "lmf" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/structure/cable/yellow{
@@ -16914,6 +17299,33 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lnP" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
+"lvm" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
+"lvB" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "lwA" = (
 /obj/structure/table/glass,
 /obj/machinery/recharger,
@@ -16951,6 +17363,16 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"lFi" = (
+/obj/effect/turf_decal/monke/siding/green,
+/obj/structure/window/reinforced,
+/obj/effect/landmark/blobstart,
+/mob/living/carbon/monkey,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/virology)
 "lFz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/closed/wall/r_wall,
@@ -17119,6 +17541,13 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mrR" = (
+/mob/living/simple_animal/pet/hamster/vector,
+/obj/effect/turf_decal/tile/green/tile_marquee{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "myI" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -17201,6 +17630,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"ncY" = (
+/obj/machinery/smartfridge/organ,
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/sleeper)
 "ngo" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -17219,6 +17655,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
+"nkv" = (
+/obj/structure/table/optable,
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 1
+	},
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -28
+	},
+/turf/open/floor/noslip/dark,
+/area/medical/sleeper)
 "nnW" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -17269,6 +17716,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"nyO" = (
+/obj/structure/chair/office/light,
+/obj/effect/landmark/start/virologist,
+/obj/effect/turf_decal/tile/green/tile_marquee{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"nBI" = (
+/turf/closed/wall,
+/area/medical/genetics)
+"nCQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "nDD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -17294,6 +17760,11 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"nGx" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "nHG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -17339,6 +17810,14 @@
 	},
 /turf/open/openspace,
 /area/maintenance/central/secondary)
+"nMi" = (
+/obj/effect/turf_decal/tile/blue/tile_marquee,
+/obj/effect/turf_decal/tile/neutral/tile_marquee{
+	dir = 1
+	},
+/obj/effect/landmark/start/emt,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "nMP" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -17346,6 +17825,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"nOh" = (
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "nOF" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -17373,6 +17855,19 @@
 	},
 /turf/open/openspace,
 /area/maintenance/starboard/aft/secondary)
+"nVu" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "nWu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -17580,6 +18075,17 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"oBg" = (
+/obj/structure/closet/l3closet,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc/auto_name/south{
+	pixel_x = 1
+	},
+/turf/open/floor/noslip/white,
+/area/medical/virology)
 "oBG" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -17717,6 +18223,18 @@
 	dir = 4
 	},
 /area/science/research)
+"oOj" = (
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/sleeper)
 "oPB" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -17791,6 +18309,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
+"oZa" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "oZf" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -17802,6 +18326,16 @@
 	},
 /turf/open/openspace,
 /area/maintenance/starboard/aft/secondary)
+"pbc" = (
+/obj/machinery/shower{
+	pixel_y = 12
+	},
+/turf/open/floor/noslip/dark,
+/area/medical/genetics)
+"pej" = (
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
 "pfe" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -17849,6 +18383,10 @@
 	},
 /turf/open/floor/engine/airless/light,
 /area/space/nearstation)
+"pnW" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "pse" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -17902,6 +18440,9 @@
 	},
 /turf/open/openspace,
 /area/maintenance/central)
+"pzt" = (
+/turf/closed/wall,
+/area/medical/medbay/balcony)
 "pBm" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable/yellow{
@@ -17947,6 +18488,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/nuke_storage)
+"pHj" = (
+/obj/effect/turf_decal/tile/green,
+/obj/structure/cable/yellow{
+	icon_state = "6-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"pIb" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/infections{
+	pixel_y = 7;
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/syringe/antiviral,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "pJi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -17985,6 +18547,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"pQo" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/monke/siding/thinplating/light{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6-8"
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "pQy" = (
 /obj/effect/turf_decal/tile/neutral/tile_marquee,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -17992,6 +18564,25 @@
 /obj/item/beacon,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"pTk" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/machinery/door/window/eastleft{
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "pUO" = (
 /obj/effect/turf_decal/loading_area,
 /obj/structure/cable/yellow{
@@ -18252,11 +18843,14 @@
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "rbn" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/space/nearstation)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/iv_drip,
+/obj/structure/bed/roller,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
+"rbD" = (
+/turf/closed/wall/r_wall,
+/area/medical/sleeper)
 "rcy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -18272,6 +18866,22 @@
 	},
 /turf/open/floor/mineral/plastitanium/airless,
 /area/space/nearstation)
+"reA" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = 26
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
+"rgx" = (
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "rjK" = (
 /obj/effect/landmark/start/cook,
 /obj/structure/cable/yellow{
@@ -18348,18 +18958,15 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "rwl" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/mob/living/carbon/monkey,
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/virology)
 "rwP" = (
 /obj/effect/landmark/start/cook,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -18390,6 +18997,12 @@
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel/white,
 /area/medical/office)
+"rGX" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
 "rIr" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -18560,6 +19173,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/research)
+"rZA" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/effect/landmark/start/geneticist,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "rZE" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -18662,6 +19282,21 @@
 	dir = 4
 	},
 /area/hallway/secondary/entry)
+"slz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
+"slY" = (
+/obj/structure/closet/l3closet,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/noslip/white,
+/area/medical/virology)
 "smV" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -18795,6 +19430,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"szQ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/firealarm/directional/east,
+/turf/open/openspace,
+/area/maintenance/central/secondary)
 "sBA" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -18851,6 +19496,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/openspace,
 /area/maintenance/central/secondary)
+"sRz" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
 "sTg" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -18942,6 +19599,9 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "tgV" = (
@@ -19084,6 +19744,16 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"txn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "txM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -19106,6 +19776,11 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"tAL" = (
+/obj/machinery/vending/wardrobe/viro_wardrobe,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "tDt" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -19202,6 +19877,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"tLQ" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "tLX" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/cable/yellow{
@@ -19214,6 +19907,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"tMt" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
+"tMW" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "tPt" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -19271,6 +19978,19 @@
 /obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/plasteel,
 /area/security/main)
+"tUW" = (
+/obj/structure/table,
+/obj/item/storage/box/beakers{
+	pixel_y = 2
+	},
+/obj/item/storage/box/syringes{
+	pixel_x = -3
+	},
+/obj/machinery/reagentgrinder{
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "tYX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -19288,6 +20008,18 @@
 /obj/machinery/advanced_airlock_controller/directional/north,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
+"uaj" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
+"uaF" = (
+/obj/effect/turf_decal/tile/blue/tile_marquee{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/obj/machinery/iv_drip,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "ucL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -19382,11 +20114,37 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
+"uuo" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "uut" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"uuy" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "uwi" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -19469,6 +20227,23 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/quartermaster/exploration_dock)
+"uTp" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-10"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/balcony)
+"uTr" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/turf_decal/monke/siding/blue{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/balcony)
 "uTz" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -19494,6 +20269,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"uVq" = (
+/obj/machinery/stasis,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "uWm" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -19605,6 +20388,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"voU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/virology)
 "vsf" = (
 /obj/effect/turf_decal/monke/siding/wood{
 	dir = 4
@@ -19614,6 +20401,28 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"vsh" = (
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_exterior";
+	name = "Virology Exterior Airlock";
+	req_access_txt = "39"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/doorButtons/access_button{
+	idDoor = "virology_airlock_exterior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	req_access_txt = "39";
+	pixel_y = 24;
+	pixel_x = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "vsI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -19673,6 +20482,41 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"vAL" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/glass/bottle/charcoal{
+	pixel_x = -4;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
+"vAU" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/item/radio/intercom{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"vBI" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "vFn" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -19707,6 +20551,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
+"vHs" = (
+/obj/machinery/dna_scannernew,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "vMI" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -19919,6 +20770,11 @@
 /obj/structure/railing/corner,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"wtk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "wtq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -20005,6 +20861,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"wKe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "wMa" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -20033,6 +20902,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/research)
+"wUV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "wVS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -20256,6 +21132,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"xAY" = (
+/obj/machinery/computer/pandemic,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "xBw" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -20277,6 +21161,14 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"xCT" = (
+/obj/effect/turf_decal/tile/blue/tile_marquee,
+/obj/effect/turf_decal/tile/neutral/tile_marquee{
+	dir = 1
+	},
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/plasteel/ameridiner,
+/area/medical/sleeper)
 "xDq" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/structure/cable/yellow{
@@ -20405,6 +21297,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "xQh" = (
@@ -20518,6 +21413,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"yjK" = (
+/obj/structure/table/glass,
+/obj/item/storage/pill_bottle/mutadone{
+	pixel_x = 10;
+	pixel_y = 8
+	},
+/obj/item/storage/box/disks{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/obj/item/storage/box/monkeycubes{
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -8
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "ykV" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -56891,9 +57806,9 @@ auJ
 aJx
 aQk
 aLu
-ovj
+rGX
 aCE
-ovj
+pej
 ovj
 aVH
 aLg
@@ -120637,7 +121552,7 @@ aaD
 aaD
 aVX
 pfe
-aaD
+gPH
 ajR
 ajR
 aHA
@@ -120881,9 +121796,9 @@ aOH
 kmc
 aTv
 gKP
+bMu
 bOm
-bym
-bOm
+szQ
 bOm
 bOm
 bOm
@@ -121137,21 +122052,21 @@ agb
 iqd
 ipz
 aTv
-avv
-avv
-aKd
-avv
-avv
-avv
-avv
+rgx
+epU
+txn
+aTv
+wKe
+eZl
+eZl
 aTv
 aTv
 aTv
 aTv
 aTv
 aTv
-aTv
-aTv
+uuy
+wUV
 xOb
 iHz
 tuZ
@@ -121394,20 +122309,20 @@ afB
 xHV
 kJd
 aTv
-avv
+nGx
 avv
 aWE
-avv
-avv
-avv
-avv
 aTv
-iop
-iop
-iop
-iop
-iop
-iop
+aaD
+aaD
+aaD
+aTv
+iiM
+fxG
+vHs
+hqi
+aTv
+aTv
 aTv
 aOj
 dyY
@@ -121653,21 +122568,21 @@ aFs
 ajR
 ajR
 aTv
+lvB
 aTv
 aTv
 aTv
 aTv
 aTv
+pbc
+dAr
+jpk
+rZA
+yjK
 aTv
-iop
-iop
-iop
-iop
-iop
-iop
-aTv
-aTv
-qry
+jJk
+avv
+dyY
 aTv
 aYV
 dJj
@@ -121908,23 +122823,23 @@ rQR
 opB
 adD
 aUd
-aOc
-iop
-iop
+ajR
+cNk
+aKd
 rbn
-amT
-aCX
-aCX
-aYD
-iop
-iop
-iop
-iop
-iop
-iop
 aTv
-aEP
-pVL
+aCX
+aCX
+pzt
+gkY
+nBI
+eZv
+kjr
+chJ
+aTv
+vBI
+avv
+dyY
 aTv
 aZQ
 aPf
@@ -122165,23 +123080,23 @@ agg
 agg
 adD
 aUd
-aOc
-iop
-iop
-iop
-amT
-aCX
-aCX
-aYD
-iop
-iop
-iop
-iop
-iop
-iop
+ajR
+bkd
+hPv
+iNK
 aTv
-avk
-rwl
+aCX
+aCX
+nVu
+kgj
+nBI
+kdP
+nBI
+gkY
+aTv
+aTv
+aTv
+qry
 aTv
 aTv
 ajR
@@ -122422,23 +123337,23 @@ aCo
 acq
 aFs
 aUd
-aOc
-iop
-iop
-iop
-amT
-aCX
-aCX
-aYD
-iop
-iop
-iop
-iop
-iop
-iop
+ajR
 aTv
-avk
-xcr
+hPv
+wtk
+aTv
+aCX
+aCX
+uTr
+knh
+tMt
+fdB
+tLQ
+pTk
+uuo
+aTv
+aEP
+pVL
 aJa
 aVr
 eHW
@@ -122679,20 +123594,20 @@ adD
 aFs
 aFs
 aAp
-aOc
-iop
-iop
-iop
-aYD
+ajR
+lvm
+aKd
+ksB
+aTv
 aCX
 aCX
-aYD
-iop
-iop
-iop
-iop
-iop
-iop
+lnP
+lkZ
+inY
+diA
+hpz
+uaj
+hja
 aTv
 aAU
 xcr
@@ -122936,21 +123851,21 @@ arj
 arj
 arj
 arj
-aOc
+ajR
 aPU
-aPU
-iop
+amv
+slz
 att
+dhQ
+sRz
+kle
+uTp
+gVk
+iop
+vsh
 iop
 iop
-iop
-iop
-iop
-iop
-iop
-iop
-iop
-aTv
+ajR
 aAb
 pVL
 aJa
@@ -123193,21 +124108,21 @@ arj
 arj
 arj
 arj
-aOc
-aOc
-aOc
-aOc
-aOc
+ajR
+ajR
+ajR
+ajR
+ajR
+dRI
+dzz
+pQo
+dRI
 iop
 iop
-iop
-iop
-iop
-iop
-iop
-iop
-iop
-aTv
+pHj
+tMW
+slY
+ajR
 aJa
 xcr
 aVr
@@ -123454,17 +124369,17 @@ arj
 arj
 arj
 arj
-aOc
+rbD
+reA
+oZa
+pnW
+iip
 iop
-iop
-iop
-iop
-iop
-iop
-iop
-iop
-iop
-aTv
+amT
+nOh
+iLM
+oBg
+ajR
 agW
 tDu
 uXW
@@ -123711,19 +124626,19 @@ arj
 arj
 arj
 aAp
-aOc
+rbD
+nCQ
+xCT
+cvu
+ncY
 iop
-iop
-iop
-iop
-iop
-iop
-iop
-iop
-iop
-aTv
+voU
+avk
+ezJ
+avk
 ajR
 ajR
+aIq
 ajR
 aTv
 atA
@@ -123968,18 +124883,18 @@ arj
 arj
 arj
 aAp
-aOc
+rbD
+hEY
+uaF
+nMi
+nkv
 iop
+cfs
+lFi
+nOh
+ckt
+tAL
 iop
-iop
-iop
-iop
-iop
-iop
-iop
-iop
-aOc
-aAp
 aUd
 aUd
 ajR
@@ -124225,18 +125140,18 @@ arj
 arj
 arj
 aAp
-aOc
+rbD
+uVq
+fam
+vAL
+oOj
 iop
+rwl
+bni
+nOh
+mrR
+axP
 iop
-iop
-iop
-iop
-iop
-iop
-iop
-iop
-aOc
-aAp
 aAp
 aAp
 aAp
@@ -124482,18 +125397,18 @@ arj
 arj
 arj
 aAp
-aOc
-aOc
-aOc
-aOc
-aOc
-aOc
-aOc
-aOc
-aOc
-aOc
-aOc
-aAp
+rbD
+rbD
+jEB
+jEB
+rbD
+iop
+iop
+iop
+vAU
+nyO
+pIb
+fWG
 arj
 arj
 arj
@@ -124745,12 +125660,12 @@ aUd
 aAp
 arj
 arj
-arj
-aAp
-aUd
-aAp
-aUd
-aAp
+ejk
+ldt
+xAY
+tUW
+bym
+iop
 arj
 arj
 arj
@@ -125003,11 +125918,11 @@ aAp
 arj
 arj
 arj
-aAp
-aAp
-aAp
-aAp
-aAp
+iop
+iop
+fWG
+iop
+iop
 arj
 arj
 arj


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Completely redoes Holestation's medical, scrapping the aux base in favor of more legroom.
The aux base will make a return in some form eventually, but this SHOULD make medical less a mess in the interim.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We should probably minimize one tile wide hallways. This also makes the RD the LAST head of staff with their gear out in the open on Hole.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots</summary>

Lower Floor:
![image](https://user-images.githubusercontent.com/50649185/171090121-25477d38-aeeb-48c0-8866-5dddc374193e.png)

Upper Floor:
![image](https://user-images.githubusercontent.com/50649185/171090205-98df3d9c-6205-44f4-bcb8-cd2a6f500a6c.png)


</details>

## Changelog

:cl:
tweak: Holestation medical's been completely redone to give each job more legroom and separate virology for safety reasons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
