### PR TITLE
BeeStation Minor Bug Fixes [Bee PORT]

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_x_act.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_x_act.dm
@@ -24,6 +24,8 @@
 #define COMSIG_ATOM_NARSIE_ACT "atom_narsie_act"
 /// from base of atom/ratvar_act(): ()
 #define COMSIG_ATOM_RATVAR_ACT "atom_ratvar_act"
+/// from base of atom/light_eater_act(): (obj/item/light_eater/light_eater)
+#define COMSIG_ATOM_LIGHTEATER_ACT "atom_lighteater_act"
 /// from base of atom/eminence_act(): ()
 #define COMSIG_ATOM_EMINENCE_ACT "atom_eminence_act"
 /// from base of atom/blob_act(): (/obj/structure/blob)

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -439,14 +439,14 @@
 	var/target_turf
 
 /datum/move_loop/has_target/jps/hostile/recalculate_path()
-	if(!COOLDOWN_FINISHED(src, repath_cooldown) || repath_active)
+	if(!COOLDOWN_FINISHED(src, repath_cooldown) || repath_active || QDELETED(src))
 		return
 	repath_active = TRUE
 	COOLDOWN_START(src, repath_cooldown, repath_delay)
 	SEND_SIGNAL(src, COMSIG_MOVELOOP_JPS_REPATH)
 	movement_path = get_path_to(moving, target, max_path_length, minimum_distance, id, simulated_only, avoid, skip_first)
 	// Implementing pathfinding fallback solution
-	if(!length(movement_path))
+	if(!length(movement_path) && !QDELETED(src))
 		var/ln = get_dist(moving, target)
 		var/turf/target_new = target
 		var/found_blocker

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -145,14 +145,14 @@
 		return FALSE
 
 	source.visible_message(
-		"<span class='warning'>[user] tries to remove [source]'s [item].</span>",
-		"<span class='userdanger'>[user] tries to remove your [item].</span>",
+		"<span class='warning'>[user] tries to remove [source]'s [item.name].</span>",
+		"<span class='userdanger'>[user] tries to remove your [item.name].</span>",
 		ignored_mobs = user,
 	)
 
-	to_chat(user, "<span class='danger'>You try to remove [source]'s [item]...</span>")
-	source.log_message("[key_name(source)] is being stripped of [item] by [key_name(user)]", LOG_ATTACK, color="red")
-	user.log_message("[key_name(source)] is being stripped of [item] by [key_name(user)]", LOG_ATTACK, color="red", log_globally=FALSE)
+	to_chat(user, "<span class='danger'>You try to remove [source]'s [item.name]...</span>")
+	source.log_message("[key_name(source)] is being stripped of [item.name] by [key_name(user)]", LOG_ATTACK, color="red")
+	user.log_message("[key_name(source)] is being stripped of [item.name] by [key_name(user)]", LOG_ATTACK, color="red", log_globally=FALSE)
 	item.add_fingerprint(src)
 
 	return TRUE

--- a/code/datums/mutations/speech.dm
+++ b/code/datums/mutations/speech.dm
@@ -14,7 +14,7 @@
 
 /datum/mutation/human/wacky
 	name = "Wacky"
-	desc = "<span class='sans'>Unknown.</span>"
+	desc = "Unknown."
 	quality = MINOR_NEGATIVE
 	text_gain_indication = "<span class='sans'>You feel an off sensation in your voicebox.</span>"
 	text_lose_indication = "<span class='notice'>The off sensation passes.</span>"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -834,7 +834,11 @@
   * Called when lighteater is called on this.
   */
 /atom/proc/lighteater_act(obj/item/light_eater/light_eater)
-	return
+	SHOULD_CALL_PARENT(TRUE)
+	SEND_SIGNAL(src,COMSIG_ATOM_LIGHTEATER_ACT)
+	for(var/datum/light_source/light_source in light_sources)
+		if(light_source.source_atom != src)
+			light_source.source_atom.lighteater_act(light_eater)
 
 /**
   * Respond to the eminence clicking on our atom

--- a/code/game/machinery/computer/apc_control.dm
+++ b/code/game/machinery/computer/apc_control.dm
@@ -187,7 +187,7 @@
 		authenticated = TRUE
 		log_activity("logged in")
 	else if(!(obj_flags & EMAGGED))
-		user.visible_message("<span class='warning'>You emag [src], disabling precise logging and allowing you to clear logs.</span>")
+		user.visible_message("<span class='warning'>[user] emags the [src], disabling precise logging!</span>", "<span class='warning'>You emag [src], disabling precise logging and allowing you to clear logs.</span>")
 		log_game("[key_name(user)] emagged [src] at [AREACOORD(src)], disabling operator tracking.")
 		obj_flags |= EMAGGED
 	playsound(src, "sparks", 50, 1)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -278,6 +278,8 @@
 				return
 			var/line_one = reject_bad_text(params["lineOne"] || "", MAX_STATUS_LINE_LENGTH)
 			var/line_two = reject_bad_text(params["lineTwo"] || "", MAX_STATUS_LINE_LENGTH)
+			message_admins("[ADMIN_LOOKUPFLW(usr)] changed the Status Message to - [line_one], [line_two] - From a Communications Console.")
+			log_game("[key_name(usr)] changed the Status Message to - [line_one], [line_two] - From a Communications Console.")
 			post_status("alert", "blank")
 			post_status("message", line_one, line_two)
 			last_status_display = list(line_one, line_two)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1170,10 +1170,11 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 	take_damage(500,  BRUTE)
 
 /obj/mecha/lighteater_act(obj/item/light_eater/light_eater)
+	..()
 	if(!lights_power)
 		return
 	lights = FALSE
 	lights_power = 0
-	set_light(0)
+	set_light_on(FALSE)
 	visible_message(src, "<span class='danger'>The lights on [src] short out!</span>")
 	playsound(src, 'sound/items/welder.ogg', 50, 1)

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -106,6 +106,8 @@
 /datum/action/innate/mecha/mech_toggle_lights/Activate()
 	if(!owner || !chassis || chassis.occupant != owner)
 		return
+	if(!chassis.lights_power)
+		return
 	chassis.lights = !chassis.lights
 	if(chassis.lights)
 		button_icon_state = "mech_lights_on"

--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -55,6 +55,7 @@
 			else
 				loaded = W //W.loc is src at this point.
 				loaded.max_amount = max_amount //We store a lot.
+				update_icon()
 				return
 
 		if(loaded.amount < max_amount)

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -207,6 +207,8 @@
 		if("message")
 			status_signal.data["msg1"] = data1
 			status_signal.data["msg2"] = data2
+			message_admins("[ADMIN_LOOKUPFLW(usr)] changed the Status Message to - [data1], [data2] - From a PDA.")
+			log_game("[key_name(usr)] changed the Status Message to - [data1], [data2] - From a PDA.")
 		if("alert")
 			status_signal.data["picture_state"] = data1
 

--- a/code/modules/antagonists/blob/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob_mobs.dm
@@ -105,7 +105,6 @@
 	del_on_death = TRUE
 	deathmessage = "explodes into a cloud of gas!"
 	gold_core_spawnable = HOSTILE_SPAWN
-	move_to_delay = 6
 	var/death_cloud_size = 1 //size of cloud produced from a dying spore
 	var/mob/living/carbon/human/oldguy
 	var/is_zombie = FALSE

--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -226,6 +226,7 @@
 			owner.special_role = TRAITOR_AGENT_ROLE
 			special_role = TRAITOR_AGENT_ROLE
 			syndicate = TRUE
+			log_game("[owner.key] has been designated an External Affairs Agent")
 			forge_single_objective()
 
 /datum/antagonist/traitor/internal_affairs/forge_traitor_objectives()

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -328,6 +328,7 @@
 	. = ..()
 	if(ismob(thing))
 		RegisterSignal(thing, COMSIG_MOB_UPDATE_SIGHT, .proc/update_user_sight)
+		RegisterSignal(thing, COMSIG_ATOM_LIGHTEATER_ACT, .proc/on_lighteater_act)
 		var/mob/being = thing
 		being.update_sight()
 		to_chat(thing, "<span class='notice'>The wisp enhances your vision.</span>")
@@ -336,6 +337,7 @@
 	. = ..()
 	if(ismob(orbits.parent))
 		UnregisterSignal(orbits.parent, COMSIG_MOB_UPDATE_SIGHT)
+		UnregisterSignal(orbits.parent, COMSIG_ATOM_LIGHTEATER_ACT)
 		to_chat(orbits.parent, "<span class='notice'>Your vision returns to normal.</span>")
 
 /obj/effect/wisp/proc/update_user_sight(mob/user)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -182,7 +182,7 @@
 
 	for(var/obj/item/bodypart/BP as() in bodyparts)
 		if(BP.limb_id != (dna.species.examine_limb_id ? dna.species.examine_limb_id : dna.species.id))
-			msg += "<span class='info'>[t_He] has \an [BP.name].</span>\n"
+			msg += "<span class='info'>[t_He] [t_has] \an [BP.name].</span>\n"
 
 	var/list/harm_descriptors = dna?.species.get_harm_descriptors()
 	var/brute_msg = harm_descriptors?["brute"]

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1674,7 +1674,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	if(!affecting) //Something went wrong. Maybe the limb is missing?
 		affecting = H.bodyparts[1]
 
-	hit_area = affecting.name
+	hit_area = parse_zone(affecting.body_zone)
 	var/def_zone = affecting.body_zone
 
 	var/armor_block = H.run_armor_check(affecting, "melee", "<span class='notice'>Your armor has protected your [hit_area]!</span>", "<span class='warning'>Your armor has softened a hit to your [hit_area]!</span>",I.armour_penetration)

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -186,14 +186,18 @@
 		return
 	AM.lighteater_act(src)
 
+/atom/movable/lighteater_act(obj/item/light_eater/light_eater)
+	..()
+	for(var/datum/component/overlay_lighting/light_source in affected_dynamic_lights)
+		if(light_source.parent != src)
+			var/atom/A = light_source.parent
+			A.lighteater_act(light_eater)
+
 /mob/living/lighteater_act(obj/item/light_eater/light_eater)
 	if(on_fire)
 		ExtinguishMob()
 		playsound(src, 'sound/items/cig_snuff.ogg', 50, 1)
-	for(var/obj/item/O in src)
-		if(O.light_range && O.light_power)
-			O.lighteater_act(light_eater)
-	if(pulling && pulling.light_range)
+	if(pulling)
 		pulling.lighteater_act(light_eater)
 
 /mob/living/carbon/human/lighteater_act(obj/item/light_eater/light_eater)
@@ -211,23 +215,26 @@
 	if(burning)
 		extinguish()
 		playsound(src, 'sound/items/cig_snuff.ogg', 50, 1)
-
-/obj/item/pda/lighteater_act(obj/item/light_eater/light_eater)
-	if(!light_range || !light_power)
-		return
-	set_light_on(FALSE)
-	light_power = 0
-	shorted = TRUE
-	update_icon()
-	visible_message("<span class='danger'>The light in [src] shorts out!</span>")
+	..()
 
 /obj/item/lighteater_act(obj/item/light_eater/light_eater)
-	if(!light_range || !light_power)
+	..()
+	if(!light_range || !light_power || !light_on)
 		return
 	if(light_eater)
 		visible_message("<span class='danger'>[src] is disintegrated by [light_eater]!</span>")
 	burn()
 	playsound(src, 'sound/items/welder.ogg', 50, 1)
+
+/obj/item/pda/lighteater_act(obj/item/light_eater/light_eater)
+	if(light_range && light_power && light_on)
+		//Eject the ID card
+		if(id)
+			id.forceMove(get_turf(src))
+			id = null
+			update_icon()
+			playsound(src, 'sound/machines/terminal_eject.ogg', 50, TRUE)
+	..()
 
 #undef HEART_SPECIAL_SHADOWIFY
 #undef HEART_RESPAWN_THRESHHOLD

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -194,6 +194,7 @@
 			A.lighteater_act(light_eater)
 
 /mob/living/lighteater_act(obj/item/light_eater/light_eater)
+	..()
 	if(on_fire)
 		ExtinguishMob()
 		playsound(src, 'sound/items/cig_snuff.ogg', 50, 1)
@@ -212,6 +213,7 @@
 		to_chat(src, "<span class='danger'>Your headlamp is fried! You'll need a human to help replace it.</span>")
 
 /obj/structure/bonfire/lighteater_act(obj/item/light_eater/light_eater)
+	..()
 	if(burning)
 		extinguish()
 		playsound(src, 'sound/items/cig_snuff.ogg', 50, 1)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -841,7 +841,7 @@
 // Override if a certain type of mob should be behave differently when stripping items (can't, for example)
 /mob/living/stripPanelUnequip(obj/item/what, mob/who, where)
 	if(!what.canStrip(who))
-		to_chat(src, "<span class='warning'>You can't remove \the [what.name], it appears to be stuck!</span>")
+		to_chat(src, "<span class='warning'>You can't remove [what.name], it appears to be stuck!</span>")
 		return
 	who.visible_message("<span class='danger'>[src] tries to remove [who]'s [what.name].</span>", \
 					"<span class='userdanger'>[src] tries to remove your [what.name].</span>")

--- a/code/modules/photography/camera/silicon_camera.dm
+++ b/code/modules/photography/camera/silicon_camera.dm
@@ -14,7 +14,7 @@
 	else
 		camera_mode_on(user)
 
-/obj/item/camera/siliconcam/lighteater_act(obj/item/light_eater/light_eater)
+/obj/item/camera/siliconcam/burn()
 	return
 
 /obj/item/camera/siliconcam/proc/camera_mode_off(mob/user)

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -100,8 +100,9 @@
 	w_class = WEIGHT_CLASS_BULKY
 	full_auto = TRUE
 
-/obj/item/gun/ballistic/automatic/wt550/rubber_loaded
-	mag_type = /obj/item/ammo_box/magazine/wt550m9/rubber
+/obj/item/gun/ballistic/automatic/wt550/rubber_loaded/Initialize(mapload)
+	magazine = new /obj/item/ammo_box/magazine/wt550m9/rubber(src)
+	. = ..()
 
 /obj/item/gun/ballistic/automatic/mini_uzi
 	name = "\improper Type U3 Uzi"

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -77,7 +77,7 @@
 
 /obj/item/bodypart/Initialize(mapload)
 	..()
-	name = "[parse_zone(body_zone)]"
+	name = "[limb_id] [parse_zone(body_zone)]"
 	if(is_dimorphic)
 		limb_gender = pick("m", "f")
 	update_icon_dropped()

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -77,7 +77,7 @@
 
 /obj/item/bodypart/Initialize(mapload)
 	..()
-	name = "[limb_id] [parse_zone(body_zone)]"
+	name = "[parse_zone(body_zone)]"
 	if(is_dimorphic)
 		limb_gender = pick("m", "f")
 	update_icon_dropped()
@@ -93,6 +93,8 @@
 		. += "<span class='warning'>This limb has [brute_dam > 30 ? "severe" : "minor"] bruising.</span>"
 	if(burn_dam > DAMAGE_PRECISION)
 		. += "<span class='warning'>This limb has [burn_dam > 30 ? "severe" : "minor"] burns.</span>"
+	if(limb_id)
+		. += "<span class='notice'>It is a [limb_id] [parse_zone(body_zone)].</span>"
 
 /obj/item/bodypart/blob_act()
 	take_damage(max_damage)

--- a/tgui/packages/tgui-panel/chat/constants.js
+++ b/tgui/packages/tgui-panel/chat/constants.js
@@ -59,7 +59,7 @@ export const MESSAGE_TYPES = [
     type: MESSAGE_TYPE_RADIO,
     name: 'Radio',
     description: 'All departments of radio messages',
-    selector: '.alert, .syndradio, .centcomradio, .aiprivradio, .comradio, .secradio, .engradio, .medradio, .sciradio, .suppradio, .servradio, .expradio, .entradio, .radio, .deptradio, .newscaster, .redteamradio, .blueteamradio, .sinister, .cult, .shadowling, .changeling',
+    selector: '.alert, .syndradio, .centcomradio, .aiprivradio, .comradio, .secradio, .engradio, .medradio, .sciradio, .suppradio, .servradio, .explradio, .entradio, .radio, .deptradio, .newscaster, .redteamradio, .blueteamradio, .sinister, .cult, .shadowling, .changeling',
   },
   {
     type: MESSAGE_TYPE_INFO,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

1. Removes limb_id from the name of limbs; "human chest" becomes "chest"
https://github.com/BeeStation/BeeStation-Hornet/pull/6972
2. Allows CorgStation autorifles to take in regular ammo
https://github.com/BeeStation/BeeStation-Hornet/pull/6979
3. Fixes a conjugation error for plural gender limb examines
https://github.com/BeeStation/BeeStation-Hornet/pull/7005
4. Fixes <span class='sans'> in wacky mutation
https://github.com/BeeStation/BeeStation-Hornet/pull/6949
5. Fixes the extra "the" when stripping someone
https://github.com/BeeStation/BeeStation-Hornet/pull/6963
6. Fixes a missing string on the power flow control console's emag_act
https://github.com/BeeStation/BeeStation-Hornet/pull/6990
7. Adds logging to External Affairs Agents
https://github.com/BeeStation/BeeStation-Hornet/pull/6996
8. Fixes exploration radio not being included when filtering radio messages in chat.
https://github.com/BeeStation/BeeStation-Hornet/pull/7009
9. Fix light eater not being able to break mech lights or wisps
https://github.com/BeeStation/BeeStation-Hornet/pull/6627
10. The ligheater act now works by checking for lights attached to an atom and applying itself to them.
https://github.com/BeeStation/BeeStation-Hornet/pull/7014
11. Adds Status Message logging
https://github.com/BeeStation/BeeStation-Hornet/pull/7015
12. Fix RCL icon not updating after refilling an empty RCL
https://github.com/BeeStation/BeeStation-Hornet/pull/6934
13. Speeds up blob spores (again) and fixes some runtimes in the moveloop
https://github.com/BeeStation/BeeStation-Hornet/pull/6914


## Why It's Good For The Game
Adds some fixes from recent Bee PRs

## Testing Photographs and Procedure

<details>
<summary>1. Cleaner limb examine #6972</summary>

![image](https://user-images.githubusercontent.com/101475356/172013463-597e0aa4-4f35-42ec-b9e8-305796a83467.png)

</details>

<details>
<summary>3.  Fixes a conjugation error for plural gender limb examines #7005</summary>

![image](https://user-images.githubusercontent.com/101475356/172013736-c6be7be3-e2f3-4ee2-8100-2b31d60e24e1.png)

Working for binary genders.
![image](https://user-images.githubusercontent.com/101475356/172013742-de0738b9-fff8-4af1-b6fd-b0a81996c967.png)

Working for plural gender.
![image](https://user-images.githubusercontent.com/101475356/172013749-228a47d5-b091-4621-9a5d-5c72a3512152.png)

Limb names got messed up. Now robotic limbs are acknowledged properly.
![image](https://user-images.githubusercontent.com/101475356/172013756-ed8dfa0b-2ea6-4378-b673-de9cdc821c5c.png)

Attack messages specify the zone instead of body part.

</details>

<details>
<summary>4.  Fixes <span class='sans'> in wacky mutation #6949 </summary>

Issue:
![image](https://user-images.githubusercontent.com/101475356/172013863-a57b0aa4-2fe3-4260-8d52-a3f3e609bb8d.png)

Fixed:
![image](https://user-images.githubusercontent.com/101475356/172013872-3675dacc-15dc-45b0-b6ca-2b32f7ce0843.png)

</details>

<details>
<summary>5. Fixes the extra "the" when stripping someone #6963 </summary>

Old:
![image](https://user-images.githubusercontent.com/101475356/172014062-f898b3b6-50b9-4abe-8369-32c92e9caa62.png)

New:
![image](https://user-images.githubusercontent.com/101475356/172014071-112bf4ff-897b-4ffa-b29c-d09c653991d5.png)

</details>

<details>
<summary>8. Fixes exploration radio not being included when filtering radio messages in chat. #7009 </summary>

![image](https://user-images.githubusercontent.com/101475356/172014485-904b28f1-1875-4778-88b2-e756f0f755f1.png)

</details>

<details>
<summary>11.  Adds Status Message logging #7015 </summary>

![image](https://user-images.githubusercontent.com/101475356/172015312-85d83e0c-eb0a-4bde-9c79-4d519a22fa03.png)

![image](https://user-images.githubusercontent.com/101475356/172015325-a4b5aa31-a55f-4bff-a97e-39e8649560cd.png)

</details>


## Changelog
:cl: mcmeiler, PowerfulBacon, ivanmixo, Ivniinv, h42-real, Autisem, qwertyquerty, MNarath1

 spellcheck: Removed the redundant species name from limb names, moves it to description
 fix: Fixed CorgStation autorifles not accepting lethal mags
 fix: Fixed wacky mutation's description in DNA console.
 fix: Fixed the extra 'the' when stripping people
 fix: Fixed players getting first person messages when someone emags a power flow control console
 admin: External Affairs Agent creation is now logged.
 fix: Fixed Exploration radio is now included when filtering radio channels in tgui
tweak: light eater works on wisps
fix: Light eater works on mechs
fix: The lighteater will now break gunlights and flashlights attached to things.
fix: The lighteater will no longer break PDAs that do not have their light turned on.
admin: Status Message logging is now a thing
fix: Update RCL icon on refill
balance: changes the movement delay of blob spores back to the default for hostiles
fix: fixes a possible runtime in jps hostile while it gets qdeleted

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
