### PR TITLE
Ports Inherit Suit Storage Units from Shiptest

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3606,6 +3606,7 @@
 #include "monkestation\code\datums\traits\negative.dm"
 #include "monkestation\code\datums\traits\neutral.dm"
 #include "monkestation\code\game\area\Space_Station_13_areas.dm"
+#include "monkestation\code\game\machinery\suit_storage_unit.dm"
 #include "monkestation\code\game\machinery\doors\airlock_types.dm"
 #include "monkestation\code\game\mecha\makeshift\lockermech.dm"
 #include "monkestation\code\game\mecha\makeshift\makeshift_tools.dm"

--- a/monkestation/code/game/machinery/suit_storage_unit.dm
+++ b/monkestation/code/game/machinery/suit_storage_unit.dm
@@ -1,0 +1,23 @@
+// Mapping helper unit takes whatever lies on top of it
+/obj/machinery/suit_storage_unit/inherit/Initialize(mapload)
+	. = ..()
+	if(mapload)
+		return INITIALIZE_HINT_LATELOAD
+
+/obj/machinery/suit_storage_unit/inherit/LateInitialize()
+	. = ..()
+	var/turf/our_turf = src.loc
+	for(var/atom/movable/checked_atom in our_turf)
+		if(istype(checked_atom, /obj/item/clothing/suit/space) && !suit)
+			checked_atom.forceMove(src)
+			suit = checked_atom
+		else if(istype(checked_atom, /obj/item/clothing/head/helmet/space) && !helmet)
+			checked_atom.forceMove(src)
+			helmet = checked_atom
+		else if(istype(checked_atom, /obj/item/clothing/mask) && !mask)
+			checked_atom.forceMove(src)
+			mask = checked_atom
+		else if(istype(checked_atom, /obj/item) && !storage)
+			checked_atom.forceMove(src)
+			storage = checked_atom
+	update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
So, mappers have had a history of assuming suit storage units will take the contents on the tile they're on, when they don't. So I dig into it out of boredom.

It turns out in an entirely random Shiptest PR, they made a suit storage unit that does *exactly that.* - Specifically, https://github.com/shiptest-ss13/Shiptest/pull/234

I took the liberty of renaming the variables to not be single or dual letters, but the rest of the code is theirs verbatim. I don't feel comfortable putting my name on the CL for that reason, hence why it's formatted the way it is.

Please consider implementing these properly in code rather than on the map if you're going to be placing multiple.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
QOL for fledgling mappers. I know a few are currently active in the discord and it's been fun to watch them grow, even if silently - you probably know who you are <3
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Changelog

:cl: AsciiSquid for Shiptest
add: A suit storage mapping helper's been added for non-preset use-cases. Please consider creating a new preset if you use the same types repeatedly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
