### PR TITLE
Exploration PP - Remapping The Old

### DIFF
--- a/_maps/RuinGeneration/13x13_ai-lab.dmm
+++ b/_maps/RuinGeneration/13x13_ai-lab.dmm
@@ -130,9 +130,6 @@
 /area/ruin/unpowered)
 "tD" = (
 /obj/effect/abstract/doorway_marker,
-/obj/machinery/door/airlock/grunge{
-	name = "Artificial Intelligence research"
-	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered)
 "tJ" = (
@@ -162,7 +159,9 @@
 /turf/template_noop,
 /area/template_noop)
 "vj" = (
-/obj/machinery/holopad,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/ruin/unpowered)
 "vv" = (
@@ -173,8 +172,7 @@
 /area/ruin/unpowered)
 "vX" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen,
-/turf/open/floor/plasteel/tech/grid,
+/turf/open/floor/plating,
 /area/ruin/unpowered)
 "za" = (
 /obj/item/kirbyplants/photosynthetic{
@@ -190,7 +188,6 @@
 	dir = 4
 	},
 /obj/machinery/flasher{
-	id = "AI";
 	pixel_y = 24
 	},
 /obj/effect/spawner/lootdrop/ruinloot/important,
@@ -199,10 +196,6 @@
 "BT" = (
 /obj/machinery/door/airlock/highsecurity,
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "AI Core shutters";
-	name = "AI core shutters"
-	},
 /turf/open/floor/circuit/red,
 /area/ruin/unpowered)
 "CO" = (
@@ -274,11 +267,6 @@
 /area/ruin/unpowered)
 "Lx" = (
 /obj/effect/decal/cleanable/robot_debris/old,
-/obj/machinery/camera{
-	c_tag = "Telecomms - Server Room - Aft-Port";
-	dir = 9;
-	network = list("ss13","tcomms")
-	},
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/item/ammo_casing/c9mm{
 	dir = 8;
@@ -430,7 +418,7 @@ JS
 JS
 tJ
 SV
-SV
+vj
 SV
 SV
 WX
@@ -466,7 +454,7 @@ vX
 JS
 to
 SV
-vj
+SV
 SV
 SV
 JS

--- a/_maps/RuinGeneration/13x13_cafe.dmm
+++ b/_maps/RuinGeneration/13x13_cafe.dmm
@@ -72,15 +72,28 @@
 "m" = (
 /turf/open/floor/wood,
 /area/ruin/unpowered)
+"n" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "p" = (
-/obj/effect/spawner/structure/window/shutter,
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "q" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/window/spawner,
+/obj/item/toy/plush/moth/ookplush,
 /turf/open/floor/grass,
+/area/ruin/unpowered)
+"r" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "s" = (
 /obj/effect/abstract/doorway_marker{
@@ -112,6 +125,10 @@
 /obj/effect/abstract/doorway_marker,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"z" = (
+/obj/effect/turf_decal/tile/neutral/tile_side,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "A" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -126,6 +143,10 @@
 "C" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/floor/grass,
+/area/ruin/unpowered)
+"D" = (
+/obj/effect/turf_decal/tile/neutral/tile_full,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "E" = (
 /obj/structure/dresser,
@@ -177,6 +198,10 @@
 /obj/effect/turf_decal/tile/red/tile_marquee,
 /obj/structure/closet/crate/wooden/toy,
 /obj/effect/spawner/lootdrop/ruinloot/security,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"L" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "M" = (
@@ -262,7 +287,7 @@ U
 f
 p
 Y
-Y
+L
 Y
 u
 "}
@@ -277,7 +302,7 @@ U
 G
 p
 Y
-Y
+L
 Y
 y
 "}
@@ -292,7 +317,7 @@ U
 g
 p
 Y
-Y
+L
 Y
 u
 "}
@@ -307,7 +332,7 @@ U
 U
 u
 Y
-Y
+L
 Y
 u
 "}
@@ -322,7 +347,7 @@ U
 U
 l
 Y
-Y
+z
 Y
 Y
 "}
@@ -337,8 +362,8 @@ U
 U
 p
 Y
-Y
-Y
+D
+r
 W
 "}
 (8,1,1) = {"
@@ -352,7 +377,7 @@ U
 U
 l
 Y
-Y
+n
 Y
 Y
 "}
@@ -367,7 +392,7 @@ X
 U
 u
 Y
-Y
+L
 Y
 u
 "}
@@ -382,7 +407,7 @@ X
 U
 p
 Y
-Y
+L
 Y
 u
 "}
@@ -397,7 +422,7 @@ X
 U
 p
 Y
-Y
+L
 Y
 y
 "}
@@ -412,7 +437,7 @@ U
 U
 p
 Y
-Y
+L
 Y
 u
 "}

--- a/_maps/RuinGeneration/13x13_corgarmory.dmm
+++ b/_maps/RuinGeneration/13x13_corgarmory.dmm
@@ -146,6 +146,9 @@
 "x" = (
 /turf/template_noop,
 /area/template_noop)
+"y" = (
+/turf/closed/wall,
+/area/ruin/unpowered)
 "z" = (
 /obj/structure/closet/secure_closet{
 	name = "contraband locker";
@@ -283,22 +286,22 @@
 /area/ruin/unpowered)
 
 (1,1,1) = {"
-M
-M
-M
-M
-M
-M
-M
-M
-M
-M
-M
-M
-M
+y
+y
+y
+y
+y
+y
+y
+y
+y
+y
+y
+y
+y
 "}
 (2,1,1) = {"
-M
+y
 x
 x
 e
@@ -310,10 +313,10 @@ x
 x
 e
 x
-M
+y
 "}
 (3,1,1) = {"
-M
+y
 x
 x
 x
@@ -325,10 +328,10 @@ M
 x
 x
 x
-M
+y
 "}
 (4,1,1) = {"
-M
+y
 x
 x
 M
@@ -340,10 +343,10 @@ M
 M
 t
 t
-M
+y
 "}
 (5,1,1) = {"
-M
+y
 t
 t
 M
@@ -355,10 +358,10 @@ j
 M
 p
 x
-M
+y
 "}
 (6,1,1) = {"
-M
+y
 x
 x
 M
@@ -370,10 +373,10 @@ m
 M
 f
 f
-M
+y
 "}
 (7,1,1) = {"
-M
+y
 x
 x
 M
@@ -388,7 +391,7 @@ v
 b
 "}
 (8,1,1) = {"
-M
+y
 x
 x
 M
@@ -400,10 +403,10 @@ m
 M
 f
 f
-M
+y
 "}
 (9,1,1) = {"
-M
+y
 t
 t
 M
@@ -415,10 +418,10 @@ L
 M
 p
 x
-M
+y
 "}
 (10,1,1) = {"
-M
+y
 x
 x
 M
@@ -430,10 +433,10 @@ M
 M
 t
 t
-M
+y
 "}
 (11,1,1) = {"
-M
+y
 x
 x
 x
@@ -445,10 +448,10 @@ M
 x
 x
 x
-M
+y
 "}
 (12,1,1) = {"
-M
+y
 x
 x
 K
@@ -460,20 +463,20 @@ x
 x
 K
 x
-M
+y
 "}
 (13,1,1) = {"
-M
-M
-M
-M
-M
-M
-M
-M
-M
-M
-M
-M
-M
+y
+y
+y
+y
+y
+y
+y
+y
+y
+y
+y
+y
+y
 "}

--- a/_maps/RuinGeneration/13x13_corgrobotics.dmm
+++ b/_maps/RuinGeneration/13x13_corgrobotics.dmm
@@ -82,21 +82,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered)
 "j" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/tile/neutral/tile_side{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "l" = (
 /obj/effect/spawner/lootdrop/glowstick/lit,
@@ -150,7 +139,7 @@
 /area/ruin/unpowered)
 "r" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "s" = (
@@ -208,6 +197,10 @@
 /area/ruin/unpowered)
 "A" = (
 /turf/closed/wall,
+/area/ruin/unpowered)
+"B" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "C" = (
 /obj/effect/turf_decal/stripes/line{
@@ -370,10 +363,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered)
 "Y" = (
@@ -414,7 +404,7 @@ Y
 W
 s
 A
-x
+j
 w
 x
 "}
@@ -429,8 +419,8 @@ h
 m
 Z
 A
-x
-x
+j
+B
 c
 "}
 (4,1,1) = {"
@@ -444,7 +434,7 @@ D
 P
 S
 A
-x
+j
 x
 x
 "}
@@ -540,7 +530,7 @@ G
 "}
 (11,1,1) = {"
 A
-j
+r
 A
 z
 z

--- a/_maps/RuinGeneration/13x13_donutroom.dmm
+++ b/_maps/RuinGeneration/13x13_donutroom.dmm
@@ -1,25 +1,101 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"b" = (
+/obj/effect/mob_spawn/human/corpse/assistant,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/airless,
+/area/ruin/unpowered)
+"c" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/unpowered)
+"d" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"e" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/airless,
+/area/ruin/unpowered)
+"f" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"g" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"i" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"j" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 4
+	},
+/obj/structure/sign/poster/contraband/donut_corp{
+	pixel_y = 32
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel/airless,
+/area/ruin/unpowered)
 "k" = (
-/obj/structure/chair/comfy,
+/obj/effect/abstract/doorway_marker,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"m" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/closed,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"n" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/obj/machinery/door/firedoor/closed,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "o" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/window,
+/obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
+/area/ruin/unpowered)
+"p" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"q" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless,
 /area/ruin/unpowered)
 "s" = (
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
-"u" = (
-/obj/structure/chair/comfy{
-	dir = 1
-	},
+"t" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
 /turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"u" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/airless,
 /area/ruin/unpowered)
 "v" = (
 /obj/effect/abstract/open_area_marker{
@@ -27,23 +103,97 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"x" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"y" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 8
+	},
+/obj/structure/sign/poster/random{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"z" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/unpowered)
 "C" = (
 /turf/template_noop,
 /area/template_noop)
+"D" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"F" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "G" = (
-/obj/machinery/vending/snack/random,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel/airless,
+/area/ruin/unpowered)
+"H" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"I" = (
+/obj/machinery/door/firedoor/closed,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "J" = (
-/obj/structure/table/wood,
+/turf/open/floor/plasteel/airless,
+/area/ruin/unpowered)
+"K" = (
+/obj/structure/sign/poster/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/unpowered)
+"L" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 8
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"M" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 4
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/unpowered)
+"N" = (
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "O" = (
 /obj/structure/lattice,
 /turf/template_noop,
 /area/template_noop)
+"P" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "Q" = (
-/obj/machinery/vending/cola/random,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "R" = (
@@ -52,8 +202,55 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"S" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"T" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/airless,
+/area/ruin/unpowered)
+"U" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"V" = (
+/obj/machinery/door/firedoor/window,
+/obj/structure/grille/broken,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"W" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel/airless,
+/area/ruin/unpowered)
+"X" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 4
+	},
+/obj/item/storage/fancy/donut_box,
+/obj/structure/table,
+/turf/open/floor/plasteel/airless,
+/area/ruin/unpowered)
 "Y" = (
 /turf/closed/wall,
+/area/ruin/unpowered)
+"Z" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 6;
+	pixel_x = -1
+	},
+/turf/open/floor/plasteel/airless,
 /area/ruin/unpowered)
 
 (1,1,1) = {"
@@ -73,54 +270,54 @@ Y
 "}
 (2,1,1) = {"
 Y
+M
+K
+J
+I
 s
 s
 s
+i
 s
 s
-s
-s
-s
-s
-s
-s
+P
 Y
 "}
 (3,1,1) = {"
 Y
+M
+W
+W
+n
+t
+t
+t
+f
+t
+t
 s
-s
-s
-s
-s
-s
-s
-s
-s
-s
-s
-Y
+k
 "}
 (4,1,1) = {"
 Y
+M
+J
+T
+m
+F
+F
+F
+S
+D
 s
-s
-s
-s
-s
-s
-s
-s
-s
-s
-s
+N
 Y
 "}
 (5,1,1) = {"
 Y
-s
-s
-a
+M
+J
+G
 Y
 o
 o
@@ -128,58 +325,58 @@ o
 Y
 Q
 s
-s
+g
 Y
 "}
 (6,1,1) = {"
 Y
-s
-s
-u
+Z
+J
+G
 o
 C
 O
 C
 o
-k
+a
 s
-s
+g
 Y
 "}
 (7,1,1) = {"
 Y
-s
-s
-J
-o
+X
+b
+G
+V
 O
 O
 O
 o
-J
+a
 s
-s
+g
 Y
 "}
 (8,1,1) = {"
 Y
-s
-s
+j
+q
 u
 o
 C
 O
 C
 o
-k
+a
 s
-s
+g
 Y
 "}
 (9,1,1) = {"
 Y
-s
-s
+M
+J
 G
 Y
 o
@@ -188,52 +385,52 @@ o
 Y
 a
 s
-s
+g
 Y
 "}
 (10,1,1) = {"
 Y
+M
+c
+z
+d
+x
+x
+x
+U
+p
 s
-s
-s
-s
-s
-s
-s
-s
-s
-s
-s
+y
 Y
 "}
 (11,1,1) = {"
 Y
-s
-s
-s
-s
-s
-s
-s
-s
-s
-s
-s
-Y
+M
+W
+e
+n
+t
+t
+t
+f
+t
+t
+g
+k
 "}
 (12,1,1) = {"
 Y
+M
+J
+J
+I
 s
 s
 s
+i
 s
-s
-s
-s
-s
-s
-s
-s
+H
+L
 Y
 "}
 (13,1,1) = {"

--- a/_maps/RuinGeneration/13x13_hilberttest.dmm
+++ b/_maps/RuinGeneration/13x13_hilberttest.dmm
@@ -2,6 +2,9 @@
 "a" = (
 /obj/structure/table/glass,
 /obj/item/stock_parts/matter_bin/bluespace,
+/obj/effect/turf_decal/monke/siding/thinplating/dark{
+	dir = 4
+	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"
 	},
@@ -9,6 +12,17 @@
 "b" = (
 /obj/structure/table/glass,
 /obj/item/stack/cable_coil/blue,
+/obj/effect/turf_decal/monke/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy{
+	icon_state = "engine"
+	},
+/area/ruin/unpowered)
+"c" = (
+/obj/effect/turf_decal/monke/siding/thinplating/dark{
+	dir = 4
+	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"
 	},
@@ -27,6 +41,28 @@
 	icon_state = "engine"
 	},
 /area/ruin/unpowered)
+"l" = (
+/obj/effect/turf_decal/monke/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy{
+	icon_state = "engine"
+	},
+/area/ruin/unpowered)
+"n" = (
+/obj/machinery/porta_turret/syndicate{
+	desc = "A ballistic machine gun auto-turret that fires bluespace bullets.";
+	lethal_projectile = /obj/item/projectile/magic/teleport;
+	name = "displacement turret";
+	stun_projectile = /obj/item/projectile/magic/teleport
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/grimy{
+	icon_state = "engine"
+	},
+/area/ruin/unpowered)
 "q" = (
 /turf/closed/wall/r_wall,
 /area/ruin/unpowered)
@@ -36,6 +72,9 @@
 	lethal_projectile = /obj/item/projectile/magic/teleport;
 	name = "displacement turret";
 	stun_projectile = /obj/item/projectile/magic/teleport
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"
@@ -57,9 +96,40 @@
 	icon_state = "engine"
 	},
 /area/ruin/unpowered)
+"v" = (
+/obj/machinery/porta_turret/syndicate{
+	desc = "A ballistic machine gun auto-turret that fires bluespace bullets.";
+	lethal_projectile = /obj/item/projectile/magic/teleport;
+	name = "displacement turret";
+	stun_projectile = /obj/item/projectile/magic/teleport
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/grimy{
+	icon_state = "engine"
+	},
+/area/ruin/unpowered)
 "y" = (
 /obj/structure/table/glass,
 /obj/item/stock_parts/subspace/amplifier,
+/obj/effect/turf_decal/monke/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy{
+	icon_state = "engine"
+	},
+/area/ruin/unpowered)
+"z" = (
+/obj/machinery/porta_turret/syndicate{
+	desc = "A ballistic machine gun auto-turret that fires bluespace bullets.";
+	lethal_projectile = /obj/item/projectile/magic/teleport;
+	name = "displacement turret";
+	stun_projectile = /obj/item/projectile/magic/teleport
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"
 	},
@@ -70,6 +140,9 @@
 "B" = (
 /obj/structure/table/glass,
 /obj/item/assembly/signaler,
+/obj/effect/turf_decal/monke/siding/thinplating/dark{
+	dir = 8
+	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"
 	},
@@ -108,6 +181,9 @@
 /obj/structure/table/glass,
 /obj/item/stock_parts/subspace/crystal,
 /obj/item/stock_parts/subspace/transmitter,
+/obj/effect/turf_decal/monke/siding/thinplating/dark{
+	dir = 4
+	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"
 	},
@@ -122,6 +198,9 @@
 "T" = (
 /obj/structure/table/glass,
 /obj/item/analyzer,
+/obj/effect/turf_decal/monke/siding/thinplating/dark{
+	dir = 8
+	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"
 	},
@@ -171,7 +250,7 @@ K
 L
 u
 u
-r
+n
 q
 "}
 (3,1,1) = {"
@@ -210,11 +289,11 @@ u
 u
 u
 u
-u
+c
 a
 O
 y
-u
+c
 u
 u
 q
@@ -270,11 +349,11 @@ u
 u
 u
 u
-u
+l
 b
 T
 B
-u
+l
 u
 u
 q
@@ -311,7 +390,7 @@ q
 "}
 (12,1,1) = {"
 q
-r
+z
 u
 u
 K
@@ -321,7 +400,7 @@ W
 K
 u
 u
-r
+v
 q
 "}
 (13,1,1) = {"

--- a/_maps/RuinGeneration/13x13_listening_base.dmm
+++ b/_maps/RuinGeneration/13x13_listening_base.dmm
@@ -2,7 +2,7 @@
 "bD" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/plasteel/grimy,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "bO" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -15,7 +15,7 @@
 /obj/item/paper/fluff/ruins/listeningstation/reports/november,
 /obj/item/pen,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "cX" = (
 /obj/machinery/vending/snack/random{
 	extended_inventory = 1
@@ -29,7 +29,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "dr" = (
 /turf/template_noop,
 /area/template_noop)
@@ -45,20 +45,10 @@
 	pixel_y = -24
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /turf/open/floor/plasteel/white/side{
 	dir = 6
 	},
-/area/ruin/space/has_grav/listeningstation)
-"eN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "fG" = (
 /obj/machinery/computer/camera_advanced{
 	dir = 4
@@ -73,7 +63,7 @@
 	pixel_x = -30
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "ic" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -83,12 +73,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "jx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white/corner,
-/area/ruin/space/has_grav/listeningstation)
+/turf/open/floor/plasteel/white/side,
+/area/ruin/unpowered)
 "jR" = (
 /obj/structure/table,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -110,58 +98,25 @@
 	pixel_y = -3
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/spawner/lootdrop/ruinloot/security,
 /obj/effect/spawner/lootdrop/ruinloot/security,
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "kZ" = (
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
-"lB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "mp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/abstract/doorway_marker{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "mw" = (
 /obj/structure/rack{
 	dir = 8
@@ -169,36 +124,18 @@
 /obj/item/multitool,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "mM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -29
 	},
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
+/turf/open/floor/plasteel/white/corner,
+/area/ruin/unpowered)
 "nQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "os" = (
 /obj/machinery/washing_machine{
 	pixel_x = 4
@@ -208,18 +145,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "oA" = (
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 8
@@ -227,14 +155,8 @@
 /obj/machinery/door/airlock{
 	name = "Cabin"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "oR" = (
 /obj/effect/turf_decal/stripes/red/corner,
 /obj/machinery/light/small{
@@ -245,59 +167,31 @@
 	pixel_x = 24
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /obj/machinery/computer/arcade/orion_trail{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "pa" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /obj/machinery/door/airlock{
 	name = "Personal Quarters"
 	},
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "pB" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/obj/item/clothing/head/welding,
-/obj/item/weldingtool/largetank,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "qm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /obj/structure/closet/emcloset/anchored,
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "qz" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/syndicate,
@@ -306,7 +200,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "rL" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -315,23 +209,11 @@
 	dir = 2;
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/red/tile_side{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "sk" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -341,7 +223,7 @@
 /turf/open/floor/plasteel/white/side{
 	dir = 10
 	},
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "sz" = (
 /obj/structure/table,
 /obj/machinery/firealarm{
@@ -349,18 +231,9 @@
 	pixel_x = -26
 	},
 /obj/machinery/microwave,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "sQ" = (
 /obj/structure/rack{
 	dir = 8;
@@ -370,23 +243,12 @@
 /obj/item/pickaxe,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "tb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "tf" = (
 /obj/structure/sink{
 	dir = 4;
@@ -400,11 +262,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/showroomfloor,
-/area/ruin/space/has_grav/listeningstation)
-"ty" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "uw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/med_data/syndie{
@@ -412,39 +270,7 @@
 	req_one_access = null
 	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
-"ux" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/power/apc/syndicate{
-	dir = 4;
-	name = "Syndicate Listening Post APC";
-	pixel_x = 24
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"ve" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "vx" = (
 /obj/structure/curtain,
 /obj/machinery/shower{
@@ -454,19 +280,10 @@
 /obj/item/soap,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/showroomfloor,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "xp" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "xC" = (
 /obj/machinery/vending/cola/random{
 	extended_inventory = 1
@@ -476,7 +293,7 @@
 /turf/open/floor/plasteel/white/corner{
 	dir = 8
 	},
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "xM" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -499,18 +316,9 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "xP" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -520,7 +328,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "yk" = (
 /obj/structure/rack{
 	dir = 8
@@ -532,27 +340,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/listeningstation)
-"Ai" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "Au" = (
 /obj/structure/filingcabinet,
 /obj/item/paper/fluff/ruins/listeningstation/reports/april,
@@ -566,45 +354,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper/fluff/ruins/listeningstation/odd_report,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "Bn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
-/obj/item/stack/sheet/iron/twenty,
-/obj/item/stack/sheet/glass{
-	amount = 10
-	},
-/obj/item/stack/rods/ten,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/box/lights/bulbs,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
-	},
-/obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
-"Bs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "BT" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -621,92 +375,60 @@
 	},
 /obj/effect/spawner/lootdrop/ruinloot/important,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "Ce" = (
 /obj/structure/table/wood,
 /obj/item/ammo_box/magazine/m10mm,
 /obj/item/paper/fluff/ruins/listeningstation/briefing,
 /turf/open/floor/plasteel/grimy,
-/area/ruin/space/has_grav/listeningstation)
-"Dg" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "DE" = (
 /turf/closed/wall,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "Ed" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "ES" = (
 /turf/closed/wall/r_wall,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "ET" = (
-/obj/structure/cable,
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/iron/twenty,
+/obj/item/stack/sheet/glass{
+	amount = 10
 	},
+/obj/item/stack/rods/ten,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/lights/bulbs,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 30
+	},
+/obj/item/stock_parts/cell/high/plus,
 /obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/wrench,
+/obj/structure/closet/crate,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "EY" = (
 /obj/item/bombcore/badmin{
 	anchored = 1;
 	invisibility = 100
 	},
 /turf/closed/wall,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "Hk" = (
 /obj/machinery/airalarm/syndicate{
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/baseturf_helper/asteroid/airless,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/red/tile_side{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "Kg" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/blood/OMinus{
@@ -715,66 +437,38 @@
 	},
 /obj/item/reagent_containers/blood/OMinus,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /turf/open/floor/plasteel/white/side{
 	dir = 9
 	},
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "Lj" = (
 /obj/structure/chair/stool,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "LH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "LZ" = (
 /obj/machinery/door/airlock/external{
 	id_tag = "syndie_listeningpost_external";
 	req_access_txt = "150"
 	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "Of" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/item/clothing/head/welding,
+/obj/item/weldingtool/largetank,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "Pg" = (
 /obj/machinery/syndicatebomb/self_destruct{
 	anchored = 1
@@ -787,38 +481,19 @@
 	pixel_x = 32
 	},
 /turf/open/floor/circuit/red,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "PW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/red/tile_side{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "QE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /turf/open/floor/plasteel/white/side{
 	dir = 5
 	},
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "RN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -827,32 +502,17 @@
 	pixel_x = -27;
 	pixel_y = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/spawner/lootdrop/ruinloot/important,
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "SJ" = (
 /obj/effect/mob_spawn/human/lavaland_syndicate/comms/space{
 	assignedrole = "Space Syndicate";
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /turf/open/floor/plasteel/grimy,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "SO" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -868,24 +528,9 @@
 	req_access_txt = "150";
 	specialfunctions = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "Tg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -895,7 +540,7 @@
 	},
 /obj/effect/spawner/lootdrop/ruinloot/medical,
 /turf/open/floor/plasteel/white,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "To" = (
 /obj/structure/closet{
 	icon_door = "black";
@@ -930,50 +575,31 @@
 /obj/item/storage/photo_album,
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/grimy,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "TD" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "TQ" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "Vh" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 1
-	},
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "Vs" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /obj/machinery/door/airlock/hatch{
 	name = "Telecommunications";
 	req_access_txt = "150"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "Vw" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
@@ -981,73 +607,36 @@
 /obj/effect/turf_decal/caution/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "Vy" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay"
 	},
 /turf/open/floor/plasteel/white,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "Wd" = (
 /obj/machinery/telecomms/relay/preset/ruskie{
 	use_power = 0
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "Xe" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /turf/open/floor/plasteel/grimy,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "Yk" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/red/tile_side{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "Yu" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
 /turf/open/floor/plasteel,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "YS" = (
 /obj/machinery/computer/message_monitor{
 	dir = 2
@@ -1059,46 +648,22 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper/monitorkey,
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "Zn" = (
 /obj/machinery/door/airlock{
 	name = "Toilet"
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/ruin/space/has_grav/listeningstation)
-"Zp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1;
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/white/side,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 "Zx" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	piping_layer = 3;
-	pixel_x = 5;
-	pixel_y = 5
-	},
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /obj/machinery/door/airlock/hatch{
 	name = "E.V.A. Equipment";
 	req_access_txt = "150"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/listeningstation)
+/area/ruin/unpowered)
 
 (1,1,1) = {"
 dr
@@ -1136,10 +701,10 @@ dr
 ES
 tf
 Zn
-ty
-eN
+Yu
+Yu
 Lj
-ve
+xp
 oA
 Xe
 To
@@ -1179,7 +744,7 @@ ES
 ES
 YS
 kZ
-Ai
+tb
 Au
 DE
 Ed
@@ -1193,14 +758,14 @@ ES
 (7,1,1) = {"
 ES
 xP
-lB
-Bs
+tb
+nQ
 nQ
 Vs
-Dg
+Yk
 Yu
 TD
-ux
+Bn
 Bn
 Vh
 ES
@@ -1258,7 +823,7 @@ SO
 tb
 Zx
 PW
-Zp
+jx
 DE
 Tg
 ES

--- a/_maps/RuinGeneration/13x13_shotelroom.dmm
+++ b/_maps/RuinGeneration/13x13_shotelroom.dmm
@@ -74,10 +74,16 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/ruin/unpowered)
+"p" = (
+/turf/template_noop/open,
+/area/template_noop)
 "q" = (
 /obj/machinery/door/airlock/wood,
 /obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/monke/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/ruin/unpowered)
 "r" = (
 /obj/structure/table/wood/fancy/purple,
@@ -216,7 +222,7 @@
 /area/ruin/unpowered)
 "R" = (
 /obj/structure/falsewall,
-/turf/open/floor/plasteel/tiled,
+/turf/open/floor/plating,
 /area/ruin/unpowered)
 "S" = (
 /obj/structure/table,
@@ -367,9 +373,9 @@ j
 j
 "}
 (7,1,1) = {"
+p
 j
 v
-h
 h
 h
 h
@@ -382,8 +388,8 @@ M
 j
 "}
 (8,1,1) = {"
+p
 j
-h
 h
 h
 h
@@ -397,8 +403,8 @@ l
 j
 "}
 (9,1,1) = {"
+p
 j
-h
 H
 H
 H
@@ -412,8 +418,8 @@ e
 j
 "}
 (10,1,1) = {"
+p
 j
-h
 L
 Z
 n
@@ -427,8 +433,8 @@ l
 j
 "}
 (11,1,1) = {"
+p
 j
-h
 L
 J
 o
@@ -442,8 +448,8 @@ t
 k
 "}
 (12,1,1) = {"
+p
 j
-h
 L
 r
 d
@@ -457,7 +463,7 @@ I
 j
 "}
 (13,1,1) = {"
-j
+p
 j
 j
 j

--- a/_maps/RuinGeneration/13x13_supermatter_containment.dmm
+++ b/_maps/RuinGeneration/13x13_supermatter_containment.dmm
@@ -1,7 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/machinery/field/generator,
-/turf/open/floor/engine,
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"b" = (
+/obj/item/stack/cable_coil,
+/turf/open/floor/wood,
 /area/ruin/unpowered)
 "c" = (
 /turf/closed/wall,
@@ -16,9 +20,12 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "h" = (
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/airlock/highsecurity,
+/obj/machinery/door/airlock/grunge,
 /turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"i" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/wood,
 /area/ruin/unpowered)
 "m" = (
 /obj/effect/abstract/open_area_marker{
@@ -26,15 +33,40 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"n" = (
+/obj/item/stack/tile/wood,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"u" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/ruin/unpowered)
 "w" = (
 /turf/open/floor/plating,
 /area/ruin/unpowered)
+"x" = (
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"C" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"F" = (
+/obj/machinery/power/emitter{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/unpowered)
 "G" = (
-/turf/open/floor/engine,
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"H" = (
+/obj/item/stack/sheet/mineral/plasma/five,
+/turf/open/floor/plating,
 /area/ruin/unpowered)
 "K" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/window,
+/obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "N" = (
@@ -86,7 +118,7 @@ N
 "}
 (3,1,1) = {"
 m
-T
+C
 T
 T
 T
@@ -103,7 +135,7 @@ N
 T
 T
 T
-T
+C
 T
 T
 T
@@ -120,7 +152,7 @@ c
 T
 T
 T
-T
+C
 T
 T
 T
@@ -137,7 +169,7 @@ c
 T
 T
 T
-T
+C
 T
 c
 c
@@ -146,8 +178,8 @@ N
 "}
 (7,1,1) = {"
 c
-G
-G
+u
+u
 c
 c
 c
@@ -162,13 +194,13 @@ N
 (8,1,1) = {"
 c
 G
-w
+n
 G
 G
 c
 c
 T
-T
+C
 T
 K
 K
@@ -195,11 +227,11 @@ w
 P
 f
 w
-G
+b
 c
 c
 T
-T
+C
 T
 c
 c
@@ -209,9 +241,9 @@ c
 a
 w
 e
+F
 G
-G
-G
+x
 c
 T
 T
@@ -221,16 +253,16 @@ c
 "}
 (12,1,1) = {"
 c
+i
 G
 G
 G
-G
-w
+H
 G
 c
 c
 T
-T
+C
 T
 c
 "}

--- a/_maps/RuinGeneration/13x17_chapel.dmm
+++ b/_maps/RuinGeneration/13x17_chapel.dmm
@@ -39,6 +39,10 @@
 	dir = 10
 	},
 /area/ruin/unpowered)
+"gl" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "gn" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet/royalblack,
@@ -95,6 +99,10 @@
 /obj/effect/abstract/open_area_marker{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"oR" = (
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "pp" = (
@@ -171,6 +179,10 @@
 /obj/item/toy/plush/bubbleplush,
 /turf/open/floor/grass/fakebasalt,
 /area/ruin/unpowered)
+"xy" = (
+/obj/effect/turf_decal/tile/neutral/tile_side,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "xP" = (
 /obj/item/stock_parts/cell/potato,
 /obj/item/bot_assembly/secbot,
@@ -186,6 +198,12 @@
 /area/ruin/unpowered)
 "zh" = (
 /turf/closed/wall/mineral/cult,
+/area/ruin/unpowered)
+"AB" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "CU" = (
 /obj/structure/window/spawner/west,
@@ -273,6 +291,12 @@
 /turf/open/floor/plasteel/chapel{
 	dir = 4
 	},
+/area/ruin/unpowered)
+"RC" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "TA" = (
 /obj/structure/chair/pew/left{
@@ -377,7 +401,7 @@ tQ
 gn
 bB
 qE
-qE
+gl
 qE
 VV
 "}
@@ -396,7 +420,7 @@ tQ
 tQ
 bB
 qE
-qE
+gl
 qE
 EP
 "}
@@ -415,7 +439,7 @@ tQ
 tQ
 bB
 qE
-qE
+gl
 qE
 VV
 "}
@@ -434,7 +458,7 @@ tQ
 tQ
 VV
 qE
-qE
+gl
 qE
 VV
 "}
@@ -453,7 +477,7 @@ tQ
 tQ
 LT
 qE
-qE
+xy
 qE
 qE
 "}
@@ -472,8 +496,8 @@ tQ
 tQ
 bB
 qE
-qE
-qE
+oR
+RC
 YA
 "}
 (8,1,1) = {"
@@ -491,7 +515,7 @@ tQ
 tQ
 LT
 qE
-qE
+AB
 qE
 qE
 "}
@@ -510,7 +534,7 @@ tQ
 tQ
 VV
 ax
-qE
+gl
 qE
 VV
 "}
@@ -529,7 +553,7 @@ tQ
 tQ
 bB
 qE
-qE
+gl
 qE
 VV
 "}
@@ -548,7 +572,7 @@ tQ
 tQ
 bB
 qE
-qE
+gl
 qE
 EP
 "}
@@ -567,7 +591,7 @@ tQ
 gn
 bB
 qE
-qE
+gl
 qE
 VV
 "}

--- a/_maps/RuinGeneration/13x17_permabrig.dmm
+++ b/_maps/RuinGeneration/13x17_permabrig.dmm
@@ -22,7 +22,6 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "ee" = (
-/obj/effect/turf_decal/tile/red,
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/ruinloot/security,
 /turf/open/floor/plasteel,
@@ -80,13 +79,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
-"mj" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/ruin/unpowered)
 "pC" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/dice,
@@ -96,9 +88,6 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Long-Term Cell 1";
 	req_access_txt = "2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -174,10 +163,6 @@
 	pixel_x = 1;
 	pixel_y = -27
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "xh" = (
@@ -234,7 +219,7 @@
 /area/ruin/unpowered)
 "Be" = (
 /obj/effect/abstract/doorway_marker,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "Bh" = (
 /obj/machinery/hydroponics/soil,
@@ -251,6 +236,9 @@
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/ruinloot/security,
 /obj/effect/spawner/lootdrop/ruinloot/security,
+/obj/effect/turf_decal/tile/red/tile_side{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "CC" = (
@@ -350,8 +338,7 @@
 /area/ruin/unpowered)
 "Me" = (
 /obj/structure/closet/secure_closet/brig,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/red/tile_side{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -421,14 +408,10 @@
 /obj/item/razor{
 	pixel_x = -6
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/spawner/lootdrop/ruinloot/security,
+/obj/effect/turf_decal/tile/red/tile_side{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/ruinloot/security,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "Qh" = (
@@ -490,11 +473,8 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "VT" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "Wr" = (
@@ -510,14 +490,12 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "Xh" = (
 /obj/structure/table,
 /obj/item/electropack,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/red/tile_side{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -581,7 +559,7 @@ vM
 lv
 bO
 bO
-mj
+bO
 Be
 "}
 (4,1,1) = {"

--- a/_maps/RuinGeneration/13x17_shuttledock.dmm
+++ b/_maps/RuinGeneration/13x17_shuttledock.dmm
@@ -1,4 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"d" = (
+/obj/effect/turf_decal/tile/neutral/tile_side,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "e" = (
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
@@ -13,9 +17,21 @@
 /obj/structure/sign/warning/vacuum/external,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
+"n" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "o" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
+/area/ruin/unpowered)
+"p" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "t" = (
 /obj/structure/closet/emcloset,
@@ -35,6 +51,10 @@
 /area/ruin/unpowered)
 "v" = (
 /turf/open/floor/plating,
+/area/ruin/unpowered)
+"w" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "C" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -61,6 +81,12 @@
 "J" = (
 /obj/effect/abstract/open_area_marker{
 	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"K" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
@@ -118,20 +144,20 @@ I
 "}
 (2,1,1) = {"
 R
+K
+e
+p
+e
+p
+e
+p
+e
+p
+e
+p
 e
 e
-e
-e
-e
-e
-e
-e
-e
-e
-e
-e
-e
-e
+w
 e
 I
 "}
@@ -150,7 +176,7 @@ e
 e
 e
 e
-e
+w
 e
 S
 "}
@@ -169,7 +195,7 @@ o
 R
 R
 D
-e
+w
 e
 I
 "}
@@ -283,7 +309,7 @@ o
 R
 R
 C
-e
+w
 e
 e
 "}
@@ -302,26 +328,26 @@ e
 e
 e
 e
-e
+w
 e
 W
 "}
 (12,1,1) = {"
 R
+n
+e
+d
+e
+d
+e
+d
+e
+d
+e
+d
 e
 e
-e
-e
-e
-e
-e
-e
-e
-e
-e
-e
-e
-e
+w
 e
 e
 "}

--- a/_maps/RuinGeneration/13x9_cratestorage.dmm
+++ b/_maps/RuinGeneration/13x9_cratestorage.dmm
@@ -67,6 +67,10 @@
 /obj/effect/spawner/lootdrop/ruinloot/basic,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"v" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "x" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate/engineering,
@@ -150,9 +154,9 @@ U
 U
 O
 g
+v
 g
-g
-g
+v
 g
 u
 U
@@ -162,7 +166,7 @@ U
 O
 g
 g
-g
+v
 g
 g
 g
@@ -182,33 +186,33 @@ U
 (6,1,1) = {"
 g
 g
-g
+v
 U
 x
 g
-g
+v
 g
 g
 "}
 (7,1,1) = {"
 G
-g
+v
 g
 U
 g
 g
 g
-g
+v
 q
 "}
 (8,1,1) = {"
 g
 g
-g
+v
 U
 Z
 E
-g
+v
 g
 g
 "}
@@ -228,7 +232,7 @@ U
 g
 g
 g
-g
+v
 g
 g
 g
@@ -238,9 +242,9 @@ U
 U
 g
 g
+v
 g
-g
-g
+v
 g
 g
 U

--- a/_maps/RuinGeneration/13x9_josito.dmm
+++ b/_maps/RuinGeneration/13x9_josito.dmm
@@ -8,6 +8,13 @@
 /obj/effect/spawner/lootdrop/snowdin/dungeonlite,
 /turf/open/floor/wood,
 /area/ruin/unpowered)
+"g" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/turf_decal/monke/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/ruin/unpowered)
 "h" = (
 /obj/effect/abstract/doorway_marker,
 /turf/open/floor/plating,
@@ -209,7 +216,7 @@ u
 (9,1,1) = {"
 u
 u
-o
+g
 u
 u
 u

--- a/_maps/RuinGeneration/13x9_medical.dmm
+++ b/_maps/RuinGeneration/13x9_medical.dmm
@@ -6,11 +6,17 @@
 /obj/effect/abstract/open_area_marker,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"d" = (
+/obj/effect/turf_decal/tile/neutral/tile_full,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "e" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white/side{
+	dir = 10
+	},
 /area/ruin/unpowered)
 "f" = (
 /obj/effect/turf_decal/tile/blue{
@@ -19,18 +25,9 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "g" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/blue/tile_full,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "h" = (
@@ -41,10 +38,7 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "j" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/blue/tile_side{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -80,41 +74,25 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "r" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/blue/tile_side{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "s" = (
 /obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/turf/open/floor/plasteel/white/side{
+	dir = 6
 	},
-/turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "t" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/tile/blue/tile_side,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "u" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/ruinloot/medical,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "w" = (
 /obj/effect/turf_decal/tile/blue{
@@ -123,13 +101,10 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "x" = (
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/sleeper{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/blue/tile_side,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "y" = (
@@ -139,34 +114,16 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "z" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/blue/tile_full,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "A" = (
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/bottle/charcoal,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/effect/spawner/lootdrop/ruinloot/medical,
+/obj/effect/turf_decal/tile/blue/tile_full,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "B" = (
@@ -187,9 +144,8 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "E" = (
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/blue/tile_side{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -200,12 +156,17 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
+"J" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "K" = (
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/blue/tile_side{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -217,19 +178,8 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "M" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
+/obj/effect/turf_decal/tile/neutral/tile_side,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "O" = (
 /obj/effect/abstract/open_area_marker{
@@ -246,6 +196,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
+"R" = (
+/turf/open/floor/plasteel/white/side,
+/area/ruin/unpowered)
 "S" = (
 /turf/closed/wall,
 /area/ruin/unpowered)
@@ -260,18 +213,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "X" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = 9;
@@ -286,6 +231,9 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/lootdrop/ruinloot/medical,
+/obj/effect/turf_decal/tile/blue/tile_side{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "Y" = (
@@ -296,25 +244,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "Z" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/effect/turf_decal/tile/blue/tile_full,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 
@@ -336,18 +273,18 @@ B
 B
 p
 a
-a
+u
 a
 S
 "}
 (3,1,1) = {"
 S
-M
+z
 n
 w
 I
 a
-a
+u
 a
 S
 "}
@@ -358,7 +295,7 @@ Q
 w
 I
 a
-a
+u
 a
 S
 "}
@@ -369,7 +306,7 @@ h
 w
 I
 y
-a
+u
 a
 S
 "}
@@ -380,7 +317,7 @@ Q
 w
 K
 o
-a
+M
 a
 a
 "}
@@ -391,8 +328,8 @@ h
 w
 r
 a
-a
-a
+d
+J
 c
 "}
 (8,1,1) = {"
@@ -430,7 +367,7 @@ S
 "}
 (11,1,1) = {"
 q
-e
+R
 f
 f
 f
@@ -444,7 +381,7 @@ S
 s
 T
 x
-u
+A
 x
 A
 t

--- a/_maps/RuinGeneration/13x9_researchlab.dmm
+++ b/_maps/RuinGeneration/13x9_researchlab.dmm
@@ -7,7 +7,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "b" = (
@@ -34,7 +33,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "d" = (
-/obj/effect/spawner/structure/window,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "e" = (
@@ -48,9 +47,6 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "g" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/item/disk/tech_disk{
 	pixel_x = -2;
@@ -61,15 +57,15 @@
 	pixel_y = -3
 	},
 /obj/item/disk/design_disk,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/spawner/lootdrop/ruinloot/science,
 /obj/effect/spawner/lootdrop/ruinloot/science,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "h" = (
@@ -80,6 +76,10 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"i" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "k" = (
@@ -137,8 +137,11 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "r" = (
-/obj/machinery/door/airlock/science,
-/turf/open/floor/plasteel/white,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
 /area/ruin/unpowered)
 "s" = (
 /obj/effect/turf_decal/tile/purple,
@@ -146,17 +149,11 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "t" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/computer/cargo/request{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "u" = (
 /turf/closed/wall,
@@ -316,6 +313,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "K" = (
@@ -433,10 +431,7 @@
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "V" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "W" = (
@@ -575,10 +570,10 @@ u
 u
 d
 d
-d
+r
 u
 V
-r
+u
 u
 "}
 (10,1,1) = {"
@@ -594,13 +589,13 @@ p
 "}
 (11,1,1) = {"
 M
-p
-p
-p
-p
-p
-p
-p
+i
+i
+i
+i
+i
+i
+i
 e
 "}
 (12,1,1) = {"

--- a/_maps/RuinGeneration/17x13_cargo.dmm
+++ b/_maps/RuinGeneration/17x13_cargo.dmm
@@ -16,10 +16,18 @@
 /obj/structure/shuttle/engine/heater{
 	dir = 4
 	},
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plating,
+/area/ruin/unpowered)
+"e" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/rnd/production/protolathe/department/cargo,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "f" = (
 /obj/structure/shuttle/engine/propulsion/burst/right{
@@ -42,6 +50,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"k" = (
+/obj/machinery/modular_fabricator/autolathe,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
 "l" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/lootdrop/crate_spawner,
@@ -49,6 +62,14 @@
 /area/ruin/unpowered)
 "n" = (
 /obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"o" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"p" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "r" = (
@@ -84,6 +105,12 @@
 "w" = (
 /obj/effect/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"x" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/closed/wall,
 /area/ruin/unpowered)
 "y" = (
 /obj/effect/turf_decal/delivery,
@@ -163,6 +190,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "S" = (
@@ -173,6 +203,10 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
+/area/ruin/unpowered)
+"U" = (
+/obj/effect/turf_decal/tile/neutral/tile_side,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "V" = (
 /turf/open/floor/plasteel/dark,
@@ -213,9 +247,9 @@ M
 (2,1,1) = {"
 M
 h
+p
 h
-h
-h
+k
 h
 h
 h
@@ -228,9 +262,9 @@ M
 (3,1,1) = {"
 M
 h
+p
 h
-h
-h
+o
 h
 h
 h
@@ -243,9 +277,9 @@ M
 (4,1,1) = {"
 M
 h
+p
 h
-h
-h
+M
 h
 h
 h
@@ -258,9 +292,9 @@ M
 (5,1,1) = {"
 M
 h
+p
 h
-h
-h
+I
 h
 h
 h
@@ -272,10 +306,10 @@ M
 "}
 (6,1,1) = {"
 M
-h
-h
-h
-h
+U
+U
+U
+M
 h
 h
 h
@@ -287,11 +321,11 @@ M
 "}
 (7,1,1) = {"
 M
-Q
-Q
-Q
-Q
-Q
+x
+x
+x
+x
+e
 Q
 i
 J

--- a/_maps/RuinGeneration/17x17_charliecrew.dmm
+++ b/_maps/RuinGeneration/17x17_charliecrew.dmm
@@ -86,6 +86,12 @@
 	dir = 4
 	},
 /area/ruin/unpowered)
+"fN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "gv" = (
 /obj/effect/abstract/open_area_marker{
 	dir = 4
@@ -114,6 +120,7 @@
 /area/ruin/unpowered)
 "hq" = (
 /obj/effect/spawner/lootdrop/ruinloot/basic,
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "hQ" = (
@@ -121,6 +128,10 @@
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"hW" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "jR" = (
 /obj/machinery/door/airlock/command/glass{
@@ -490,6 +501,10 @@
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
+"PV" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel/airless,
+/area/ruin/unpowered)
 "QB" = (
 /turf/template_noop,
 /area/template_noop)
@@ -627,7 +642,7 @@ aY
 lm
 lf
 sU
-sU
+hW
 sU
 lf
 wp
@@ -646,7 +661,7 @@ ww
 Ks
 cF
 UJ
-sU
+hW
 sU
 Dy
 ps
@@ -701,7 +716,7 @@ Vu
 Rr
 Ff
 lf
-sU
+fN
 sU
 Zo
 lf
@@ -821,7 +836,7 @@ aW
 lf
 te
 sU
-de
+PV
 de
 lf
 "}
@@ -840,7 +855,7 @@ dS
 lf
 lf
 xZ
-de
+PV
 de
 lf
 "}
@@ -859,7 +874,7 @@ aW
 ES
 KR
 de
-de
+PV
 de
 lf
 "}
@@ -878,7 +893,7 @@ aW
 aW
 Gu
 de
-de
+PV
 de
 lf
 "}
@@ -897,7 +912,7 @@ Sy
 yL
 UP
 de
-de
+PV
 de
 lf
 "}

--- a/_maps/RuinGeneration/17x9_pubbybridgehall.dmm
+++ b/_maps/RuinGeneration/17x9_pubbybridgehall.dmm
@@ -17,7 +17,7 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "m" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "o" = (

--- a/_maps/RuinGeneration/21x17_shuttledock.dmm
+++ b/_maps/RuinGeneration/21x17_shuttledock.dmm
@@ -22,6 +22,12 @@
 "k" = (
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"o" = (
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "q" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
@@ -46,8 +52,26 @@
 /obj/machinery/door/firedoor/window,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"D" = (
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "F" = (
 /turf/closed/wall,
+/area/ruin/unpowered)
+"G" = (
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"T" = (
+/obj/effect/turf_decal/trimline/neutral/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "W" = (
 /obj/structure/fans/tiny,
@@ -88,10 +112,10 @@ k
 k
 k
 k
-k
-k
-k
-k
+T
+o
+o
+o
 F
 "}
 (3,1,1) = {"
@@ -278,7 +302,7 @@ A
 A
 A
 A
-v
+F
 k
 k
 k
@@ -419,10 +443,10 @@ F
 "}
 (20,1,1) = {"
 F
-k
-k
-k
-k
+D
+D
+D
+G
 k
 k
 k

--- a/_maps/RuinGeneration/21x21_singularity.dmm
+++ b/_maps/RuinGeneration/21x21_singularity.dmm
@@ -15,9 +15,21 @@
 "g" = (
 /turf/closed/wall,
 /area/ruin)
+"h" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin)
 "j" = (
 /obj/structure/sign/warning/radiation{
 	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/ruin)
+"k" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/ruin)
@@ -39,9 +51,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin)
+"s" = (
+/obj/effect/turf_decal/tile/neutral/tile_side,
+/turf/open/floor/plasteel,
+/area/ruin)
 "t" = (
 /turf/template_noop/open,
 /area/template_noop)
+"w" = (
+/obj/effect/turf_decal/tile/neutral/tile_full,
+/turf/open/floor/plasteel,
+/area/ruin)
 "x" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
@@ -69,6 +89,12 @@
 /area/ruin)
 "G" = (
 /obj/effect/abstract/open_area_marker{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin)
+"J" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -128,7 +154,7 @@ z
 c
 c
 c
-c
+s
 c
 c
 c
@@ -150,9 +176,9 @@ c
 c
 c
 c
-c
-c
-c
+J
+w
+h
 c
 c
 c
@@ -304,7 +330,7 @@ g
 (10,1,1) = {"
 c
 c
-c
+s
 c
 c
 R
@@ -320,14 +346,14 @@ N
 R
 E
 c
-c
+s
 c
 c
 "}
 (11,1,1) = {"
 d
-c
-c
+J
+w
 c
 c
 C
@@ -343,14 +369,14 @@ t
 C
 x
 c
-c
-c
+w
+h
 A
 "}
 (12,1,1) = {"
 c
 c
-c
+k
 c
 c
 R
@@ -366,7 +392,7 @@ N
 R
 E
 c
-c
+k
 c
 c
 "}
@@ -518,9 +544,9 @@ c
 c
 c
 c
-c
-c
-c
+J
+w
+h
 c
 c
 c
@@ -542,7 +568,7 @@ z
 c
 c
 c
-c
+k
 c
 c
 c

--- a/_maps/RuinGeneration/21x29_solars.dmm
+++ b/_maps/RuinGeneration/21x29_solars.dmm
@@ -224,9 +224,6 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes,
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "U" = (
@@ -615,8 +612,8 @@ z
 q
 q
 f
-b
-b
+f
+f
 F
 p
 S
@@ -647,7 +644,7 @@ q
 q
 q
 q
-b
+f
 b
 b
 b

--- a/_maps/RuinGeneration/5x5_0_hallwaycross.dmm
+++ b/_maps/RuinGeneration/5x5_0_hallwaycross.dmm
@@ -1,6 +1,24 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"b" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "c" = (
 /obj/effect/abstract/open_area_marker,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"i" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "m" = (
@@ -12,16 +30,46 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"r" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"w" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "x" = (
 /obj/effect/abstract/open_area_marker{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"A" = (
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"E" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"F" = (
+/obj/effect/turf_decal/tile/neutral/tile_full,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "J" = (
 /obj/effect/abstract/open_area_marker{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"N" = (
+/obj/effect/turf_decal/tile/neutral/tile_side,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "Q" = (
@@ -37,23 +85,23 @@ m
 "}
 (2,1,1) = {"
 Q
-Q
-Q
-Q
+r
+a
+b
 Q
 "}
 (3,1,1) = {"
 n
-Q
-Q
-Q
+E
+F
+w
 c
 "}
 (4,1,1) = {"
 Q
-Q
-Q
-Q
+i
+N
+A
 Q
 "}
 (5,1,1) = {"

--- a/_maps/RuinGeneration/5x5_14_hallway-end-east.dmm
+++ b/_maps/RuinGeneration/5x5_14_hallway-end-east.dmm
@@ -2,6 +2,11 @@
 "a" = (
 /turf/closed/wall,
 /area/ruin/unpowered)
+"k" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/neutral/tile_side,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "n" = (
 /obj/structure/lattice,
 /turf/template_noop,
@@ -12,18 +17,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"C" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/neutral/tile_side,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "F" = (
 /turf/template_noop,
 /area/template_noop)
 "M" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/window,
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plating,
+/obj/machinery/vending/cola/random,
+/obj/effect/turf_decal/tile/neutral/tile_side,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "Q" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/window,
+/obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "R" = (
@@ -39,16 +47,16 @@ a
 "}
 (2,1,1) = {"
 a
-R
-R
-R
+M
+k
+C
 a
 "}
 (3,1,1) = {"
 a
 Q
 Q
-M
+Q
 a
 "}
 (4,1,1) = {"

--- a/_maps/RuinGeneration/5x5_14_hallway-end-north.dmm
+++ b/_maps/RuinGeneration/5x5_14_hallway-end-north.dmm
@@ -1,5 +1,26 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "f" = (
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"o" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"y" = (
+/obj/machinery/vending/snack/random,
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "N" = (
@@ -14,8 +35,7 @@
 /turf/template_noop,
 /area/template_noop)
 "T" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/window,
+/obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "X" = (
@@ -33,21 +53,21 @@ X
 R
 O
 T
-f
+y
 f
 "}
 (3,1,1) = {"
 R
 R
 T
-f
+o
 N
 "}
 (4,1,1) = {"
 R
 O
 T
-f
+a
 f
 "}
 (5,1,1) = {"

--- a/_maps/RuinGeneration/5x5_14_hallway-end-south.dmm
+++ b/_maps/RuinGeneration/5x5_14_hallway-end-south.dmm
@@ -3,16 +3,36 @@
 /obj/structure/lattice,
 /turf/template_noop,
 /area/template_noop)
+"d" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 8
+	},
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "g" = (
 /turf/closed/wall,
 /area/ruin/unpowered)
 "j" = (
 /turf/template_noop,
 /area/template_noop)
+"p" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 8
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "C" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/window,
+/obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
+/area/ruin/unpowered)
+"E" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 8
+	},
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "P" = (
 /turf/open/floor/plasteel,
@@ -33,21 +53,21 @@ j
 "}
 (2,1,1) = {"
 P
-P
+p
 C
 c
 j
 "}
 (3,1,1) = {"
 Q
-P
+E
 C
 j
 j
 "}
 (4,1,1) = {"
 P
-P
+d
 C
 c
 j

--- a/_maps/RuinGeneration/5x5_14_hallway-end-west.dmm
+++ b/_maps/RuinGeneration/5x5_14_hallway-end-west.dmm
@@ -2,6 +2,13 @@
 "g" = (
 /turf/closed/wall,
 /area/ruin/unpowered)
+"k" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "y" = (
 /turf/template_noop,
 /area/template_noop)
@@ -18,9 +25,17 @@
 "P" = (
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"R" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "V" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/window,
+/obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 
@@ -47,9 +62,9 @@ g
 "}
 (4,1,1) = {"
 g
-P
-P
-P
+k
+R
+R
 g
 "}
 (5,1,1) = {"

--- a/_maps/RuinGeneration/5x5_1_hallwayvertical_eastwest_room.dmm
+++ b/_maps/RuinGeneration/5x5_1_hallwayvertical_eastwest_room.dmm
@@ -1,4 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"c" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "h" = (
 /turf/closed/wall,
 /area/ruin/unpowered)
@@ -44,9 +48,9 @@ Q
 "}
 (3,1,1) = {"
 M
-Q
-Q
-Q
+c
+c
+c
 V
 "}
 (4,1,1) = {"

--- a/_maps/RuinGeneration/5x5_20_hallwayhorizontal.dmm
+++ b/_maps/RuinGeneration/5x5_20_hallwayhorizontal.dmm
@@ -14,6 +14,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"M" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "P" = (
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
@@ -28,21 +32,21 @@ g
 (2,1,1) = {"
 g
 P
-P
+M
 P
 g
 "}
 (3,1,1) = {"
 g
 P
-P
+M
 P
 g
 "}
 (4,1,1) = {"
 g
 P
-P
+M
 P
 g
 "}

--- a/_maps/RuinGeneration/5x5_20_hallwayvertical.dmm
+++ b/_maps/RuinGeneration/5x5_20_hallwayvertical.dmm
@@ -2,6 +2,10 @@
 "h" = (
 /turf/closed/wall,
 /area/ruin/unpowered)
+"z" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "M" = (
 /obj/effect/abstract/open_area_marker{
 	dir = 1
@@ -32,9 +36,9 @@ Q
 "}
 (3,1,1) = {"
 M
-Q
-Q
-Q
+z
+z
+z
 V
 "}
 (4,1,1) = {"

--- a/_maps/RuinGeneration/5x5_4_room-dorm.dmm
+++ b/_maps/RuinGeneration/5x5_4_room-dorm.dmm
@@ -3,8 +3,7 @@
 /turf/closed/wall,
 /area/ruin/unpowered)
 "b" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
+/obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/wood,
 /area/ruin/unpowered)
 "l" = (
@@ -15,32 +14,39 @@
 /obj/structure/bed,
 /obj/item/bedsheet/random,
 /obj/item/toy/plush/carpplushie,
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/ruin/unpowered)
 "B" = (
 /obj/item/chair/wood,
 /turf/open/floor/wood,
 /area/ruin/unpowered)
+"C" = (
+/obj/structure/table_frame/wood,
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/wood,
+/area/ruin/unpowered)
 "H" = (
 /obj/item/toy/plush/lizardplushie,
+/obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/ruin/unpowered)
 "J" = (
 /obj/effect/abstract/doorway_marker{
 	dir = 4
 	},
+/obj/effect/turf_decal/monke/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/ruin/unpowered)
 "U" = (
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/ruin/unpowered)
 "W" = (
 /obj/structure/sign/poster/official/no_erp{
 	pixel_y = 32
 	},
-/obj/structure/table_frame/wood,
-/obj/item/stack/sheet/mineral/wood,
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/ruin/unpowered)
 
 (1,1,1) = {"
@@ -54,7 +60,7 @@ a
 a
 l
 B
-l
+C
 a
 "}
 (3,1,1) = {"

--- a/_maps/RuinGeneration/5x5_4_room-janitor_closet.dmm
+++ b/_maps/RuinGeneration/5x5_4_room-janitor_closet.dmm
@@ -10,25 +10,18 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "n" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/effect/turf_decal/tile/green/tile_side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
+/obj/structure/closet/l3closet/janitor,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "x" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/reagent_containers/glass/bucket,
+/obj/effect/turf_decal/tile/green/tile_side{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "y" = (
@@ -37,15 +30,13 @@
 /obj/item/soap/nanotrasen,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"D" = (
+/obj/structure/sign/departments/minsky/supply/janitorial,
+/turf/closed/wall,
+/area/ruin/unpowered)
 "E" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/effect/turf_decal/tile/green/tile_side{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
@@ -53,28 +44,21 @@
 /turf/closed/wall,
 /area/ruin/unpowered)
 "P" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 12
 	},
+/obj/effect/turf_decal/tile/green/tile_side{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "V" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /obj/structure/sign/poster/contraband/lusty_xenomorph{
 	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile/green/tile_side{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
@@ -108,7 +92,7 @@ M
 l
 P
 n
-M
+D
 "}
 (5,1,1) = {"
 M

--- a/_maps/RuinGeneration/5x5_4_room-storage.dmm
+++ b/_maps/RuinGeneration/5x5_4_room-storage.dmm
@@ -6,7 +6,7 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
 /area/ruin/unpowered)
 "i" = (
 /turf/open/floor/plasteel,
@@ -23,21 +23,26 @@
 /area/ruin/unpowered)
 "z" = (
 /obj/effect/decal/cleanable/oil/streak,
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 6
+	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "G" = (
 /obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plasteel,
+/obj/item/stack/tile/plasteel,
+/turf/open/floor/plating,
 /area/ruin/unpowered)
 "W" = (
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "X" = (
-/obj/vehicle/ridden/atv,
-/turf/open/floor/plasteel,
+/obj/structure/table,
+/turf/open/floor/plating,
 /area/ruin/unpowered)
 "Y" = (
-/obj/structure/closet/crate/secure/loot,
+/obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 
@@ -50,7 +55,7 @@ e
 "}
 (2,1,1) = {"
 e
-X
+i
 G
 Y
 e
@@ -58,8 +63,8 @@ e
 (3,1,1) = {"
 j
 k
-i
 W
+X
 e
 "}
 (4,1,1) = {"

--- a/_maps/RuinGeneration/5x5_4_room-toilet.dmm
+++ b/_maps/RuinGeneration/5x5_4_room-toilet.dmm
@@ -3,7 +3,7 @@
 /obj/structure/urinal{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/showroomfloor,
 /area/ruin/unpowered)
 "g" = (
 /obj/structure/sink{
@@ -13,19 +13,35 @@
 /obj/structure/mirror{
 	pixel_x = -28
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/green/filled/arrow_cw,
+/turf/open/floor/plasteel/showroomfloor,
 /area/ruin/unpowered)
 "l" = (
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/green/filled/shrink_ccw{
+	dir = 1
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/unpowered)
+"o" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/machinery/door/window/westright,
+/obj/structure/window/reinforced/tinted,
+/turf/open/floor/plasteel/showroomfloor,
 /area/ruin/unpowered)
 "p" = (
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/showroomfloor,
 /area/ruin/unpowered)
 "q" = (
 /turf/closed/wall,
+/area/ruin/unpowered)
+"x" = (
+/obj/effect/turf_decal/tile/green/tile_full,
+/turf/open/floor/plasteel/showroomfloor,
 /area/ruin/unpowered)
 "K" = (
 /obj/effect/abstract/doorway_marker{
@@ -34,15 +50,28 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "M" = (
-/obj/machinery/door/window/eastright,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/green/filled/shrink_ccw,
+/turf/open/floor/plasteel/showroomfloor,
 /area/ruin/unpowered)
 "X" = (
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/structure/window/reinforced/spawner/north,
-/turf/open/floor/plasteel,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/machinery/door/window/westleft,
+/turf/open/floor/plasteel/showroomfloor,
+/area/ruin/unpowered)
+"Y" = (
+/obj/structure/urinal{
+	pixel_y = 32
+	},
+/obj/structure/window/reinforced/tinted,
+/obj/effect/turf_decal/trimline/green/filled/arrow_cw{
+	dir = 1
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/ruin/unpowered)
 
 (1,1,1) = {"
@@ -62,14 +91,14 @@ q
 (3,1,1) = {"
 q
 l
-p
+x
 M
 q
 "}
 (4,1,1) = {"
 q
-c
-p
+Y
+o
 X
 q
 "}

--- a/_maps/RuinGeneration/5x5_5_hallwayroom_east.dmm
+++ b/_maps/RuinGeneration/5x5_5_hallwayroom_east.dmm
@@ -1,4 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"b" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "d" = (
 /obj/effect/abstract/open_area_marker{
 	dir = 8
@@ -28,14 +32,14 @@ h
 (2,1,1) = {"
 h
 Q
-Q
+b
 Q
 h
 "}
 (3,1,1) = {"
 h
 Q
-Q
+b
 Q
 h
 "}

--- a/_maps/RuinGeneration/5x5_5_hallwayroom_west.dmm
+++ b/_maps/RuinGeneration/5x5_5_hallwayroom_west.dmm
@@ -1,4 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"b" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "h" = (
 /turf/closed/wall,
 /area/ruin/unpowered)
@@ -35,14 +39,14 @@ h
 (3,1,1) = {"
 h
 Q
-Q
+b
 Q
 h
 "}
 (4,1,1) = {"
 h
 Q
-Q
+b
 Q
 h
 "}

--- a/_maps/RuinGeneration/5x5_6_hallwayvertical_east_room.dmm
+++ b/_maps/RuinGeneration/5x5_6_hallwayvertical_east_room.dmm
@@ -17,6 +17,10 @@
 "Q" = (
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"T" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "V" = (
 /obj/effect/abstract/open_area_marker,
 /turf/open/floor/plasteel,
@@ -38,9 +42,9 @@ Q
 "}
 (3,1,1) = {"
 M
-Q
-Q
-Q
+T
+T
+T
 V
 "}
 (4,1,1) = {"

--- a/_maps/RuinGeneration/5x5_6_hallwayvertical_west_room.dmm
+++ b/_maps/RuinGeneration/5x5_6_hallwayvertical_west_room.dmm
@@ -8,6 +8,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"y" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "M" = (
 /obj/effect/abstract/open_area_marker{
 	dir = 1
@@ -38,9 +42,9 @@ Q
 "}
 (3,1,1) = {"
 M
-Q
-Q
-Q
+y
+y
+y
 V
 "}
 (4,1,1) = {"

--- a/_maps/RuinGeneration/5x5_8_hallwayt-east.dmm
+++ b/_maps/RuinGeneration/5x5_8_hallwayt-east.dmm
@@ -5,6 +5,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"f" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"q" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "s" = (
 /obj/effect/abstract/open_area_marker{
 	dir = 1
@@ -16,6 +28,16 @@
 /area/ruin/unpowered)
 "L" = (
 /obj/effect/abstract/open_area_marker,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"O" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"S" = (
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "Y" = (
@@ -38,15 +60,15 @@ Y
 "}
 (3,1,1) = {"
 s
-Y
-Y
-Y
+f
+S
+q
 L
 "}
 (4,1,1) = {"
 Y
 Y
-Y
+O
 Y
 Y
 "}

--- a/_maps/RuinGeneration/5x5_8_hallwayt-north.dmm
+++ b/_maps/RuinGeneration/5x5_8_hallwayt-north.dmm
@@ -5,6 +5,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"e" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "l" = (
 /obj/effect/abstract/open_area_marker{
 	dir = 1
@@ -23,6 +29,20 @@
 "E" = (
 /turf/closed/wall,
 /area/ruin/unpowered)
+"L" = (
+/obj/effect/turf_decal/tile/neutral/tile_side,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"P" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"Q" = (
+/obj/effect/turf_decal/tile/neutral/tile_full,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 
 (1,1,1) = {"
 E
@@ -34,21 +54,21 @@ E
 (2,1,1) = {"
 n
 n
-n
+L
 n
 E
 "}
 (3,1,1) = {"
 l
-n
-n
+e
+Q
 n
 E
 "}
 (4,1,1) = {"
 n
 n
-n
+P
 n
 E
 "}

--- a/_maps/RuinGeneration/5x5_8_hallwayt-south.dmm
+++ b/_maps/RuinGeneration/5x5_8_hallwayt-south.dmm
@@ -1,4 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"h" = (
+/obj/effect/turf_decal/tile/neutral/tile_side,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "j" = (
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
@@ -15,10 +19,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"J" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"K" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "U" = (
 /obj/effect/abstract/open_area_marker{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"X" = (
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 
@@ -32,21 +52,21 @@ s
 (2,1,1) = {"
 s
 j
-j
+h
 j
 j
 "}
 (3,1,1) = {"
 s
 j
-j
-j
+X
+K
 p
 "}
 (4,1,1) = {"
 s
 j
-j
+J
 j
 j
 "}

--- a/_maps/RuinGeneration/5x5_8_hallwayt-west.dmm
+++ b/_maps/RuinGeneration/5x5_8_hallwayt-west.dmm
@@ -3,8 +3,22 @@
 /obj/effect/abstract/open_area_marker,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"g" = (
+/obj/effect/turf_decal/tile/neutral/tile_side,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "h" = (
 /turf/closed/wall,
+/area/ruin/unpowered)
+"k" = (
+/obj/effect/turf_decal/tile/neutral/tile_full,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"s" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "z" = (
 /obj/effect/abstract/open_area_marker{
@@ -15,6 +29,12 @@
 "N" = (
 /obj/effect/abstract/open_area_marker{
 	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"R" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
@@ -32,15 +52,15 @@ h
 (2,1,1) = {"
 X
 X
-X
+g
 X
 X
 "}
 (3,1,1) = {"
 z
-X
-X
-X
+s
+k
+R
 d
 "}
 (4,1,1) = {"

--- a/_maps/RuinGeneration/5x5_cryo.dmm
+++ b/_maps/RuinGeneration/5x5_cryo.dmm
@@ -24,16 +24,12 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/ruin/unpowered)
-"u" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ruin/unpowered)
 "x" = (
 /obj/effect/abstract/doorway_marker,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "C" = (
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "E" = (
 /obj/machinery/cryopod{
@@ -51,7 +47,7 @@
 /obj/machinery/computer/cryopod{
 	pixel_y = 25
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "R" = (
 /obj/effect/turf_decal/stripes/line{
@@ -79,7 +75,7 @@ L
 t
 f
 E
-u
+L
 "}
 (3,1,1) = {"
 L
@@ -93,7 +89,7 @@ L
 j
 R
 T
-u
+L
 "}
 (5,1,1) = {"
 L

--- a/_maps/RuinGeneration/5x5_hern.dmm
+++ b/_maps/RuinGeneration/5x5_hern.dmm
@@ -13,17 +13,30 @@
 /area/ruin/unpowered)
 "D" = (
 /obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "H" = (
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "J" = (
-/obj/item/kirbyplants/random,
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "R" = (
-/obj/structure/closet/emcloset,
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"V" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "W" = (
@@ -54,7 +67,7 @@ W
 (4,1,1) = {"
 W
 H
-H
+V
 H
 W
 "}

--- a/_maps/RuinGeneration/5x5_hern_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hern_damaged.dmm
@@ -7,6 +7,9 @@
 /area/ruin/unpowered)
 "k" = (
 /obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "s" = (
@@ -16,22 +19,21 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "y" = (
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "A" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "D" = (
 /obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "S" = (
 /turf/closed/wall,
-/area/ruin/unpowered)
-"V" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plating,
 /area/ruin/unpowered)
 "W" = (
 /obj/effect/abstract/doorway_marker{
@@ -50,7 +52,7 @@ S
 (2,1,1) = {"
 S
 k
-V
+u
 D
 S
 "}

--- a/_maps/RuinGeneration/5x5_hernsw.dmm
+++ b/_maps/RuinGeneration/5x5_hernsw.dmm
@@ -2,6 +2,10 @@
 "k" = (
 /turf/closed/wall,
 /area/ruin/unpowered)
+"B" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "G" = (
 /obj/effect/abstract/open_area_marker{
 	dir = 4
@@ -45,14 +49,14 @@ k
 (3,1,1) = {"
 T
 M
-M
+B
 M
 Y
 "}
 (4,1,1) = {"
 k
 M
-M
+B
 M
 k
 "}

--- a/_maps/RuinGeneration/5x5_hernsw_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hernsw_damaged.dmm
@@ -6,7 +6,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "u" = (
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "x" = (
 /obj/effect/abstract/doorway_marker,
@@ -29,7 +29,7 @@
 /area/ruin/unpowered)
 "L" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "Q" = (
 /obj/effect/abstract/open_area_marker{

--- a/_maps/RuinGeneration/5x5_hernw.dmm
+++ b/_maps/RuinGeneration/5x5_hernw.dmm
@@ -3,7 +3,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "q" = (
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "u" = (
@@ -39,20 +39,20 @@ U
 U
 o
 o
-q
+o
 U
 "}
 (3,1,1) = {"
 M
 o
-o
+q
 o
 U
 "}
 (4,1,1) = {"
 U
 o
-o
+q
 o
 U
 "}

--- a/_maps/RuinGeneration/5x5_hernw_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hernw_damaged.dmm
@@ -13,7 +13,7 @@
 /area/ruin/unpowered)
 "h" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "l" = (
 /obj/effect/abstract/open_area_marker{
@@ -22,7 +22,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "o" = (
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "y" = (
 /turf/closed/wall,

--- a/_maps/RuinGeneration/5x5_hers.dmm
+++ b/_maps/RuinGeneration/5x5_hers.dmm
@@ -12,15 +12,28 @@
 /turf/closed/wall,
 /area/ruin/unpowered)
 "v" = (
-/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "w" = (
 /obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"x" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "A" = (
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "W" = (
@@ -52,7 +65,7 @@ W
 (4,1,1) = {"
 r
 o
-o
+x
 o
 r
 "}

--- a/_maps/RuinGeneration/5x5_hers_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hers_damaged.dmm
@@ -8,7 +8,7 @@
 /area/ruin/unpowered)
 "o" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "s" = (
 /turf/open/floor/plating,
@@ -17,7 +17,7 @@
 /turf/closed/wall,
 /area/ruin/unpowered)
 "F" = (
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "J" = (
 /obj/effect/abstract/doorway_marker,

--- a/_maps/RuinGeneration/5x5_hersw.dmm
+++ b/_maps/RuinGeneration/5x5_hersw.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "s" = (
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "w" = (
@@ -35,7 +35,7 @@ C
 "}
 (2,1,1) = {"
 C
-s
+K
 K
 K
 C
@@ -43,14 +43,14 @@ C
 (3,1,1) = {"
 C
 K
-K
+s
 K
 M
 "}
 (4,1,1) = {"
 C
 K
-K
+s
 K
 C
 "}

--- a/_maps/RuinGeneration/5x5_hersw_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hersw_damaged.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "g" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "j" = (
 /obj/effect/abstract/doorway_marker{
@@ -19,6 +19,10 @@
 "B" = (
 /turf/closed/wall,
 /area/ruin/unpowered)
+"G" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "H" = (
 /obj/effect/abstract/open_area_marker{
 	dir = 4
@@ -29,7 +33,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "Z" = (
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 
 (1,1,1) = {"
@@ -56,7 +60,7 @@ m
 (4,1,1) = {"
 Z
 A
-I
+G
 I
 B
 "}

--- a/_maps/RuinGeneration/5x5_hesrnw.dmm
+++ b/_maps/RuinGeneration/5x5_hesrnw.dmm
@@ -8,8 +8,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"r" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "t" = (
 /turf/closed/wall,
+/area/ruin/unpowered)
+"x" = (
+/obj/effect/turf_decal/tile/neutral/tile_full,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "z" = (
 /obj/effect/abstract/open_area_marker{
@@ -19,6 +29,12 @@
 /area/ruin/unpowered)
 "H" = (
 /obj/effect/abstract/open_area_marker,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"M" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "U" = (
@@ -45,14 +61,14 @@ e
 (3,1,1) = {"
 U
 e
-e
-e
+x
+M
 H
 "}
 (4,1,1) = {"
 t
 e
-e
+r
 e
 e
 "}

--- a/_maps/RuinGeneration/5x5_hesrnw_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hesrnw_damaged.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "b" = (
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "d" = (
 /turf/open/floor/plasteel,
@@ -16,7 +16,7 @@
 /area/ruin/unpowered)
 "l" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "n" = (
 /obj/effect/abstract/doorway_marker{

--- a/_maps/RuinGeneration/5x5_heswrn.dmm
+++ b/_maps/RuinGeneration/5x5_heswrn.dmm
@@ -1,6 +1,18 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"b" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "f" = (
 /obj/effect/abstract/doorway_marker{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"q" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -27,6 +39,14 @@
 "N" = (
 /turf/closed/wall,
 /area/ruin/unpowered)
+"P" = (
+/obj/effect/turf_decal/tile/neutral/tile_full,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"T" = (
+/obj/effect/turf_decal/tile/neutral/tile_side,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 
 (1,1,1) = {"
 N
@@ -38,21 +58,21 @@ N
 (2,1,1) = {"
 N
 F
-F
+T
 F
 F
 "}
 (3,1,1) = {"
 f
 F
-F
-F
+P
+b
 H
 "}
 (4,1,1) = {"
 N
 F
-F
+q
 F
 F
 "}

--- a/_maps/RuinGeneration/5x5_heswrn_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_heswrn_damaged.dmm
@@ -22,10 +22,10 @@
 /area/ruin/unpowered)
 "A" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "F" = (
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "G" = (
 /obj/effect/abstract/open_area_marker{

--- a/_maps/RuinGeneration/5x5_hew_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hew_damaged.dmm
@@ -3,7 +3,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "f" = (
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "s" = (
 /obj/effect/abstract/open_area_marker{
@@ -13,7 +13,7 @@
 /area/ruin/unpowered)
 "D" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "F" = (
 /turf/closed/wall,

--- a/_maps/RuinGeneration/5x5_hewrn.dmm
+++ b/_maps/RuinGeneration/5x5_hewrn.dmm
@@ -11,6 +11,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"B" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "C" = (
 /turf/closed/wall,
 /area/ruin/unpowered)
@@ -34,21 +38,21 @@ C
 (2,1,1) = {"
 C
 K
-K
+B
 K
 C
 "}
 (3,1,1) = {"
 T
 K
-K
+B
 K
 C
 "}
 (4,1,1) = {"
 C
 K
-K
+B
 K
 C
 "}

--- a/_maps/RuinGeneration/5x5_hewrn_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hewrn_damaged.dmm
@@ -18,9 +18,13 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "A" = (
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "G" = (
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"O" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "Q" = (
@@ -28,7 +32,7 @@
 /area/ruin/unpowered)
 "W" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "Z" = (
 /turf/open/floor/plating,
@@ -58,7 +62,7 @@ A
 (4,1,1) = {"
 Q
 G
-G
+O
 Z
 A
 "}

--- a/_maps/RuinGeneration/5x5_hewrns.dmm
+++ b/_maps/RuinGeneration/5x5_hewrns.dmm
@@ -3,6 +3,10 @@
 /obj/effect/abstract/doorway_marker,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"j" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "n" = (
 /obj/effect/abstract/open_area_marker{
 	dir = 8
@@ -38,21 +42,21 @@ J
 (2,1,1) = {"
 J
 E
-E
+j
 E
 J
 "}
 (3,1,1) = {"
 V
 E
-E
+j
 E
 e
 "}
 (4,1,1) = {"
 J
 E
-E
+j
 E
 J
 "}

--- a/_maps/RuinGeneration/5x5_hewrns_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hewrns_damaged.dmm
@@ -5,7 +5,7 @@
 /area/ruin/unpowered)
 "d" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "h" = (
 /turf/closed/wall,

--- a/_maps/RuinGeneration/5x5_hewrs.dmm
+++ b/_maps/RuinGeneration/5x5_hewrs.dmm
@@ -8,6 +8,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"u" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "v" = (
 /turf/closed/wall,
 /area/ruin/unpowered)
@@ -32,21 +36,21 @@ v
 (2,1,1) = {"
 v
 l
-l
+u
 l
 v
 "}
 (3,1,1) = {"
 v
 l
-l
+u
 l
 V
 "}
 (4,1,1) = {"
 v
 l
-l
+u
 l
 v
 "}

--- a/_maps/RuinGeneration/5x5_hewrs_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hewrs_damaged.dmm
@@ -20,10 +20,10 @@
 /area/ruin/unpowered)
 "w" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "F" = (
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "L" = (
 /obj/effect/abstract/open_area_marker{

--- a/_maps/RuinGeneration/5x5_hnersw.dmm
+++ b/_maps/RuinGeneration/5x5_hnersw.dmm
@@ -2,6 +2,12 @@
 "f" = (
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"g" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "l" = (
 /obj/effect/abstract/open_area_marker{
 	dir = 1
@@ -20,6 +26,16 @@
 /area/ruin/unpowered)
 "x" = (
 /turf/closed/wall,
+/area/ruin/unpowered)
+"D" = (
+/obj/effect/turf_decal/tile/neutral/tile_full,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"R" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "Y" = (
 /obj/effect/abstract/open_area_marker{
@@ -44,15 +60,15 @@ x
 "}
 (3,1,1) = {"
 l
-f
-f
+R
+D
 f
 v
 "}
 (4,1,1) = {"
 f
 f
-f
+g
 f
 x
 "}

--- a/_maps/RuinGeneration/5x5_hnersw_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hnersw_damaged.dmm
@@ -4,7 +4,7 @@
 /area/ruin/unpowered)
 "o" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "p" = (
 /obj/effect/abstract/doorway_marker,

--- a/_maps/RuinGeneration/5x5_hnesrw.dmm
+++ b/_maps/RuinGeneration/5x5_hnesrw.dmm
@@ -1,8 +1,30 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"c" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "i" = (
 /turf/closed/wall,
 /area/ruin/unpowered)
 "j" = (
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"m" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"n" = (
+/obj/effect/turf_decal/tile/neutral/tile_full,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"p" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "q" = (
@@ -44,15 +66,15 @@ j
 "}
 (3,1,1) = {"
 T
-j
-j
-j
+p
+n
+c
 D
 "}
 (4,1,1) = {"
 j
 j
-j
+m
 j
 j
 "}

--- a/_maps/RuinGeneration/5x5_hnesrw_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hnesrw_damaged.dmm
@@ -9,14 +9,14 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "i" = (
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "p" = (
 /turf/closed/wall,
 /area/ruin/unpowered)
 "C" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "G" = (
 /turf/open/floor/plating,

--- a/_maps/RuinGeneration/5x5_hnewrs.dmm
+++ b/_maps/RuinGeneration/5x5_hnewrs.dmm
@@ -9,6 +9,10 @@
 /obj/effect/abstract/doorway_marker,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"F" = (
+/obj/effect/turf_decal/tile/neutral/tile_full,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "H" = (
 /turf/closed/wall,
 /area/ruin/unpowered)
@@ -16,6 +20,22 @@
 /obj/effect/abstract/open_area_marker{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"O" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"P" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"S" = (
+/obj/effect/turf_decal/tile/neutral/tile_side,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "V" = (
@@ -38,21 +58,21 @@ H
 (2,1,1) = {"
 Y
 Y
-Y
+S
 Y
 H
 "}
 (3,1,1) = {"
 e
-Y
-Y
+P
+F
 Y
 f
 "}
 (4,1,1) = {"
 Y
 Y
-Y
+O
 Y
 H
 "}

--- a/_maps/RuinGeneration/5x5_hnewrs_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hnewrs_damaged.dmm
@@ -26,7 +26,7 @@
 /area/ruin/unpowered)
 "X" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "Z" = (
 /obj/effect/abstract/open_area_marker{

--- a/_maps/RuinGeneration/5x5_hnresw.dmm
+++ b/_maps/RuinGeneration/5x5_hnresw.dmm
@@ -3,6 +3,10 @@
 /obj/effect/abstract/doorway_marker,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"h" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "i" = (
 /turf/closed/wall,
 /area/ruin/unpowered)
@@ -44,8 +48,8 @@ i
 "}
 (3,1,1) = {"
 n
-j
-j
+h
+h
 j
 g
 "}

--- a/_maps/RuinGeneration/5x5_hnresw_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hnresw_damaged.dmm
@@ -32,7 +32,7 @@
 /area/ruin/unpowered)
 "X" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 
 (1,1,1) = {"

--- a/_maps/RuinGeneration/5x5_hns_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hns_damaged.dmm
@@ -9,7 +9,7 @@
 /turf/closed/wall,
 /area/ruin/unpowered)
 "z" = (
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "D" = (
 /obj/effect/abstract/open_area_marker,
@@ -17,7 +17,7 @@
 /area/ruin/unpowered)
 "F" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "J" = (
 /obj/effect/abstract/open_area_marker{

--- a/_maps/RuinGeneration/5x5_hnswre.dmm
+++ b/_maps/RuinGeneration/5x5_hnswre.dmm
@@ -5,17 +5,37 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"b" = (
+/obj/effect/turf_decal/tile/neutral/tile_full,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "f" = (
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"i" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "m" = (
 /obj/effect/abstract/open_area_marker,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"o" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "p" = (
 /obj/effect/abstract/open_area_marker{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"I" = (
+/obj/effect/turf_decal/tile/neutral/tile_side,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "J" = (
@@ -38,15 +58,15 @@ J
 (2,1,1) = {"
 f
 f
-f
+I
 f
 f
 "}
 (3,1,1) = {"
 P
-f
-f
-f
+o
+b
+i
 m
 "}
 (4,1,1) = {"

--- a/_maps/RuinGeneration/5x5_hnswre_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hnswre_damaged.dmm
@@ -7,7 +7,7 @@
 /area/ruin/unpowered)
 "n" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "q" = (
 /obj/effect/abstract/doorway_marker{
@@ -25,7 +25,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "D" = (
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "G" = (
 /turf/closed/wall,

--- a/_maps/RuinGeneration/5x5_hnwres.dmm
+++ b/_maps/RuinGeneration/5x5_hnwres.dmm
@@ -1,4 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"j" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "m" = (
 /obj/effect/abstract/open_area_marker{
 	dir = 8
@@ -11,6 +17,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"w" = (
+/obj/effect/turf_decal/tile/neutral/tile_full,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "F" = (
 /obj/effect/abstract/doorway_marker,
 /turf/open/floor/plasteel,
@@ -20,6 +30,10 @@
 /area/ruin/unpowered)
 "R" = (
 /turf/closed/wall,
+/area/ruin/unpowered)
+"Y" = (
+/obj/effect/turf_decal/tile/neutral/tile_side,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "Z" = (
 /obj/effect/abstract/doorway_marker{
@@ -38,14 +52,14 @@ R
 (2,1,1) = {"
 O
 O
-O
+Y
 O
 R
 "}
 (3,1,1) = {"
 n
-O
-O
+j
+w
 O
 F
 "}

--- a/_maps/RuinGeneration/5x5_hnwres_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hnwres_damaged.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "c" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "k" = (
 /turf/open/floor/plating,

--- a/_maps/RuinGeneration/5x5_hsrnew.dmm
+++ b/_maps/RuinGeneration/5x5_hsrnew.dmm
@@ -2,6 +2,10 @@
 "k" = (
 /turf/closed/wall,
 /area/ruin/unpowered)
+"C" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "E" = (
 /obj/effect/abstract/doorway_marker{
 	dir = 4
@@ -45,8 +49,8 @@ U
 (3,1,1) = {"
 P
 U
-U
-U
+C
+C
 W
 "}
 (4,1,1) = {"

--- a/_maps/RuinGeneration/5x5_hsrnew_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hsrnew_damaged.dmm
@@ -19,7 +19,7 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "v" = (
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "E" = (
 /turf/closed/wall,
@@ -35,7 +35,7 @@
 /area/ruin/unpowered)
 "X" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 
 (1,1,1) = {"

--- a/_maps/RuinGeneration/5x5_hswrne.dmm
+++ b/_maps/RuinGeneration/5x5_hswrne.dmm
@@ -1,12 +1,26 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"j" = (
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "k" = (
 /obj/effect/abstract/doorway_marker{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"v" = (
+/obj/effect/turf_decal/tile/neutral/tile_full,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "x" = (
 /obj/effect/abstract/open_area_marker,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"G" = (
+/obj/effect/turf_decal/tile/neutral/tile_side,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "J" = (
@@ -38,15 +52,15 @@ W
 (2,1,1) = {"
 W
 P
-P
+G
 P
 P
 "}
 (3,1,1) = {"
 k
 P
-P
-P
+v
+j
 x
 "}
 (4,1,1) = {"

--- a/_maps/RuinGeneration/5x5_hswrne_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hswrne_damaged.dmm
@@ -8,7 +8,7 @@
 /area/ruin/unpowered)
 "o" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "q" = (
 /obj/effect/abstract/open_area_marker{
@@ -20,7 +20,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "H" = (
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "N" = (
 /turf/open/floor/plating,

--- a/_maps/RuinGeneration/5x5_hwres.dmm
+++ b/_maps/RuinGeneration/5x5_hwres.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "f" = (
@@ -36,20 +36,20 @@ w
 (2,1,1) = {"
 w
 f
-f
+a
 f
 w
 "}
 (3,1,1) = {"
 w
 f
-f
+a
 f
 q
 "}
 (4,1,1) = {"
 w
-a
+f
 f
 f
 w

--- a/_maps/RuinGeneration/5x5_hwres_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hwres_damaged.dmm
@@ -9,23 +9,18 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "m" = (
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "p" = (
 /obj/effect/abstract/doorway_marker,
 /turf/open/floor/plasteel,
-/area/ruin/unpowered)
-"t" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/structure/lattice,
-/turf/open/space/basic,
 /area/ruin/unpowered)
 "C" = (
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "D" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "F" = (
 /turf/closed/wall,
@@ -60,7 +55,7 @@ p
 "}
 (4,1,1) = {"
 m
-t
+D
 d
 C
 F

--- a/_maps/RuinGeneration/5x5_hwrn.dmm
+++ b/_maps/RuinGeneration/5x5_hwrn.dmm
@@ -1,13 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"f" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "h" = (
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "j" = (
-/obj/structure/closet/emcloset,
+/obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "o" = (
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "q" = (
@@ -17,7 +21,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "x" = (
-/obj/structure/closet/firecloset,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "N" = (
@@ -40,14 +44,14 @@ N
 (2,1,1) = {"
 N
 h
-h
+f
 h
 N
 "}
 (3,1,1) = {"
 q
 h
-h
+f
 h
 N
 "}

--- a/_maps/RuinGeneration/5x5_hwrn_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hwrn_damaged.dmm
@@ -1,11 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "i" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "t" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "u" = (
 /obj/effect/abstract/open_area_marker{
@@ -14,7 +13,8 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "v" = (
-/turf/open/space/basic,
+/obj/item/chair/stool,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "A" = (
 /obj/effect/abstract/doorway_marker{
@@ -44,25 +44,25 @@ G
 I
 X
 t
-v
+i
 "}
 (3,1,1) = {"
 A
 X
 v
-v
+i
 G
 "}
 (4,1,1) = {"
 G
 t
 t
-i
+X
 G
 "}
 (5,1,1) = {"
-v
-v
+i
+i
 G
 G
 G

--- a/_maps/RuinGeneration/5x5_hwrne.dmm
+++ b/_maps/RuinGeneration/5x5_hwrne.dmm
@@ -6,7 +6,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "o" = (
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "r" = (
@@ -38,14 +38,14 @@ s
 (2,1,1) = {"
 s
 G
-G
+o
 G
 s
 "}
 (3,1,1) = {"
 b
 G
-G
+o
 G
 s
 "}
@@ -53,7 +53,7 @@ s
 s
 G
 G
-o
+G
 s
 "}
 (5,1,1) = {"

--- a/_maps/RuinGeneration/5x5_hwrne_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hwrne_damaged.dmm
@@ -1,21 +1,16 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "b" = (
-/obj/item/twohanded/required/kirbyplants/random,
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "e" = (
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "h" = (
 /obj/effect/abstract/doorway_marker{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/ruin/unpowered)
-"v" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
 /area/ruin/unpowered)
 "x" = (
 /turf/open/floor/plating,
@@ -50,15 +45,15 @@ N
 N
 X
 x
-v
+b
 x
 "}
 (3,1,1) = {"
 D
 x
-v
+b
 e
-v
+e
 "}
 (4,1,1) = {"
 N

--- a/_maps/RuinGeneration/5x5_hwrnes.dmm
+++ b/_maps/RuinGeneration/5x5_hwrnes.dmm
@@ -8,6 +8,10 @@
 "j" = (
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"m" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "o" = (
 /obj/effect/abstract/doorway_marker,
 /turf/open/floor/plasteel,
@@ -38,14 +42,14 @@ A
 (2,1,1) = {"
 A
 j
-j
+m
 j
 A
 "}
 (3,1,1) = {"
 Q
 j
-j
+m
 j
 o
 "}

--- a/_maps/RuinGeneration/5x5_hwrnes_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hwrnes_damaged.dmm
@@ -22,7 +22,7 @@
 /area/ruin/unpowered)
 "D" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "G" = (
 /turf/closed/wall,

--- a/_maps/RuinGeneration/5x5_hwrns.dmm
+++ b/_maps/RuinGeneration/5x5_hwrns.dmm
@@ -1,6 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "e" = (
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "f" = (
@@ -11,7 +13,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "q" = (
-/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "v" = (
@@ -27,7 +29,10 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "R" = (
-/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/neutral/tile_side{
+	dir = 1
+	},
+/obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "U" = (
@@ -45,20 +50,20 @@ U
 U
 R
 e
-q
+e
 U
 "}
 (3,1,1) = {"
 F
 f
-f
+q
 f
 g
 "}
 (4,1,1) = {"
 U
 f
-f
+q
 f
 U
 "}

--- a/_maps/RuinGeneration/5x5_hwrns_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hwrns_damaged.dmm
@@ -15,11 +15,11 @@
 /turf/closed/wall,
 /area/ruin/unpowered)
 "I" = (
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "J" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "O" = (
 /obj/effect/abstract/doorway_marker,

--- a/_maps/RuinGeneration/5x5_hwrs.dmm
+++ b/_maps/RuinGeneration/5x5_hwrs.dmm
@@ -32,7 +32,7 @@
 /area/ruin/unpowered)
 "Z" = (
 /obj/effect/abstract/open_area_marker{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)

--- a/_maps/RuinGeneration/5x5_hwrs.dmm
+++ b/_maps/RuinGeneration/5x5_hwrs.dmm
@@ -3,15 +3,24 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"o" = (
+/obj/item/pickaxe,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "u" = (
 /obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"E" = (
+/obj/structure/ore_box,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "F" = (
 /turf/closed/wall,
 /area/ruin/unpowered)
 "G" = (
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "I" = (
@@ -37,23 +46,23 @@ F
 "}
 (2,1,1) = {"
 F
-U
-U
+E
+G
 U
 F
 "}
 (3,1,1) = {"
 F
-U
-U
+o
+G
 U
 I
 "}
 (4,1,1) = {"
 F
 h
-G
 u
+U
 F
 "}
 (5,1,1) = {"

--- a/_maps/RuinGeneration/5x5_hwrs_damaged.dmm
+++ b/_maps/RuinGeneration/5x5_hwrs_damaged.dmm
@@ -9,11 +9,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"I" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "K" = (
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "L" = (
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 "N" = (
 /obj/effect/abstract/doorway_marker,
@@ -27,7 +31,7 @@
 /area/ruin/unpowered)
 "Y" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop/open,
 /area/ruin/unpowered)
 
 (1,1,1) = {"
@@ -40,14 +44,14 @@ U
 (2,1,1) = {"
 U
 K
-K
+I
 K
 U
 "}
 (3,1,1) = {"
 L
 V
-K
+I
 K
 N
 "}

--- a/_maps/RuinGeneration/5x9_gateway.dmm
+++ b/_maps/RuinGeneration/5x9_gateway.dmm
@@ -4,16 +4,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered)
 "b" = (
@@ -21,16 +12,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered)
 "d" = (
@@ -40,36 +22,18 @@
 "f" = (
 /obj/machinery/gateway,
 /obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered)
 "h" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/ruin/unpowered)
 "p" = (
 /obj/machinery/gateway{
 	dir = 9
 	},
 /obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered)
 "s" = (
@@ -77,61 +41,24 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered)
 "x" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered)
 "C" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "gateshutter";
-	name = "Gateway Access Shutter"
-	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "H" = (
 /obj/machinery/gateway{
 	dir = 1
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered)
 "K" = (
@@ -139,16 +66,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered)
 "M" = (
@@ -164,16 +82,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/neutral/tile_full,
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered)
 "V" = (

--- a/_maps/RuinGeneration/5x9_lounge.dmm
+++ b/_maps/RuinGeneration/5x9_lounge.dmm
@@ -7,24 +7,49 @@
 /obj/effect/abstract/doorway_marker{
 	dir = 8
 	},
+/obj/effect/turf_decal/monke/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "h" = (
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"k" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "q" = (
 /obj/structure/chair/comfy{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/monke/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
 /area/ruin/unpowered)
 "t" = (
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"w" = (
+/obj/effect/turf_decal/monke/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"C" = (
 /obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
 /area/ruin/unpowered)
 "G" = (
 /obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel,
+/turf/open/floor/wood,
+/area/ruin/unpowered)
+"I" = (
+/obj/structure/chair/comfy{
+	dir = 4
+	},
+/turf/open/floor/wood,
 /area/ruin/unpowered)
 "J" = (
 /obj/effect/abstract/open_area_marker{
@@ -50,33 +75,33 @@ Z
 (2,1,1) = {"
 Z
 c
-q
-q
-q
 h
 h
+q
+I
+t
 t
 Z
 "}
 (3,1,1) = {"
 Z
 h
+k
 h
-h
-h
-h
-h
-h
+w
+t
+t
+t
 Z
 "}
 (4,1,1) = {"
 Z
 h
+k
 h
-h
-h
-h
-h
+w
+t
+C
 G
 Z
 "}

--- a/_maps/RuinGeneration/5x9_northernairlock.dmm
+++ b/_maps/RuinGeneration/5x9_northernairlock.dmm
@@ -1,4 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"e" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "q" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -62,7 +66,7 @@ T
 E
 s
 O
-O
+e
 S
 "}
 (4,1,1) = {"

--- a/_maps/RuinGeneration/5x9_southernairlock.dmm
+++ b/_maps/RuinGeneration/5x9_southernairlock.dmm
@@ -18,6 +18,10 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
+"P" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "T" = (
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
@@ -58,7 +62,7 @@ U
 "}
 (3,1,1) = {"
 Y
-T
+P
 T
 n
 h

--- a/_maps/RuinGeneration/5x9_windowroom.dmm
+++ b/_maps/RuinGeneration/5x9_windowroom.dmm
@@ -1,4 +1,14 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"c" = (
+/obj/machinery/door/airlock/grunge,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"e" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
 "f" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -6,16 +16,27 @@
 "k" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/gloves,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered)
 "m" = (
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 5
+	},
+/area/ruin/unpowered)
+"n" = (
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered)
 "u" = (
 /obj/structure/chair/office{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"z" = (
+/obj/machinery/photocopier,
+/turf/open/floor/plasteel/dark/side{
+	dir = 5
+	},
 /area/ruin/unpowered)
 "B" = (
 /obj/effect/abstract/doorway_marker{
@@ -25,15 +46,36 @@
 /area/ruin/unpowered)
 "E" = (
 /obj/structure/table,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"F" = (
+/obj/structure/rack,
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered)
 "G" = (
 /obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
+/area/ruin/unpowered)
+"I" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
+/area/ruin/unpowered)
+"P" = (
+/obj/structure/table,
+/obj/item/modular_computer/laptop/preset/civillian,
+/turf/open/floor/plasteel/dark,
 /area/ruin/unpowered)
 "R" = (
 /obj/structure/filingcabinet/security,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
+/area/ruin/unpowered)
+"W" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
 /area/ruin/unpowered)
 "X" = (
 /turf/closed/wall,
@@ -52,45 +94,45 @@ X
 "}
 (2,1,1) = {"
 X
+z
+W
+I
+c
 m
-m
-m
-m
-m
-m
+W
 G
 X
 "}
 (3,1,1) = {"
 X
-m
-m
-m
-m
-m
+F
+n
+n
+X
+n
 u
-E
+e
 X
 "}
 (4,1,1) = {"
 X
 R
-m
-m
-m
+n
+n
+f
 k
-E
+P
 E
 X
 "}
 (5,1,1) = {"
 X
 X
-f
-f
 X
-f
-f
+X
+X
+X
+X
 X
 X
 "}

--- a/_maps/RuinGeneration/9x13_kitchen.dmm
+++ b/_maps/RuinGeneration/9x13_kitchen.dmm
@@ -51,6 +51,10 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ruin/unpowered)
+"n" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "o" = (
 /obj/structure/table,
 /obj/item/kitchen/rollingpin,
@@ -81,11 +85,8 @@
 /area/ruin/unpowered)
 "F" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/cafeteria,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
 /area/ruin/unpowered)
 "G" = (
 /obj/machinery/processor,
@@ -124,11 +125,8 @@
 "T" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/cafeteria,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
 /area/ruin/unpowered)
 "Z" = (
 /obj/machinery/deepfryer,
@@ -161,7 +159,7 @@ O
 L
 q
 z
-z
+n
 z
 L
 "}
@@ -176,7 +174,7 @@ O
 L
 q
 z
-z
+n
 z
 L
 "}
@@ -191,7 +189,7 @@ O
 T
 q
 z
-z
+n
 z
 L
 "}
@@ -206,7 +204,7 @@ O
 F
 q
 z
-z
+n
 z
 L
 "}
@@ -221,7 +219,7 @@ O
 F
 q
 z
-z
+n
 z
 L
 "}
@@ -236,7 +234,7 @@ O
 F
 q
 z
-z
+n
 z
 L
 "}
@@ -251,7 +249,7 @@ O
 L
 q
 z
-z
+n
 z
 L
 "}

--- a/_maps/RuinGeneration/9x13_medstorage.dmm
+++ b/_maps/RuinGeneration/9x13_medstorage.dmm
@@ -10,7 +10,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "i" = (
 /obj/structure/window/reinforced,
@@ -43,6 +43,10 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
+"m" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "p" = (
 /obj/structure/table/glass,
 /obj/machinery/door/window{
@@ -65,6 +69,10 @@
 /obj/effect/spawner/lootdrop/ruinloot/medical,
 /obj/effect/spawner/lootdrop/ruinloot/medical,
 /turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"w" = (
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "x" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
@@ -116,7 +124,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "J" = (
 /obj/effect/turf_decal/tile/blue,
@@ -161,13 +169,10 @@
 /obj/effect/abstract/open_area_marker{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "P" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/closed/wall,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "R" = (
 /turf/open/floor/plasteel/white,
@@ -176,7 +181,7 @@
 /obj/effect/abstract/open_area_marker{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "T" = (
 /obj/structure/table/glass,
@@ -203,29 +208,29 @@
 /area/ruin/unpowered)
 "Y" = (
 /obj/effect/abstract/doorway_marker,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/ruin/unpowered)
 
 (1,1,1) = {"
 c
-R
-S
-R
-c
-c
-c
-c
-c
-c
-c
 P
+S
+P
+c
+c
+c
+c
+c
+c
+c
+c
 c
 "}
 (2,1,1) = {"
 c
-R
-R
-J
+P
+m
+w
 c
 x
 B
@@ -238,8 +243,8 @@ c
 "}
 (3,1,1) = {"
 c
-R
-R
+P
+m
 E
 M
 t
@@ -253,8 +258,8 @@ Y
 "}
 (4,1,1) = {"
 c
-R
-R
+P
+m
 E
 a
 t
@@ -268,8 +273,8 @@ c
 "}
 (5,1,1) = {"
 c
-R
-R
+P
+m
 E
 M
 t
@@ -283,8 +288,8 @@ c
 "}
 (6,1,1) = {"
 c
-R
-R
+P
+m
 E
 a
 t
@@ -298,8 +303,8 @@ c
 "}
 (7,1,1) = {"
 c
-R
-R
+P
+m
 E
 M
 X
@@ -313,8 +318,8 @@ c
 "}
 (8,1,1) = {"
 c
-R
-R
+P
+m
 f
 c
 A
@@ -328,9 +333,9 @@ c
 "}
 (9,1,1) = {"
 c
-R
+P
 O
-R
+P
 c
 c
 c

--- a/_maps/RuinGeneration/9x13_sleeproom.dmm
+++ b/_maps/RuinGeneration/9x13_sleeproom.dmm
@@ -73,6 +73,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"x" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "z" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm3";
@@ -236,17 +240,17 @@ s
 "}
 (7,1,1) = {"
 Y
-s
-s
-s
-s
-s
-s
-s
-s
-s
-s
-s
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
+x
 e
 "}
 (8,1,1) = {"

--- a/_maps/RuinGeneration/9x13_vault.dmm
+++ b/_maps/RuinGeneration/9x13_vault.dmm
@@ -141,6 +141,10 @@
 /obj/effect/turf_decal/bot_white/right,
 /turf/open/floor/plasteel/dark/airless,
 /area/ruin/unpowered)
+"U" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "V" = (
 /obj/effect/abstract/open_area_marker{
 	dir = 4
@@ -190,7 +194,7 @@ i
 z
 w
 g
-o
+U
 o
 a
 "}
@@ -205,7 +209,7 @@ i
 z
 w
 g
-o
+U
 o
 h
 "}
@@ -220,7 +224,7 @@ i
 w
 w
 g
-o
+U
 o
 a
 "}
@@ -235,7 +239,7 @@ P
 k
 C
 g
-o
+U
 o
 a
 "}
@@ -250,7 +254,7 @@ i
 w
 w
 g
-o
+U
 o
 a
 "}
@@ -265,7 +269,7 @@ i
 z
 w
 g
-o
+U
 O
 a
 "}
@@ -280,7 +284,7 @@ i
 z
 w
 g
-o
+U
 o
 a
 "}

--- a/_maps/RuinGeneration/9x5_3_seperation.dmm
+++ b/_maps/RuinGeneration/9x5_3_seperation.dmm
@@ -3,7 +3,7 @@
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "f" = (
-/obj/effect/spawner/structure/window,
+/obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "j" = (

--- a/_maps/RuinGeneration/9x5_hallwaymaints.dmm
+++ b/_maps/RuinGeneration/9x5_hallwaymaints.dmm
@@ -4,12 +4,8 @@
 /area/ruin/unpowered)
 "c" = (
 /obj/structure/closet/firecloset/full,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/obj/effect/turf_decal/tile/green/tile_side{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
@@ -29,14 +25,8 @@
 /area/ruin/unpowered)
 "y" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/effect/turf_decal/tile/green/tile_side{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
@@ -50,10 +40,7 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "K" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/tile/green/tile_side{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67,6 +54,10 @@
 /area/ruin/unpowered)
 "S" = (
 /obj/effect/abstract/open_area_marker,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"T" = (
+/obj/effect/turf_decal/tile/neutral/tile_marquee,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "W" = (
@@ -118,9 +109,9 @@ P
 "}
 (7,1,1) = {"
 d
-P
-P
-P
+T
+T
+T
 S
 "}
 (8,1,1) = {"

--- a/_maps/RuinGeneration/9x5_morgue.dmm
+++ b/_maps/RuinGeneration/9x5_morgue.dmm
@@ -40,6 +40,12 @@
 "s" = (
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
+"u" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 "B" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 1
@@ -69,6 +75,7 @@
 /area/ruin/unpowered)
 "J" = (
 /obj/effect/spawner/lootdrop/ruinloot/medical,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
 "O" = (
@@ -86,6 +93,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/unpowered)
+"Z" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
 
 (1,1,1) = {"
 o
@@ -96,9 +107,9 @@ o
 "}
 (2,1,1) = {"
 o
+u
 s
-s
-s
+Z
 o
 "}
 (3,1,1) = {"
@@ -124,16 +135,16 @@ o
 "}
 (6,1,1) = {"
 o
-s
+u
 s
 J
 o
 "}
 (7,1,1) = {"
 o
-s
+u
 O
-s
+Z
 o
 "}
 (8,1,1) = {"

--- a/_maps/RuinGeneration/9x9_chemlab.dmm
+++ b/_maps/RuinGeneration/9x9_chemlab.dmm
@@ -1,9 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/yellow/tile_side{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "b" = (
@@ -12,24 +11,19 @@
 "c" = (
 /obj/structure/table/glass,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/tile/yellow/tile_side{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "d" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/chem_heater,
+/obj/effect/turf_decal/tile/yellow/tile_side{
+	dir = 9
+	},
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "e" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
@@ -38,47 +32,35 @@
 /obj/item/storage/box/medsprays,
 /obj/item/reagent_containers/medspray,
 /obj/item/reagent_containers/medspray,
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "f" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/blue/tile_side{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "g" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/yellow/tile_side{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "i" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/tile_side{
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "j" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
 	pixel_x = -1;
 	pixel_y = 7
+	},
+/obj/effect/turf_decal/tile/yellow/tile_side{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin)
@@ -86,10 +68,7 @@
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "m" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/blue/tile_side,
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "n" = (
@@ -97,25 +76,21 @@
 /turf/open/floor/plasteel,
 /area/ruin)
 "p" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/light_switch{
 	pixel_x = 1;
 	pixel_y = -25
 	},
+/obj/effect/turf_decal/tile/yellow/tile_side{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "q" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/machinery/chem_dispenser{
 	layer = 2.7
+	},
+/obj/effect/turf_decal/tile/yellow/tile_side{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin)
@@ -124,12 +99,6 @@
 /turf/open/floor/plating,
 /area/ruin)
 "t" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large{
 	pixel_x = -3;
@@ -144,17 +113,14 @@
 	pixel_x = 1;
 	pixel_y = 4
 	},
+/obj/effect/turf_decal/tile/yellow/tile_side{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "u" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/tile/blue/tile_side{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin)
@@ -165,23 +131,13 @@
 /turf/open/floor/plasteel,
 /area/ruin)
 "w" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/closet/secure_closet/chemical,
+/obj/effect/turf_decal/tile/yellow/tile_side{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/chemical,
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "x" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/bottle/charcoal{
 	pixel_x = 3;
@@ -195,17 +151,17 @@
 /obj/item/storage/pill_bottle,
 /obj/item/storage/pill_bottle,
 /obj/item/reagent_containers/syringe,
+/obj/effect/turf_decal/tile/yellow/tile_side{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "y" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/tile_side{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin)
@@ -217,49 +173,36 @@
 	req_access_txt = "5; 33"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plating,
 /area/ruin)
 "A" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/tile_side{
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "C" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/effect/turf_decal/tile/blue/tile_side{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "D" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/chem_master,
+/obj/effect/turf_decal/tile/yellow/tile_side{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "E" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow/tile_side,
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "F" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/blue/tile_side{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -271,59 +214,38 @@
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "I" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
+	},
+/obj/effect/turf_decal/tile/yellow/tile_side{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "J" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers,
 /obj/item/reagent_containers/syringe,
 /obj/item/reagent_containers/syringe,
+/obj/effect/turf_decal/tile/yellow/tile_side{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "K" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Chemistry Lab";
-	req_access_txt = "5; 33"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/machinery/door/airlock/medical/glass,
+/obj/effect/turf_decal/stripes/closeup,
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "L" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow/tile_side,
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "M" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/vending/wardrobe/chem_wardrobe,
+/obj/effect/turf_decal/tile/yellow/tile_side{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "N" = (
@@ -338,11 +260,8 @@
 /turf/closed/wall,
 /area/ruin)
 "U" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/yellow/tile_side{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin)
@@ -353,21 +272,12 @@
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "X" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/rack,
 /obj/item/construction/plumbing,
+/obj/effect/turf_decal/tile/yellow/tile_side,
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "Y" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/table/glass,
 /obj/machinery/light{
 	dir = 1
@@ -375,15 +285,17 @@
 /obj/item/book/manual/wiki/grenades{
 	pixel_y = 3
 	},
+/obj/effect/turf_decal/tile/yellow/tile_side{
+	dir = 10
+	},
 /turf/open/floor/plasteel/white,
 /area/ruin)
 "Z" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/table/glass,
 /obj/effect/spawner/lootdrop/snowdin/dungeonlite,
+/obj/effect/turf_decal/tile/yellow/tile_side{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/ruin)
 
@@ -467,7 +379,7 @@ O
 (8,1,1) = {"
 O
 w
-L
+k
 e
 X
 E

--- a/_maps/RuinGeneration/9x9_genetics.dmm
+++ b/_maps/RuinGeneration/9x9_genetics.dmm
@@ -1,13 +1,10 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 12
 	},
+/obj/effect/turf_decal/tile/blue/tile_side,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "c" = (
@@ -26,16 +23,7 @@
 /area/ruin/unpowered)
 "f" = (
 /obj/machinery/vending/medical,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue/tile_full,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "h" = (
@@ -55,30 +43,15 @@
 	pixel_x = 1;
 	pixel_y = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/blue/tile_full,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "l" = (
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/tile/blue/tile_side{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
@@ -90,16 +63,7 @@
 	},
 /obj/item/storage/box/monkeycubes,
 /obj/effect/spawner/lootdrop/ruinloot/medical,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue/tile_full,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "q" = (
@@ -121,27 +85,14 @@
 /area/ruin/unpowered)
 "u" = (
 /obj/structure/chair/office/light,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/effect/turf_decal/tile/blue/tile_side{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "v" = (
 /obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/blue/tile_full,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "w" = (
@@ -162,16 +113,7 @@
 	},
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/gloves/color/latex,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/blue/tile_full,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "C" = (
@@ -179,22 +121,13 @@
 /turf/open/floor/plasteel/freezer,
 /area/ruin/unpowered)
 "D" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/tile_side{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "E" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/blue/tile_side{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -206,16 +139,7 @@
 "H" = (
 /obj/structure/table/glass,
 /obj/effect/spawner/lootdrop/ruinloot/medical,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/blue/tile_full,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "I" = (
@@ -242,16 +166,7 @@
 /obj/machinery/computer/scan_consolenew{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/blue/tile_full,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "N" = (
@@ -262,10 +177,7 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "P" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue/tile_side,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "Q" = (
@@ -275,47 +187,25 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "T" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/blue/tile_side{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "V" = (
 /obj/machinery/computer/scan_consolenew,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/blue/tile_full,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "W" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/blue/tile_side{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 "X" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue/tile_full,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
 
@@ -376,7 +266,7 @@ q
 "}
 (6,1,1) = {"
 q
-E
+w
 d
 d
 d


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Part one of my Exploration Plus Plus project. Touches up, fixes, details, and even redoes and adds new doors to *107* different exploration map modules, mostly comprising of turf decals. This doesn't touch the (purposefully left disabled) turbolift module.

This first part shouldn't cause any noticeable gameplay differences, unless you take the smoker quirk, in which case exploration should be slightly more friendly to you now.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Exploration is currently the most scuffed job in the game. Let's change that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Examples Of Newly Generated Ruins</summary>

![image](https://user-images.githubusercontent.com/50649185/172012174-2880f031-ece7-4803-83be-eb4300831c9b.png)
![image](https://user-images.githubusercontent.com/50649185/172012211-06b70f44-f72c-421b-b92c-e189ddb58545.png)
![image](https://user-images.githubusercontent.com/50649185/172012302-2edca842-faa9-498f-b3d7-ed22a78ad2bb.png)




</details>

## Changelog

:cl:
add: 107 Exploration Modules have been touched up! You should notice some more detail as you explore derelicts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
