### PR TITLE
Exploration PP - Reworks Outpost Nuke Announcement

### DIFF
--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/nuke_ruin.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/nuke_ruin.dm
@@ -54,6 +54,7 @@ GLOBAL_LIST_EMPTY(decomission_bombs)
 	proper_bomb = FALSE
 	var/datum/orbital_objective/nuclear_bomb/linked_objective
 	var/target_z
+	var/obj/item/radio/headset/radio // Our internal radio.
 
 /obj/machinery/nuclearbomb/decomission/ComponentInitialize()
 	. = ..()
@@ -62,6 +63,7 @@ GLOBAL_LIST_EMPTY(decomission_bombs)
 /obj/machinery/nuclearbomb/decomission/Initialize(mapload)
 	. = ..()
 	GLOB.decomission_bombs += src
+	radio = new /obj/item/radio/headset/silicon/ai(src)
 	r_code = "[rand(10000, 99999)]"
 	print_command_report("Nuclear decomission explosive code: [r_code]")
 	var/obj/structure/closet/supplypod/bluespacepod/pod = new()
@@ -71,6 +73,7 @@ GLOBAL_LIST_EMPTY(decomission_bombs)
 
 /obj/machinery/nuclearbomb/decomission/Destroy()
 	. = ..()
+	QDEL_NULL(radio)
 	GLOB.decomission_bombs -= src
 
 /obj/machinery/nuclearbomb/decomission/process()
@@ -103,9 +106,7 @@ GLOBAL_LIST_EMPTY(decomission_bombs)
 	if(timing)
 		detonation_timer = world.time + (timer_set * 10)
 		countdown.start()
-		priority_announce("Nuclear fission explosive armed at abandoned outpost, vacate \
-			outpost immediately.",
-			null, 'sound/misc/notice1.ogg', "Priority")
+		radio.talk_into(src, "Nuclear fission explosive armed at [loc]. Vacate area immediately.", list("Exploration"))
 	else
 		detonation_timer = null
 		countdown.stop()

--- a/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/nuke_ruin.dm
+++ b/code/modules/shuttle/super_cruise/orbital_poi_generator/objective_types/nuke_ruin.dm
@@ -106,7 +106,7 @@ GLOBAL_LIST_EMPTY(decomission_bombs)
 	if(timing)
 		detonation_timer = world.time + (timer_set * 10)
 		countdown.start()
-		radio.talk_into(src, "Nuclear fission explosive armed at [loc]. Vacate area immediately.", list("Exploration"))
+		radio.talk_into(src, "Nuclear fission explosive armed. Vacate area immediately.", list("Exploration"))
 	else
 		detonation_timer = null
 		countdown.stop()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Someone figured out how to spam outpost nuke to make ears bleed.
That's bad.

We've been tossing the idea of making it not a command report anyways, and the POWER OF SPITE COMPELS ME.
This changes the announcement into a radio message (Which also has the gameplay benefit of sabotaged exploration comms not explaining to the others that it's armed, for the antagonists out there.)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stop trying to destroy my ears you literal chuds
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
tweak: Exploration Nuclear Bombs now talk on exploration comms rather than announcing their armament via command report.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
