### PR TITLE
Legion Core Notice

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -549,7 +549,7 @@
 
 /datum/status_effect/regenerative_core/on_apply()
 	if(!HAS_TRAIT(owner, TRAIT_NECROPOLIS_INFECTED))
-		to_chat(owner, "<span class='userdanger'>Tendrils of vile corruption knit your flesh together and strengthen your sinew. You resist the temptation of giving in to the corruption.</span>")
+		to_chat(owner, "<span class='userdanger'>Tendrils of vile corruption knit your flesh together and strengthen your sinew. You resist the temptation of giving in to the corruption.\nYou sense that another would overwhelm and corrupt you.</span>")
 	else
 		alreadyinfected = TRUE
 	ADD_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "legion_core_trait")
@@ -573,7 +573,7 @@
 	REMOVE_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, "legion_core_trait")
 	REMOVE_TRAIT(owner, TRAIT_NECROPOLIS_INFECTED, "legion_core_trait")
 	if(!alreadyinfected)
-		to_chat(owner, "<span class='userdanger'>You feel empty as the vile tendrils slink out of your flesh and leave you, a fragile human once more.</span>")
+		to_chat(owner, "<span class='userdanger'>You feel empty as the vile tendrils slink out of your flesh and leave you, a fragile human once more.</span>\n<span class='warning'>It should be safe to use another regenerative core...</span>")
 
 /datum/status_effect/good_music
 	id = "Good Music"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Adds extra messages to the regenerative core which should make it more obvious that you shouldn't be using more than one in a row.

## Why It's Good For The Game

Self-round removal because there was no obvious message that you SHOULDN'T use an object twice isn't great.
Now you are actually clearly warned.

Solves half the issues in #326


## Changelog

:cl:
add: Adds a more clear message to the regenerative core
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
