### PR TITLE
Alt Movement "Fix"

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3601,6 +3601,7 @@
 #include "monkestation\code\datums\greyscale\greyscale_configs.dm"
 #include "monkestation\code\datums\keybinding\human.dm"
 #include "monkestation\code\datums\keybinding\living.dm"
+#include "monkestation\code\datums\keybinding\passthrough.dm"
 #include "monkestation\code\datums\station_traits\neutral_traits.dm"
 #include "monkestation\code\datums\traits\good.dm"
 #include "monkestation\code\datums\traits\negative.dm"

--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -77,3 +77,9 @@
 //MonkeStation Edit: Hotkey Emotes
 
 #define COMSIG_KB_EMOTE_QUICK_EMOTE		"keybinding_emote"
+
+//Movement Passthrough
+#define COMSIG_KB_MOB_MOVENORTH_PASSTHROUGH "keybinding_mob_move_north_passthrough"
+#define COMSIG_KB_MOB_MOVESOUTH_PASSTHROUGH "keybinding_mob_move_south_passthrough"
+#define COMSIG_KB_MOB_MOVEEAST_PASSTHROUGH "keybinding_mob_move_east_passthrough"
+#define COMSIG_KB_MOB_MOVEWEST_PASSTHROUGH "keybinding_mob_move_west_passthrough"

--- a/monkestation/code/datums/keybinding/passthrough.dm
+++ b/monkestation/code/datums/keybinding/passthrough.dm
@@ -1,0 +1,111 @@
+/datum/keybinding/mob/passthrough
+		category = CATEGORY_HUMAN
+		weight = WEIGHT_MOB
+
+
+//I will outright admit, this is a hack. But functionality is the most important thing when things break.
+//It's actually rather interesting how WASD itself is hacked in.
+//The movement press itself sends WASD, but the down/up proc itself sends North, West, East, South instead
+//Byond is hardcoded to use those for movement I suppose?
+//Any better solution to this would be welcomed, but I'd simply like to see mechas and walking work again.
+//Thanks for coming to my TED Talk.
+
+//UP
+
+/datum/keybinding/mob/passthrough/alt_north
+	key = "Alt+W"
+	name = "move_north_passthrough"
+	full_name = "Move North(Alt)"
+	description = ""
+	keybind_signal = COMSIG_KB_MOB_MOVENORTH_PASSTHROUGH
+
+/datum/keybinding/mob/passthrough/alt_north/down(client/user)
+	. = ..()
+	if(.)
+		return
+	if(!user.mob) return
+	user.keyDown("North")
+	return TRUE
+
+/datum/keybinding/mob/passthrough/alt_north/up(client/user)
+	. = ..()
+	if(.)
+		return
+	if(!user.mob) return
+	user.keyUp("North")
+	return TRUE
+
+//DOWN
+
+/datum/keybinding/mob/passthrough/alt_south
+	key = "Alt+S"
+	name = "move_south_passthrough"
+	full_name = "Move South(Alt)"
+	description = ""
+	keybind_signal = COMSIG_KB_MOB_MOVESOUTH_PASSTHROUGH
+
+/datum/keybinding/mob/passthrough/alt_south/down(client/user)
+	. = ..()
+	if(.)
+		return
+	if(!user.mob) return
+	user.keyDown("South")
+	return TRUE
+
+/datum/keybinding/mob/passthrough/alt_south/up(client/user)
+	. = ..()
+	if(.)
+		return
+	if(!user.mob) return
+	user.keyUp("South")
+	return TRUE
+
+//RIGHT
+
+/datum/keybinding/mob/passthrough/alt_east
+	key = "Alt+D"
+	name = "move_east_passthrough"
+	full_name = "Move East(Alt)"
+	description = ""
+	keybind_signal = COMSIG_KB_MOB_MOVEEAST_PASSTHROUGH
+
+/datum/keybinding/mob/passthrough/alt_east/down(client/user)
+	. = ..()
+	if(.)
+		return
+	if(!user.mob) return
+	user.keyDown("East")
+	return TRUE
+
+/datum/keybinding/mob/passthrough/alt_east/up(client/user)
+	. = ..()
+	if(.)
+		return
+	if(!user.mob) return
+	user.keyUp("East")
+	return TRUE
+
+//LEFT
+
+/datum/keybinding/mob/passthrough/alt_west
+	key = "Alt+A"
+	name = "move_west_passthrough"
+	full_name = "Move West(Alt)"
+	description = ""
+	keybind_signal = COMSIG_KB_MOB_MOVEWEST_PASSTHROUGH
+
+/datum/keybinding/mob/passthrough/alt_west/down(client/user)
+	. = ..()
+	if(.)
+		return
+	if(!user.mob) return
+	user.keyDown("West")
+	return TRUE
+
+/datum/keybinding/mob/passthrough/alt_west/up(client/user)
+	. = ..()
+	if(.)
+		return
+	if(!user.mob) return
+	user.keyUp("West")
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Adds a set of movement keybindings that are meant to simulate a key passthrough.
This allows you to walk and move at the same time and use mecha strafe mode as intended once again.

## Why It's Good For The Game

Mechas have been broken due to their inability to strafewalk and with the addition of liquids, we need means to actually walk through puddles.

closes #110

## Changelog

:cl:
add: Adds a new set of keybindings to allow for alt-walking and mecha strafing
fix: RESET OR MANUALLY ADD YOUR CUSTOM BIND
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
