### PR TITLE
Adds lethal injection syringe to research and seclathe

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -235,8 +235,8 @@
 "D" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/straight_jacket,
-/obj/item/reagent_containers/syringe/lethal,
-/obj/item/reagent_containers/syringe/lethal/choral,
+/obj/item/reagent_containers/syringe/meta,
+/obj/item/reagent_containers/syringe/meta/choral,
 /turf/open/floor/plasteel/airless/dark,
 /area/ruin/space/has_grav/gasthelizard)
 "E" = (

--- a/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
@@ -611,8 +611,8 @@
 /area/tcommsat/oldaisat)
 "cb" = (
 /obj/structure/table,
-/obj/item/reagent_containers/syringe/lethal/choral,
-/obj/item/reagent_containers/syringe/lethal{
+/obj/item/reagent_containers/syringe/meta/choral,
+/obj/item/reagent_containers/syringe/meta{
 	pixel_y = 4
 	},
 /turf/open/floor/plasteel/airless/dark,

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -221,7 +221,7 @@
 
 /obj/item/storage/box/syringes/variety/PopulateContents()
 	new /obj/item/reagent_containers/syringe(src)
-	new /obj/item/reagent_containers/syringe/lethal(src)
+	new /obj/item/reagent_containers/syringe/meta(src) //monkestation
 	new /obj/item/reagent_containers/syringe/cryo(src)
 	new /obj/item/reagent_containers/syringe/piercing(src)
 	new /obj/item/reagent_containers/syringe/bluespace(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -243,7 +243,7 @@
 /obj/structure/closet/secure_closet/injection/PopulateContents()
 	..()
 	for(var/i in 1 to 5)
-		new /obj/item/reagent_containers/syringe/lethal/execution(src)
+		new /obj/item/reagent_containers/syringe/meta/execution(src) //monkestation edit
 
 /obj/structure/closet/secure_closet/brig
 	name = "brig locker"

--- a/code/modules/projectiles/guns/misc/syringe_gun.dm
+++ b/code/modules/projectiles/guns/misc/syringe_gun.dm
@@ -61,7 +61,8 @@
 
 /obj/item/gun/syringe/attackby(obj/item/A, mob/user, params, show_msg = TRUE)
 	if(istype(A, /obj/item/reagent_containers/syringe))
-		if(istype(A, /obj/item/reagent_containers/syringe/lethal) || istype(A, /obj/item/reagent_containers/syringe/bluespace)) //monkestation edit: no more lethal or bluespace syringes
+		var/obj/item/reagent_containers/syringe/S = A //to check shootability //monkestation edit
+		if(!S.shootable) //monkestation edit: no more lethal or bluespace syringes
 			to_chat(user, "<span class='warning'>[A] is too large to fit in the [src]!</span>") //monkestation edit
 			return FALSE //monkestation edit
 		if(syringes.len < max_syringes)

--- a/code/modules/projectiles/guns/misc/syringe_gun.dm
+++ b/code/modules/projectiles/guns/misc/syringe_gun.dm
@@ -61,6 +61,9 @@
 
 /obj/item/gun/syringe/attackby(obj/item/A, mob/user, params, show_msg = TRUE)
 	if(istype(A, /obj/item/reagent_containers/syringe))
+		if(istype(A, /obj/item/reagent_containers/syringe/lethal) || istype(A, /obj/item/reagent_containers/syringe/bluespace)) //monkestation edit: no more lethal or bluespace syringes
+			to_chat(user, "<span class='warning'>[A] is too large to fit in the [src]!</span>") //monkestation edit
+			return FALSE //monkestation edit
 		if(syringes.len < max_syringes)
 			if(!user.transferItemToLoc(A, src))
 				return FALSE

--- a/code/modules/projectiles/guns/misc/syringe_gun.dm
+++ b/code/modules/projectiles/guns/misc/syringe_gun.dm
@@ -61,8 +61,8 @@
 
 /obj/item/gun/syringe/attackby(obj/item/A, mob/user, params, show_msg = TRUE)
 	if(istype(A, /obj/item/reagent_containers/syringe))
-		var/obj/item/reagent_containers/syringe/S = A //to check shootability //monkestation edit
-		if(!S.shootable) //monkestation edit: no more lethal or bluespace syringes
+		var/obj/item/reagent_containers/syringe/incoming_syringe = A //to check shootability //monkestation edit
+		if(!incoming_syringe.shootable) //monkestation edit: no more lethal or bluespace syringes
 			to_chat(user, "<span class='warning'>[A] is too large to fit in the [src]!</span>") //monkestation edit
 			return FALSE //monkestation edit
 		if(syringes.len < max_syringes)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -282,17 +282,17 @@
 	desc = "Contains plasma."
 	list_reagents = list(/datum/reagent/toxin/plasma = 15)
 
-/obj/item/reagent_containers/syringe/lethal
-	name = "lethal injection syringe"
-	desc = "A syringe used for lethal injections. It can hold up to 50 units."
+/obj/item/reagent_containers/syringe/meta //monkestation edit
+	name = "metamaterial syringe" //monkestation edit
+	desc = "A large syringe reinforced with titanium and designed for swift injections. It can hold up to 50 units." //monkestation edit
 	shootable = FALSE //monkestation edit
 	amount_per_transfer_from_this = 50
 	volume = 50
 
-/obj/item/reagent_containers/syringe/lethal/choral
+/obj/item/reagent_containers/syringe/meta/choral //monkestation edit
 	list_reagents = list(/datum/reagent/toxin/chloralhydrate = 50)
 
-/obj/item/reagent_containers/syringe/lethal/execution
+/obj/item/reagent_containers/syringe/meta/execution //monkestation edit
 	list_reagents = list(/datum/reagent/toxin/plasma = 15, /datum/reagent/toxin/formaldehyde = 15, /datum/reagent/toxin/cyanide = 10, /datum/reagent/toxin/acid/fluacid = 10)
 
 /obj/item/reagent_containers/syringe/mulligan

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -16,6 +16,7 @@
 	var/mode = SYRINGE_DRAW
 	var/busy = FALSE		// needed for delayed drawing of blood
 	var/proj_piercing = 0 //does it pierce through thick clothes when shot with syringe gun
+	var/shootable = TRUE //can it be used as ammo in syringe guns? //monkestation edit
 	materials = list(/datum/material/iron=10, /datum/material/glass=20)
 	reagent_flags = TRANSPARENT
 	var/list/syringediseases = list()
@@ -284,6 +285,7 @@
 /obj/item/reagent_containers/syringe/lethal
 	name = "lethal injection syringe"
 	desc = "A syringe used for lethal injections. It can hold up to 50 units."
+	shootable = FALSE //monkestation edit
 	amount_per_transfer_from_this = 50
 	volume = 50
 
@@ -310,6 +312,7 @@
 /obj/item/reagent_containers/syringe/bluespace
 	name = "bluespace syringe"
 	desc = "An advanced syringe that can hold 60 units of chemicals."
+	shootable = FALSE //monkestation edit
 	amount_per_transfer_from_this = 20
 	icon_state = "bluespace_0"
 	base_icon_state = "bluespace"

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -62,18 +62,6 @@
 	build_path = /obj/item/reagent_containers/glass/beaker/meta
 	category = list("Medical Designs")
 
-//monkestation edit begin
-/datum/design/lethalsyringe
-	name = "Lethal Injection Syringe"
-	desc = "A syringe used for lethal injections. It can hold up to 50 units."
-	id = "lethalsyringe"
-	build_type = PROTOLATHE
-	materials = list(/datum/material/glass = 2000, /datum/material/plastic = 1000, /datum/material/gold = 1000, /datum/material/titanium = 1000)
-	build_path = /obj/item/reagent_containers/syringe/lethal
-	category = list("Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
-//monkestation edit end
-
 /datum/design/bluespacesyringe
 	name = "Bluespace Syringe"
 	desc = "An advanced syringe that can hold 60 units of chemicals"

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -62,6 +62,18 @@
 	build_path = /obj/item/reagent_containers/glass/beaker/meta
 	category = list("Medical Designs")
 
+//monkestation edit begin
+/datum/design/lethalsyringe
+	name = "Lethal Injection Syringe"
+	desc = "A syringe used for lethal injections. It can hold up to 50 units."
+	id = "lethalsyringe"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/glass = 2000, /datum/material/plastic = 1000, /datum/material/gold = 1000, /datum/material/titanium = 1000)
+	build_path = /obj/item/reagent_containers/syringe/lethal
+	category = list("Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+//monkestation edit end
+
 /datum/design/bluespacesyringe
 	name = "Bluespace Syringe"
 	desc = "An advanced syringe that can hold 60 units of chemicals"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -896,7 +896,7 @@
 	display_name = "Medical Weaponry"
 	description = "Weapons using medical technology."
 	prereq_ids = list("adv_biotech", "weaponry")
-	design_ids = list("rapidsyringe", "lethalsyringe") //monkestation edit
+	design_ids = list("rapidsyringe", "metasyringe") //monkestation edit
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -896,7 +896,7 @@
 	display_name = "Medical Weaponry"
 	description = "Weapons using medical technology."
 	prereq_ids = list("adv_biotech", "weaponry")
-	design_ids = list("rapidsyringe")
+	design_ids = list("rapidsyringe", "lethalsyringe") //monkestation edit
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 

--- a/monkestation/code/modules/research/designs/medical_designs.dm
+++ b/monkestation/code/modules/research/designs/medical_designs.dm
@@ -20,12 +20,12 @@
 	category = list("Misc", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/lethalsyringe
-	name = "Lethal Injection Syringe"
-	desc = "A syringe used for lethal injections. It can hold up to 50 units."
-	id = "lethalsyringe"
+/datum/design/metasyringe
+	name = "Metamaterial Syringe"
+	desc = "A large syringe reinforced with titanium and designed for swift injections. It can hold up to 50 units."
+	id = "metasyringe"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/glass = 2000, /datum/material/plastic = 1000, /datum/material/gold = 1000, /datum/material/titanium = 1000)
-	build_path = /obj/item/reagent_containers/syringe/lethal
+	build_path = /obj/item/reagent_containers/syringe/meta
 	category = list("Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY

--- a/monkestation/code/modules/research/designs/medical_designs.dm
+++ b/monkestation/code/modules/research/designs/medical_designs.dm
@@ -19,3 +19,13 @@
 	build_path = /obj/item/organ/cyberimp/arm/lighter
 	category = list("Misc", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+
+/datum/design/lethalsyringe
+	name = "Lethal Injection Syringe"
+	desc = "A syringe used for lethal injections. It can hold up to 50 units."
+	id = "lethalsyringe"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/glass = 2000, /datum/material/plastic = 1000, /datum/material/gold = 1000, /datum/material/titanium = 1000)
+	build_path = /obj/item/reagent_containers/syringe/lethal
+	category = list("Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This allows you to print more lethal injection syringes at (only) the security lathe, after you've researched the "medical weaponry" node.  The price is based on a metamaterial beaker and bluespace syringe.

## Why It's Good For The Game

I'm not a fan of how the lethal syringe is a unique item.  I think it should either be able to stand on its own, or be brought in line balance-wise.  Possible moves forward if it feels too strong could include giving it a longer injection time, and making it impossible to load into various syringe launchers.  The requirement of research, plastic, gold and titanium should limit mass-production.

## Testing Photographs and Procedure
Checked lathes, no syringe.  Did research.  Checked all lathes again, no syringe in the science or medbay lathe, rapid syringe gun was in the medbay lathe, lethal syringe was in the seclathe and rapid syringe gun was not.

## Changelog

:cl:
add: Lethal injection syringes can now be researched, and are printed at the security lathe
del: Syringe guns can no longer load lethal injection or bluespace syringes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
