### PR TITLE
Hard del Fixes [Bee PORT]

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -67,6 +67,11 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	if(usr.client == parent.current_user)
 		parent.finished = TRUE
 
+/atom/movable/screen/radial/center/Destroy()
+	if(parent)
+		parent.close_button = null
+	return ..()
+
 /datum/radial_menu
 	/// List of choice IDs
 	var/list/choices = list()

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -229,6 +229,10 @@
 	reagents = tank.reagents
 	max_water = tank.volume
 
+/obj/item/extinguisher/mini/nozzle/Destroy()
+	reagents = null
+	tank = null
+	return ..()
 
 /obj/item/extinguisher/mini/nozzle/doMove(atom/destination)
 	if(destination && (destination != tank.loc || !ismob(destination)))

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -69,6 +69,12 @@
 	to_chat(holder,"<span class='warning'>You feel a gust of energy flow through your body... the Rusted Hills heard your call...</span>")
 	qdel(sword)
 
+/datum/action/innate/heretic_shatter/Destroy()
+	if(sword)
+		sword.linked_action = null
+		sword = null
+	holder = null
+	return ..()
 
 /obj/item/melee/sickly_blade
 	name = "Sickly blade"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

- Ports some of Bee's latest hard-del fixes for heretic blades, atmos backpack nozzle, and Radial Menu Center Buttons.
- Prevents hard-del of `/atom/movable/screen/radial/center `by clearing out an extant reference.

## Why It's Good For The Game
Fixes some hard-dels

## Testing Photographs and Procedure
N/A

## PR References
- https://github.com/BeeStation/BeeStation-Hornet/pull/6921
- https://github.com/BeeStation/BeeStation-Hornet/pull/6971
- https://github.com/BeeStation/BeeStation-Hornet/pull/6908

## Changelog
:cl: Penwin0, DatBoiTim
 fix: Fixes harddel in heretic blades
 fix: fixes harddel with atmos backpack nozzle
 fix: Fixed Hard-Del of Radial Menu Center Button
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
