### PR TITLE
Fixes Survival Pod Window Shitcode

### DIFF
--- a/_maps/map_files/HoleStation/holestation.dmm
+++ b/_maps/map_files/HoleStation/holestation.dmm
@@ -121,10 +121,8 @@
 /turf/closed/wall,
 /area/crew_quarters/heads/hop)
 "aaw" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
 /obj/machinery/camera/autoname,
+/obj/structure/window/reinforced/survival_pod/spawner/east,
 /turf/open/openspace,
 /area/ai_monitored/turret_protected/ai)
 "aax" = (
@@ -2270,9 +2268,7 @@
 /turf/open/floor/carpet,
 /area/maintenance/port/aft)
 "aje" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8
-	},
+/obj/structure/window/reinforced/survival_pod/spawner/west,
 /turf/open/openspace,
 /area/ai_monitored/turret_protected/ai)
 "ajf" = (
@@ -5113,9 +5109,7 @@
 	},
 /area/ai_monitored/turret_protected/ai_upload)
 "atx" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
+/obj/structure/window/reinforced/survival_pod/spawner/east,
 /turf/open/openspace,
 /area/ai_monitored/turret_protected/ai)
 "aty" = (
@@ -5831,12 +5825,10 @@
 /turf/open/floor/plasteel,
 /area/security/nuke_storage)
 "awi" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8
-	},
 /obj/machinery/camera/autoname{
 	dir = 6
 	},
+/obj/structure/window/reinforced/survival_pod/spawner/west,
 /turf/open/openspace,
 /area/ai_monitored/turret_protected/ai)
 "awk" = (
@@ -6049,14 +6041,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "awX" = (
-/obj/structure/window/reinforced/survival_pod,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8
-	},
-/obj/structure/window/reinforced/survival_pod{
+/obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/window/reinforced/survival_pod/spawner/west,
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
 	dir = 10
 	},
 /turf/open/floor/plating,
@@ -8394,14 +8384,12 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "aGr" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
-/obj/structure/window/reinforced/survival_pod,
-/obj/structure/window/reinforced/survival_pod{
+/obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/window/reinforced/survival_pod/spawner/east,
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
 	dir = 6
 	},
 /turf/open/floor/plating,
@@ -10089,19 +10077,17 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/server)
 "aMQ" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
-/obj/structure/window/reinforced/survival_pod,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 6
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable/orange{
 	icon_state = "0-8"
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/east,
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
@@ -10732,13 +10718,11 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "aPg" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/porta_turret/ai,
+/obj/structure/window/reinforced/survival_pod/spawner/west,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
 "aPh" = (
@@ -11877,13 +11861,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "aSH" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/machinery/porta_turret/ai,
+/obj/structure/window/reinforced/survival_pod/spawner/east,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai)
 "aSI" = (
@@ -12113,17 +12095,15 @@
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "aTz" = (
-/obj/structure/window/reinforced/survival_pod,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 10
-	},
 /obj/machinery/turretid{
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/west,
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
 	dir = 10
 	},
 /turf/open/floor/plating,

--- a/code/game/objects/effects/spawners/structure.dm
+++ b/code/game/objects/effects/spawners/structure.dm
@@ -201,12 +201,12 @@ again.
 /obj/effect/spawner/structure/window/survival_pod
 	name = "pod window spawner"
 	icon_state = "podwindow_spawner"
-	spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/survival_pod)
+	spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod)
 
 /obj/effect/spawner/structure/window/hollow/survival_pod
 	name = "hollow pod window spawner"
 	icon_state = "podwindow_spawner_full"
-	spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod, /obj/structure/window/shuttle/survival_pod/spawner/north, /obj/structure/window/shuttle/survival_pod/spawner/east, /obj/structure/window/shuttle/survival_pod/spawner/west)
+	spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/survival_pod, /obj/structure/window/reinforced/survival_pod/spawner/north, /obj/structure/window/reinforced/survival_pod/spawner/east, /obj/structure/window/reinforced/survival_pod/spawner/west)
 
 /obj/effect/spawner/structure/window/hollow/survival_pod/end
 	icon_state = "podwindow_spawner_end"
@@ -214,13 +214,13 @@ again.
 /obj/effect/spawner/structure/window/hollow/survival_pod/end/Initialize(mapload)
 	switch(dir)
 		if(NORTH)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod/spawner/north, /obj/structure/window/shuttle/survival_pod/spawner/east, /obj/structure/window/shuttle/survival_pod/spawner/west)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/survival_pod/spawner/north, /obj/structure/window/reinforced/survival_pod/spawner/east, /obj/structure/window/reinforced/survival_pod/spawner/west)
 		if(EAST)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod, /obj/structure/window/shuttle/survival_pod/spawner/north, /obj/structure/window/shuttle/survival_pod/spawner/east)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/survival_pod, /obj/structure/window/reinforced/survival_pod/spawner/north, /obj/structure/window/reinforced/survival_pod/spawner/east)
 		if(SOUTH)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod, /obj/structure/window/shuttle/survival_pod/spawner/east, /obj/structure/window/shuttle/survival_pod/spawner/west)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/survival_pod, /obj/structure/window/reinforced/survival_pod/spawner/east, /obj/structure/window/reinforced/survival_pod/spawner/west)
 		if(WEST)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod, /obj/structure/window/shuttle/survival_pod/spawner/north, /obj/structure/window/shuttle/survival_pod/spawner/west)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/survival_pod, /obj/structure/window/reinforced/survival_pod/spawner/north, /obj/structure/window/reinforced/survival_pod/spawner/west)
 	. = ..()
 
 /obj/effect/spawner/structure/window/hollow/survival_pod/middle
@@ -229,9 +229,9 @@ again.
 /obj/effect/spawner/structure/window/hollow/survival_pod/middle/Initialize(mapload)
 	switch(dir)
 		if(NORTH,SOUTH)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod, /obj/structure/window/shuttle/survival_pod/spawner/north)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/survival_pod, /obj/structure/window/reinforced/survival_pod/spawner/north)
 		if(EAST,WEST)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod/spawner/east, /obj/structure/window/shuttle/survival_pod/spawner/west)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/survival_pod/spawner/east, /obj/structure/window/reinforced/survival_pod/spawner/west)
 	. = ..()
 
 /obj/effect/spawner/structure/window/hollow/survival_pod/directional
@@ -240,21 +240,21 @@ again.
 /obj/effect/spawner/structure/window/hollow/survival_pod/directional/Initialize(mapload)
 	switch(dir)
 		if(NORTH)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod/spawner/north)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/survival_pod/spawner/north)
 		if(NORTHEAST)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod/spawner/north, /obj/structure/window/shuttle/survival_pod/spawner/east)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/survival_pod/spawner/north, /obj/structure/window/reinforced/survival_pod/spawner/east)
 		if(EAST)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod/spawner/east)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/survival_pod/spawner/east)
 		if(SOUTHEAST)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod, /obj/structure/window/shuttle/survival_pod/spawner/east)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/survival_pod, /obj/structure/window/reinforced/survival_pod/spawner/east)
 		if(SOUTH)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/survival_pod)
 		if(SOUTHWEST)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod, /obj/structure/window/shuttle/survival_pod/spawner/west)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/survival_pod, /obj/structure/window/reinforced/survival_pod/spawner/west)
 		if(WEST)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod/spawner/west)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/survival_pod/spawner/west)
 		if(NORTHWEST)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod/spawner/north, /obj/structure/window/shuttle/survival_pod/spawner/west)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/survival_pod/spawner/north, /obj/structure/window/reinforced/survival_pod/spawner/west)
 	. = ..()
 
 

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -124,19 +124,19 @@
 	//smooth = SMOOTH_MORE //MONKESTATION REMOVAL
 	//canSmoothWith = list(/turf/closed/wall/mineral/titanium/survival, /obj/machinery/door/airlock/survival_pod, /obj/structure/window/shuttle/survival_pod) //MONKESTATION REMOVAL
 
-/obj/structure/window/shuttle/survival_pod/spawner/north
-	dir = NORTH
-
-/obj/structure/window/shuttle/survival_pod/spawner/east
-	dir = EAST
-
-/obj/structure/window/shuttle/survival_pod/spawner/west
-	dir = WEST
-
 /obj/structure/window/reinforced/survival_pod
 	name = "pod window"
 	icon = 'icons/obj/lavaland/survival_pod.dmi'
 	icon_state = "pwindow"
+
+/obj/structure/window/reinforced/survival_pod/spawner/north
+	dir = NORTH
+
+/obj/structure/window/reinforced/survival_pod/spawner/east
+	dir = EAST
+
+/obj/structure/window/reinforced/survival_pod/spawner/west
+	dir = WEST
 
 //Door
 /obj/machinery/door/airlock/survival_pod

--- a/monkestation/_maps/shuttles/emergency_holestation.dmm
+++ b/monkestation/_maps/shuttles/emergency_holestation.dmm
@@ -45,8 +45,7 @@
 /turf/open/floor/carpet/purple,
 /area/shuttle/escape)
 "fa" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle/survival_pod,
+/obj/effect/spawner/structure/window/survival_pod,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "ga" = (
@@ -66,19 +65,15 @@
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "hB" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 5
-	},
 /obj/effect/turf_decal/monke/siding/thinplating/dark{
 	dir = 5
 	},
 /obj/structure/flora/ausbushes/leafybush,
+/obj/structure/window/reinforced/survival_pod/spawner/east,
+/obj/structure/window/reinforced/survival_pod/spawner/north,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 5
+	},
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "ii" = (
@@ -136,12 +131,10 @@
 /area/shuttle/escape)
 "kX" = (
 /obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
 /obj/effect/turf_decal/monke/siding/thinplating/light{
 	dir = 1
 	},
+/obj/structure/window/reinforced/survival_pod/spawner/north,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "li" = (
@@ -152,14 +145,12 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "lz" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
 /obj/effect/turf_decal/monke/siding/thinplating/dark{
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/window/reinforced/survival_pod/spawner/north,
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "lI" = (
@@ -235,13 +226,11 @@
 /area/shuttle/escape)
 "rm" = (
 /obj/structure/window/reinforced/survival_pod,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
 /obj/effect/turf_decal/monke/siding/thinplating/dark{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/window/reinforced/survival_pod/spawner/north,
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "rF" = (
@@ -332,12 +321,10 @@
 /area/shuttle/escape)
 "xS" = (
 /obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/window/reinforced/survival_pod/spawner/north,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "yX" = (
@@ -359,15 +346,13 @@
 /turf/open/floor/pod,
 /area/shuttle/escape)
 "Be" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
 /obj/effect/turf_decal/monke/siding/thinplating/dark{
 	dir = 1
 	},
 /obj/item/toy/plush/moth/ookplush,
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/junglebush,
+/obj/structure/window/reinforced/survival_pod/spawner/north,
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "Bn" = (
@@ -451,13 +436,11 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/escape)
 "Gg" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
 /obj/effect/turf_decal/monke/siding/thinplating/dark{
 	dir = 1
 	},
 /obj/structure/flora/grass/jungle,
+/obj/structure/window/reinforced/survival_pod/spawner/north,
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "HX" = (
@@ -475,9 +458,7 @@
 	pixel_y = 4
 	},
 /obj/item/pen,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8
-	},
+/obj/structure/window/reinforced/survival_pod/spawner/west,
 /turf/open/floor/pod,
 /area/shuttle/escape)
 "IC" = (
@@ -523,9 +504,7 @@
 	dir = 4
 	},
 /obj/item/kirbyplants/random,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
+/obj/structure/window/reinforced/survival_pod/spawner/east,
 /turf/open/floor/pod,
 /area/shuttle/escape)
 "Lu" = (
@@ -539,14 +518,12 @@
 /area/shuttle/escape)
 "LU" = (
 /obj/structure/window/reinforced/survival_pod,
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
 /obj/item/toy/plush/moth/tyriaplush,
 /obj/effect/turf_decal/monke/siding/thinplating/dark{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/window/reinforced/survival_pod/spawner/north,
 /turf/open/floor/fakespace,
 /area/shuttle/escape)
 "MM" = (
@@ -562,20 +539,16 @@
 /turf/open/floor/carpet/green,
 /area/shuttle/escape)
 "MP" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 9
-	},
 /obj/effect/turf_decal/monke/siding/thinplating/dark{
 	dir = 9
 	},
 /obj/structure/flora/rock/jungle,
 /obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window/reinforced/survival_pod/spawner/west,
+/obj/structure/window/reinforced/survival_pod/spawner/north,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 9
+	},
 /turf/open/floor/grass,
 /area/shuttle/escape)
 "Nk" = (

--- a/monkestation/_maps/shuttles/exploration_holestation.dmm
+++ b/monkestation/_maps/shuttles/exploration_holestation.dmm
@@ -415,9 +415,7 @@
 /obj/machinery/atmospherics/components/unary/shuttle/heater{
 	dir = 1
 	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
+/obj/structure/window/reinforced/survival_pod/spawner/north,
 /turf/open/floor/plating/airless,
 /area/shuttle/exploration)
 "Um" = (

--- a/monkestation/_maps/shuttles/mining_holestation.dmm
+++ b/monkestation/_maps/shuttles/mining_holestation.dmm
@@ -17,58 +17,44 @@
 /turf/open/floor/pod,
 /area/shuttle/mining)
 "k" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8
-	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
+/obj/structure/window/reinforced/survival_pod/spawner/west,
 /turf/open/floor/pod,
 /area/shuttle/mining)
 "n" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 9
-	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/west,
+/obj/structure/window/reinforced/survival_pod/spawner/north,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 9
 	},
 /turf/open/floor/pod,
 /area/shuttle/mining)
 "o" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
+/obj/structure/window/reinforced/survival_pod/spawner/east,
 /turf/open/floor/pod,
 /area/shuttle/mining)
 "u" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
 /obj/machinery/light/small,
 /obj/structure/ore_box,
+/obj/structure/window/reinforced/survival_pod/spawner/east,
 /turf/open/floor/pod,
 /area/shuttle/mining)
 "w" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 5
-	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/east,
+/obj/structure/window/reinforced/survival_pod/spawner/north,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 5
 	},
 /turf/open/floor/pod,
 /area/shuttle/mining)
@@ -76,17 +62,13 @@
 /turf/open/floor/pod,
 /area/shuttle/mining)
 "W" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8
-	},
 /obj/structure/closet/crate,
+/obj/structure/window/reinforced/survival_pod/spawner/west,
 /turf/open/floor/pod,
 /area/shuttle/mining)
 "Y" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
 /obj/machinery/computer/shuttle_flight/mining,
+/obj/structure/window/reinforced/survival_pod/spawner/north,
 /turf/open/floor/pod,
 /area/shuttle/mining)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
I love how on every codebase, *ever*, survival pod windows are fucking broken and everyone just kinda pretends they're not

This fixes survival pod windows in their entirety and uses the newly fixed spawners where appropriate on Holestation. The spawners are now safe to use.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
***ISSS FIX***
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Changelog

:cl:
fix: Survival pod window spawners now finally work and are no longer improperly pathed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
