### PR TITLE
Fixes Security Cam Issues + Deletion Optimizations

### DIFF
--- a/code/_onclick/hud/map_popups.dm
+++ b/code/_onclick/hud/map_popups.dm
@@ -77,23 +77,19 @@
 		screen_maps[screen_obj.assigned_map] = list()
 	// NOTE: Possibly an expensive operation
 	var/list/screen_map = screen_maps[screen_obj.assigned_map]
-	if(!screen_map.Find(screen_obj))
-		screen_map += screen_obj
-	if(!screen.Find(screen_obj))
-		screen += screen_obj
+	screen_map |= screen_obj
+	screen |= screen_obj
+
 
 /**
  * Clears the map of registered screen objects.
- *
- * Not really needed most of the time, as the client's screen list gets reset
- * on relog. any of the buttons are going to get caught by garbage collection
- * anyway. they're effectively qdel'd.
  */
 /client/proc/clear_map(map_name)
-	if(!map_name || !(map_name in screen_maps))
+	if(!map_name || !screen_maps[map_name])
 		return FALSE
 	for(var/atom/movable/screen/screen_obj in screen_maps[map_name])
 		screen_maps[map_name] -= screen_obj
+		screen -= screen_obj
 		if(screen_obj.del_on_map_removal)
 			qdel(screen_obj)
 	screen_maps -= map_name

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -8,8 +8,6 @@
 	circuit = /obj/item/circuitboard/computer/security
 	light_color = LIGHT_COLOR_RED
 
-
-
 	var/list/network = list("ss13")
 	var/obj/machinery/camera/active_camera
 	/// The turf where the camera was last updated.
@@ -20,9 +18,10 @@
 	// Stuff needed to render the map
 	var/map_name
 	var/atom/movable/screen/map_view/cam_screen
-	var/atom/movable/screen/plane_master/lighting/cam_plane_master
-	var/atom/movable/screen/plane_master/o_light_visual/visual_plane_master
+	/// All the plane masters that need to be applied.
+	var/list/cam_plane_masters
 	var/atom/movable/screen/background/cam_background
+
 
 /obj/machinery/computer/security/Initialize(mapload)
 	. = ..()
@@ -40,25 +39,21 @@
 	cam_screen.assigned_map = map_name
 	cam_screen.del_on_map_removal = FALSE
 	cam_screen.screen_loc = "[map_name]:1,1"
-	cam_plane_master = new
-	cam_plane_master.name = "plane_master"
-	cam_plane_master.assigned_map = map_name
-	cam_plane_master.del_on_map_removal = FALSE
-	cam_plane_master.screen_loc = "[map_name]:CENTER"
-	visual_plane_master = new
-	visual_plane_master.name = "plane_master"
-	visual_plane_master.assigned_map = map_name
-	visual_plane_master.del_on_map_removal = FALSE
-	visual_plane_master.screen_loc = "[map_name]:CENTER"
+	cam_plane_masters = list()
+	for(var/plane in subtypesof(/atom/movable/screen/plane_master))
+		var/atom/movable/screen/plane_master/instance= new plane()
+		instance.assigned_map = map_name
+		instance.del_on_map_removal = FALSE
+		instance.screen_loc = "[map_name]:CENTER"
+		cam_plane_masters += instance
 	cam_background = new
 	cam_background.assigned_map = map_name
 	cam_background.del_on_map_removal = FALSE
 
 /obj/machinery/computer/security/Destroy()
-	qdel(cam_screen)
-	qdel(cam_plane_master)
-	qdel(visual_plane_master)
-	qdel(cam_background)
+	QDEL_NULL(cam_screen)
+	QDEL_LIST(cam_plane_masters)
+	QDEL_NULL(cam_background)
 	return ..()
 
 /obj/machinery/computer/security/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)
@@ -71,6 +66,7 @@
 	return GLOB.default_state
 
 /obj/machinery/computer/security/ui_interact(mob/user, datum/tgui/ui)
+	. = ..()
 	// Update UI
 	ui = SStgui.try_update_ui(user, src, ui)
 
@@ -90,13 +86,19 @@
 			use_power(active_power_usage)
 		// Register map objects
 		user.client.register_map_obj(cam_screen)
-		user.client.register_map_obj(cam_plane_master)
-		user.client.register_map_obj(visual_plane_master)
+		for(var/plane in cam_plane_masters)
+			user.client.register_map_obj(plane)
 		user.client.register_map_obj(cam_background)
 		// Open UI
 		ui = new(user, src, "CameraConsole")
 		ui.open()
 		ui.set_autoupdate(FALSE)
+
+/obj/machinery/computer/security/ui_status(mob/user)
+	. = ..()
+	if(. == UI_DISABLED)
+		return UI_CLOSE
+	return .
 
 /obj/machinery/computer/security/ui_data()
 	var/list/data = list()

--- a/code/game/objects/items/devices/spyglasses.dm
+++ b/code/game/objects/items/devices/spyglasses.dm
@@ -9,7 +9,7 @@
 		return
 	if(!linked_bug)
 		user.audible_message("<span class='warning'>[src] lets off a shrill beep!</span>")
-	if("spypopup_map" in user.client.screen_maps) //alright, the popup this object uses is already IN use, so the window is open. no point in doing any other work here, so we're good.
+	if(user.client.screen_maps["spypopup_map"]) //alright, the popup this object uses is already IN use, so the window is open. no point in doing any other work here, so we're good.
 		return
 	user.client.setup_popup("spypopup", 3, 3, 2)
 	user.client.register_map_obj(linked_bug.cam_screen)
@@ -75,9 +75,9 @@
 /obj/item/clothing/accessory/spy_bug/Destroy()
 	if(linked_glasses)
 		linked_glasses.linked_bug = null
-	qdel(cam_screen)
+	QDEL_NULL(cam_screen)
 	QDEL_LIST(cam_plane_masters)
-	qdel(tracker)
+	QDEL_NULL(tracker)
 	return ..()
 
 /obj/item/clothing/accessory/spy_bug/proc/update_view()//this doesn't do anything too crazy, just updates the vis_contents of its screen obj

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -10,6 +10,7 @@ GLOBAL_DATUM_INIT(openspace_backdrop_one_for_all, /atom/movable/openspace_backdr
 	plane           = OPENSPACE_BACKDROP_PLANE
 	mouse_opacity 	= MOUSE_OPACITY_TRANSPARENT
 	layer           = SPLASHSCREEN_LAYER
+	vis_flags = VIS_INHERIT_ID
 
 /turf/open/openspace
 	name = "open space"

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -1,6 +1,7 @@
 GLOBAL_LIST_EMPTY(station_turfs)
 /turf
 	icon = 'icons/turf/floors.dmi'
+	vis_flags = VIS_INHERIT_ID|VIS_INHERIT_PLANE // Important for interaction with and visualization of openspace.
 	level = 1
 
 	/// If this is TRUE, that means this floor is on top of plating so pipes and wires and stuff will appear under it... or something like that it's not entirely clear.
@@ -52,7 +53,6 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	/// Should we used the smooth tiled dirt decal or not
 	var/tiled_dirt = FALSE
 
-	vis_flags = VIS_INHERIT_PLANE|VIS_INHERIT_ID	//when this be added to vis_contents of something it inherit something.plane and be associated with something on clicking, important for visualisation of turf in openspace and interraction with openspace that show you turf.
 
 	///the holodeck can load onto this turf if TRUE
 	var/holodeck_compatible = FALSE

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -51,9 +51,9 @@
 	cam_background.del_on_map_removal = FALSE
 
 /datum/computer_file/program/secureye/Destroy()
-	qdel(cam_screen)
+	QDEL_NULL(cam_screen)
 	QDEL_LIST(cam_plane_masters)
-	qdel(cam_background)
+	QDEL_NULL(cam_background)
 	return ..()
 
 /datum/computer_file/program/secureye/ui_interact(mob/user, datum/tgui/ui)
@@ -75,6 +75,12 @@
 			user.client.register_map_obj(plane)
 		user.client.register_map_obj(cam_background)
 		return ..()
+
+/datum/computer_file/program/secureye/ui_status(mob/user)
+	. = ..()
+	if(. == UI_DISABLED)
+		return UI_CLOSE
+	return .
 
 /datum/computer_file/program/secureye/ui_data()
 	var/list/data = get_header_data()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
No longer see random potted plant spawners on security cameras
Openspace now gets displayed properly on cameras.
Makes map popups actually clear the screen they're effecting of their objects, preventing plane master harddels

Once emissive stuff is added they should also be able to display properly with these changes

## Why It's Good For The Game


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/101475356/172954506-0c92bd26-995c-4527-aa44-798ecfad165c.png)

</details>

## PR References:
- https://github.com/tgstation/tgstation/pull/51182
- https://github.com/tgstation/tgstation/pull/63704
- https://github.com/tgstation/tgstation/pull/61562

## Changelog
:cl: DoctorSquishy
fix: Fixed Security Camera display issues
fix: Cameras are viewable from a distance, but this is limited to 2 tiles.
fix: The viewing range limit of 2 tiles also applies to the SecurEye tablet software.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
