### PR TITLE
Caltrop Updates + Fixes Gravity Runtime [TG PORT]

### DIFF
--- a/code/__DEFINES/dcs/flags.dm
+++ b/code/__DEFINES/dcs/flags.dm
@@ -37,5 +37,8 @@
 #define ARCH_MAXDROP "max_drop_amount"				//each item's max drop amount
 
 //Ouch my toes!
-#define CALTROP_BYPASS_SHOES 1
-#define CALTROP_IGNORE_WALKERS 2
+#define CALTROP_BYPASS_SHOES (1 << 0)
+#define CALTROP_IGNORE_WALKERS (1 << 1)
+#define CALTROP_SILENT (1 << 2)
+#define CALTROP_NOSTUN (1 << 3)
+#define CALTROP_NOCRAWL (1 << 4)

--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -1,81 +1,122 @@
+/**
+ * Caltrop element; for hurting people when they walk over this.
+ *
+ * Used for broken glass, cactuses and four sided dice.
+ */
 /datum/component/caltrop
+	///Minimum damage done when crossed
 	var/min_damage
+
+	///Maximum damage done when crossed
 	var/max_damage
+
+	///Probability of actually "firing", stunning and doing damage
 	var/probability
+
+	///Miscelanous caltrop flags; shoe bypassing, walking interaction, silence
 	var/flags
-	COOLDOWN_DECLARE(caltrop_cooldown)
+
+	///The sound that plays when a caltrop is triggered.
+	var/soundfile
+
 	///given to connect_loc to listen for something moving over target
 	var/static/list/crossed_connections = list(
 		COMSIG_ATOM_ENTERED = .proc/on_entered,
 	)
 
+	///So we can update ant damage
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 
-/datum/component/caltrop/Initialize(_min_damage = 0, _max_damage = 0, _probability = 100,  _flags = NONE)
+/datum/component/caltrop/Initialize(min_damage = 0, max_damage = 0, probability = 100, flags = NONE, soundfile = null)
 	. = ..()
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 
-	min_damage = _min_damage
-	max_damage = max(_min_damage, _max_damage)
-	probability = _probability
-	flags = _flags
+	src.min_damage = min_damage
+	src.max_damage = max(min_damage, max_damage)
+	src.probability = probability
+	src.flags = flags
+	src.soundfile = soundfile
 
 	if(ismovable(parent))
 		AddComponent(/datum/component/connect_loc_behalf, parent, crossed_connections)
 	else
 		RegisterSignal(get_turf(parent), COMSIG_ATOM_ENTERED, .proc/on_entered)
 
+// Inherit the new values passed to the component
+/datum/component/caltrop/InheritComponent(datum/component/caltrop/new_comp, original, min_damage, max_damage, probability, flags, soundfile)
+	if(!original)
+		return
+	if(min_damage)
+		src.min_damage = min_damage
+	if(max_damage)
+		src.max_damage = max_damage
+	if(probability)
+		src.probability = probability
+	if(flags)
+		src.flags = flags
+	if(soundfile)
+		src.soundfile = soundfile
+
 /datum/component/caltrop/proc/on_entered(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
-
-	var/atom/A = parent
-	if(!A.has_gravity())
-		return
 
 	if(!prob(probability))
 		return
 
-	if(ishuman(arrived))
-		var/mob/living/carbon/human/H = arrived
-		if(HAS_TRAIT(H, TRAIT_PIERCEIMMUNE))
+	if(!ishuman(arrived))
+		return
+
+	var/mob/living/carbon/human/Human = arrived
+	if(HAS_TRAIT(Human, TRAIT_PIERCEIMMUNE))
+		return
+
+	if((flags & CALTROP_IGNORE_WALKERS) && Human.m_intent == MOVE_INTENT_WALK)
+		return
+
+	if(Human.movement_type & (FLOATING|FLYING)) //check if they are able to pass over us
+		//gravity checking only our parent would prevent us from triggering they're using magboots / other gravity assisting items that would cause them to still touch us.
+		return
+
+	if(Human.buckled) //if they're buckled to something, that something should be checked instead.
+		return
+
+	if(!(Human.mobility_flags & MOBILITY_STAND)) //if were not standing we cant step on the caltrop
+		return
+
+	var/picked_def_zone = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
+	var/obj/item/bodypart/BodyPart = Human.get_bodypart(picked_def_zone)
+	if(!istype(BodyPart))
+		return
+
+	if(!IS_ORGANIC_LIMB(BodyPart))
+		return
+
+	if (!(flags & CALTROP_BYPASS_SHOES))
+		if ((Human.wear_suit?.body_parts_covered | Human.w_uniform?.body_parts_covered | Human.shoes?.body_parts_covered) & FEET)
 			return
 
-		if((flags & CALTROP_IGNORE_WALKERS) && H.m_intent == MOVE_INTENT_WALK)
-			return
+	var/damage = rand(min_damage, max_damage)
+	if(HAS_TRAIT(Human, TRAIT_LIGHT_STEP))
+		damage *= 0.5
 
-		var/picked_def_zone = pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
-		var/obj/item/bodypart/O = H.get_bodypart(picked_def_zone)
-		if(!istype(O))
-			return
-		if(!IS_ORGANIC_LIMB(O))
-			return
 
-		var/feetCover = (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)) || (H.w_uniform && (H.w_uniform.body_parts_covered & FEET))
+	if(!(flags & CALTROP_SILENT) && !Human.has_status_effect(/datum/status_effect/caltropped))
+		Human.apply_status_effect(/datum/status_effect/caltropped)
+		Human.visible_message(
+			span_danger("[Human] steps on [parent]."),
+			span_userdanger("You step on [parent]!")
+		)
 
-		if(!(flags & CALTROP_BYPASS_SHOES) && (H.shoes || feetCover))
-			return
+	Human.apply_damage(damage, BRUTE, picked_def_zone)
 
-		if((H.movement_type & FLYING) || !(H.mobility_flags & MOBILITY_STAND)|| H.buckled)
-			return
+	if(!(flags & CALTROP_NOSTUN)) // Won't set off the paralysis.
+		Human.Paralyze(50)
 
-		var/damage = rand(min_damage, max_damage)
-		if(HAS_TRAIT(H, TRAIT_LIGHT_STEP))
-			damage *= 0.5
-
-		H.apply_damage(damage, BRUTE, picked_def_zone)
-
-		if(COOLDOWN_FINISHED(src, caltrop_cooldown))
-			COOLDOWN_START(src, caltrop_cooldown, 1 SECONDS) //cooldown to avoid message spam.
-			if(!H.incapacitated(ignore_restraints = TRUE))
-				H.visible_message("<span class='danger'>[H] steps on [A].</span>", \
-						"<span class='userdanger'>You step on [A]!</span>")
-			else
-				H.visible_message("<span class='danger'>[H] slides on [A]!</span>", \
-						"<span class='userdanger'>You slide on [A]!</span>")
-
-		H.Paralyze(40)
+	if(!soundfile)
+		return
+	playsound(Human, soundfile, 15, TRUE, -3)
 
 /datum/component/caltrop/UnregisterFromParent()
-	. = ..()
 	if(ismovable(parent))
 		qdel(GetComponent(/datum/component/connect_loc_behalf))

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -148,3 +148,19 @@
 	. = ..()
 	if(.)
 		listening_in = tracker
+
+/*
+ * A status effect used for preventing caltrop message spam
+ *
+ * While a mob has this status effect, they won't recieve any messages about
+ * stepping on caltrops. But they will be stunned and damaged regardless.
+ *
+ * The status effect itself has no effect, other than to disappear after
+ * a second.
+ */
+/datum/status_effect/caltropped
+	id = "caltropped"
+	duration = 1 SECONDS
+	tick_interval = INFINITY
+	status_type = STATUS_EFFECT_REFRESH
+	alert_type = null

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -96,7 +96,8 @@
 
 /obj/item/dice/d4/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/caltrop, 4)
+	// 1d4 damage
+	AddComponent(/datum/component/caltrop, min_damage = 1, max_damage = 4)
 
 /obj/item/dice/d6
 	name = "d6"

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -260,7 +260,7 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 
 /obj/item/shard/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/caltrop, force)
+	AddComponent(/datum/component/caltrop, min_damage = force)
 	AddComponent(/datum/component/butchering, 150, 65)
 	icon_state = pick("large", "medium", "small")
 	switch(icon_state)

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -138,7 +138,7 @@
 
 /obj/structure/punji_sticks/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/caltrop, 20, 30, 100, CALTROP_BYPASS_SHOES)
+	AddComponent(/datum/component/caltrop, min_damage = 20, max_damage = 30, flags = CALTROP_BYPASS_SHOES)
 
 /////////BONFIRES//////////
 

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -162,7 +162,7 @@
 /obj/structure/flora/ash/cacti/Initialize(mapload)
 	. = ..()
 	// min dmg 3, max dmg 6, prob(70)
-	AddComponent(/datum/component/caltrop, 3, 6, 70)
+	AddComponent(/datum/component/caltrop, min_damage = 3, max_damage = 6, probability = 70)
 
 //SNACKS
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -888,7 +888,7 @@
 
 /obj/item/light/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/caltrop, force)
+	AddComponent(/datum/component/caltrop, min_damage = force)
 
 /obj/item/light/proc/on_entered(datum/source, atom/movable/L)
 	SIGNAL_HANDLER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Updates caltrop code to current TG standards, accounts for kapulimbs organic limbs changes
Caltrops now have inherit component.
Caltrop has a status effect now to prevent message spams instead of using COOLDOWN. 
A message about "sliding over" caltrops has been removed, since it's now intended that you only trigger caltrops if you're not lying down.

## Why It's Good For The Game
Fixes gravity runtime for caltrops and porting objects that rely on caltrop from TG, such as with ants and cockroaches with spikey helmets should mean less code changes for food and ants. The inherit component also avoids unique components for each shard of glass and cactus in the world which should save on memory.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Walking through with shoes on with gravity, only the punjisticks puncture
![image](https://user-images.githubusercontent.com/101475356/173251750-a2a3e6ef-5a8b-4696-904f-db73bf8b2c9d.png)

Walking through without shoes every type is hit
![image](https://user-images.githubusercontent.com/101475356/173252029-846feb4a-2dae-4e4b-be8c-85fd2e8cd8b7.png)

No gravity, no runtimes, no damage, and floating above caltrop objects with no issues
![image](https://user-images.githubusercontent.com/101475356/173252111-0e3029ad-1f46-43d5-a0cc-53baa28de2a3.png)


</details>

## PR References
- https://github.com/tgstation/tgstation/pull/65523 (accounts for kapulimbs now for organic limbs)
- https://github.com/tgstation/tgstation/pull/56020 (implements a few comments and inherit values)
- https://github.com/tgstation/tgstation/pull/55252


## Changelog

:cl:
code: Updates caltrop types, cacti, shards of glass, punjisticks. You can still laydown to avoid them and float above them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
