### PR TITLE
[Speedmerge] Fixes Large Mining Shuttle

### DIFF
--- a/_maps/shuttles/mining_box.dmm
+++ b/_maps/shuttles/mining_box.dmm
@@ -3,9 +3,7 @@
 /turf/closed/wall/mineral/titanium/survival,
 /area/shuttle/mining)
 "b" = (
-/obj/effect/spawner/structure/window/hollow/survival_pod/directional{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/survival_pod,
 /turf/open/floor/plating,
 /area/shuttle/mining)
 "c" = (
@@ -51,16 +49,9 @@
 /area/shuttle/mining)
 "j" = (
 /obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/plating,
 /area/shuttle/mining)
 "k" = (
@@ -74,12 +65,6 @@
 "q" = (
 /turf/closed/wall/mineral/titanium/survival/nodiagonal,
 /area/shuttle/mining)
-"F" = (
-/obj/effect/spawner/structure/window/hollow/survival_pod/directional{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/mining)
 "K" = (
 /turf/open/floor/pod/light,
 /area/shuttle/mining)
@@ -89,19 +74,13 @@
 	},
 /turf/open/floor/pod/dark,
 /area/shuttle/mining)
-"X" = (
-/obj/effect/spawner/structure/window/hollow/survival_pod/directional{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/mining)
 
 (1,1,1) = {"
 a
 q
-X
+b
 q
-X
+b
 q
 a
 "}
@@ -135,9 +114,9 @@ q
 (5,1,1) = {"
 a
 q
-F
+b
 h
-F
+b
 q
 a
 "}

--- a/_maps/shuttles/mining_delta.dmm
+++ b/_maps/shuttles/mining_delta.dmm
@@ -3,9 +3,7 @@
 /turf/closed/wall/mineral/titanium/survival,
 /area/shuttle/mining)
 "b" = (
-/obj/effect/spawner/structure/window/hollow/survival_pod/directional{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/survival_pod,
 /turf/open/floor/plating,
 /area/shuttle/mining)
 "c" = (
@@ -256,16 +254,10 @@
 /area/shuttle/mining)
 "r" = (
 /obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/plating/airless,
 /area/shuttle/mining)
 "s" = (
@@ -279,24 +271,9 @@
 /area/shuttle/mining)
 "t" = (
 /obj/structure/shuttle/engine/propulsion/burst,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/plating/airless,
-/area/shuttle/mining)
-"J" = (
-/obj/effect/spawner/structure/window/hollow/survival_pod/directional{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/mining)
-"Q" = (
-/obj/effect/spawner/structure/window/hollow/survival_pod/directional{
-	dir = 8
-	},
-/turf/open/floor/plating,
 /area/shuttle/mining)
 "S" = (
 /turf/closed/wall/mineral/titanium/survival/nodiagonal,
@@ -305,9 +282,9 @@
 (1,1,1) = {"
 a
 S
-Q
+b
 i
-Q
+b
 S
 a
 "}
@@ -341,9 +318,9 @@ S
 (5,1,1) = {"
 a
 S
-J
+b
 m
-J
+b
 S
 a
 "}

--- a/_maps/shuttles/mining_fland.dmm
+++ b/_maps/shuttles/mining_fland.dmm
@@ -12,12 +12,6 @@
 	},
 /turf/open/floor/pod/dark,
 /area/shuttle/mining/large)
-"g" = (
-/obj/effect/spawner/structure/window/hollow/survival_pod/directional{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/mining/large)
 "l" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -58,14 +52,8 @@
 "q" = (
 /obj/structure/shuttle/engine/heater,
 /obj/effect/turf_decal/stripes/full,
-/obj/effect/spawner/structure/window/hollow/survival_pod/directional,
+/obj/effect/spawner/structure/window/hollow/survival_pod/middle,
 /turf/open/floor/plating/airless,
-/area/shuttle/mining/large)
-"t" = (
-/obj/effect/spawner/structure/window/hollow/survival_pod/directional{
-	dir = 8
-	},
-/turf/open/floor/plating,
 /area/shuttle/mining/large)
 "u" = (
 /obj/effect/turf_decal/stripes/line{
@@ -266,9 +254,7 @@
 /turf/closed/wall/mineral/titanium/survival,
 /area/shuttle/mining/large)
 "V" = (
-/obj/effect/spawner/structure/window/hollow/survival_pod/directional{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/survival_pod,
 /turf/open/floor/plating,
 /area/shuttle/mining/large)
 "Y" = (
@@ -281,10 +267,10 @@
 
 (1,1,1) = {"
 U
-t
+V
 U
 n
-t
+V
 I
 a
 "}
@@ -317,10 +303,10 @@ E
 "}
 (5,1,1) = {"
 U
-g
+V
 U
 P
-g
+V
 I
 a
 "}

--- a/_maps/shuttles/mining_large.dmm
+++ b/_maps/shuttles/mining_large.dmm
@@ -2,12 +2,6 @@
 "a" = (
 /turf/template_noop,
 /area/template_noop)
-"b" = (
-/obj/effect/spawner/structure/window/hollow/survival_pod/directional{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/shuttle/mining/large)
 "c" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/emergency,
@@ -434,10 +428,7 @@
 /area/shuttle/mining/large)
 "G" = (
 /obj/structure/shuttle/engine/heater,
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/plating/airless,
 /area/shuttle/mining/large)
 "H" = (
@@ -475,46 +466,26 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/mining/large)
-"N" = (
-/obj/effect/spawner/structure/window/hollow/survival_pod/directional{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/shuttle/mining/large)
 "Q" = (
-/obj/effect/spawner/structure/window/hollow/survival_pod/directional{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/shuttle/mining/large)
-"U" = (
-/obj/effect/spawner/structure/window/hollow/survival_pod/directional{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/mining/large)
-"Y" = (
-/obj/effect/spawner/structure/window/hollow/survival_pod/directional{
-	dir = 1
-	},
+/obj/effect/spawner/structure/window/survival_pod,
 /turf/open/floor/plating,
 /area/shuttle/mining/large)
 
 (1,1,1) = {"
 a
-U
-U
+Q
+Q
 k
 k
 k
-U
+Q
 k
 F
 a
 "}
 (2,1,1) = {"
-b
-Y
+Q
+Q
 f
 l
 k
@@ -525,7 +496,7 @@ G
 I
 "}
 (3,1,1) = {"
-Y
+Q
 c
 g
 m
@@ -537,7 +508,7 @@ k
 k
 "}
 (4,1,1) = {"
-Y
+Q
 d
 h
 n
@@ -549,7 +520,7 @@ H
 J
 "}
 (5,1,1) = {"
-Y
+Q
 e
 i
 o
@@ -562,7 +533,7 @@ k
 "}
 (6,1,1) = {"
 Q
-Y
+Q
 j
 p
 k
@@ -575,11 +546,11 @@ I
 (7,1,1) = {"
 a
 Q
-N
+Q
 k
 k
 k
-N
+Q
 k
 F
 a

--- a/_maps/templates/shelter_2.dmm
+++ b/_maps/templates/shelter_2.dmm
@@ -65,14 +65,11 @@
 /turf/open/floor/pod,
 /area/survivalpod)
 "n" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8;
-	layer = 3
-	},
 /obj/machinery/door/window/survival_pod{
 	dir = 1;
 	icon_state = "windoor"
 	},
+/obj/structure/window/reinforced/survival_pod/spawner/west,
 /turf/open/floor/carpet/black,
 /area/survivalpod)
 "o" = (
@@ -82,9 +79,7 @@
 	icon_state = "cutout_lusty";
 	name = "lusty xenomorph maid"
 	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
+/obj/structure/window/reinforced/survival_pod/spawner/north,
 /turf/open/floor/carpet/black,
 /area/survivalpod)
 "p" = (
@@ -101,9 +96,7 @@
 /turf/open/floor/pod,
 /area/survivalpod)
 "r" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8
-	},
+/obj/structure/window/reinforced/survival_pod/spawner/west,
 /turf/open/floor/carpet/black,
 /area/survivalpod)
 "s" = (
@@ -126,12 +119,10 @@
 /obj/machinery/microwave{
 	pixel_y = -2
 	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
 /obj/structure/table/wood/fancy/black{
 	pixel_y = -9
 	},
+/obj/structure/window/reinforced/survival_pod/spawner/north,
 /turf/open/floor/carpet/black,
 /area/survivalpod)
 "u" = (
@@ -142,9 +133,6 @@
 /turf/open/floor/carpet/black,
 /area/survivalpod)
 "v" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
 /obj/structure/displaycase{
 	alert = 0;
 	desc = "A display case containing an expensive forgery, probably.";
@@ -152,6 +140,7 @@
 	req_access_txt = "48";
 	start_showpiece_type = /obj/item/fakeartefact
 	},
+/obj/structure/window/reinforced/survival_pod/spawner/north,
 /turf/open/floor/carpet/black,
 /area/survivalpod)
 "w" = (

--- a/_maps/templates/shelter_3.dmm
+++ b/_maps/templates/shelter_3.dmm
@@ -168,17 +168,7 @@
 /turf/closed/wall/mineral/titanium/survival/nodiagonal,
 /area/survivalpod)
 "C" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 8
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
-/obj/structure/window/reinforced/survival_pod,
-/obj/structure/grille,
+/obj/effect/spawner/structure/window/survival_pod,
 /turf/open/floor/pod/dark,
 /area/survivalpod)
 "D" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Fixes the large mining shuttle (and some others) as they were designed with pod window shitcode in mind.

Other maps touched have been touched for the same reasons.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
#423 left the large mining shuttle spaced roundstart which is in fact bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
fix: The large mining shuttle is no longer spaced roundstart.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
