### PR TITLE
Adds the admin only Ratvarian escape shuttle and some minor fixes to my modular bars.

### DIFF
--- a/monkestation/_maps/RandomRooms/_Bars/Box/clockwork_bar.dmm
+++ b/monkestation/_maps/RandomRooms/_Bars/Box/clockwork_bar.dmm
@@ -206,6 +206,7 @@
 	id = "barShutters";
 	name = "privacy shutters"
 	},
+/obj/structure/grille/ratvar,
 /turf/open/floor/bronze,
 /area/crew_quarters/bar)
 "KH" = (

--- a/monkestation/_maps/RandomRooms/_Bars/Meta/magical_bar.dmm
+++ b/monkestation/_maps/RandomRooms/_Bars/Meta/magical_bar.dmm
@@ -79,21 +79,6 @@
 "i" = (
 /turf/open/floor/plasteel/cult,
 /area/crew_quarters/bar)
-"j" = (
-/obj/structure/chair/wood/wings{
-	dir = 1
-	},
-/obj/structure/chair/wood/wings{
-	dir = 1
-	},
-/obj/structure/chair/wood/wings{
-	dir = 1
-	},
-/obj/structure/chair/wood/wings{
-	dir = 1
-	},
-/turf/open/floor/plasteel/cult,
-/area/crew_quarters/bar)
 "k" = (
 /obj/structure/table/wood/poker,
 /obj/item/reagent_containers/food/snacks/burger/spell,
@@ -186,7 +171,6 @@
 /turf/open/floor/plasteel/cult,
 /area/crew_quarters/bar)
 "D" = (
-/obj/structure/chair/wood/wings,
 /obj/structure/chair/wood/wings,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/cult,
@@ -343,7 +327,7 @@ s
 S
 i
 r
-j
+P
 i
 Q
 i

--- a/monkestation/_maps/shuttles/emergency_brass.dmm
+++ b/monkestation/_maps/shuttles/emergency_brass.dmm
@@ -1,0 +1,72 @@
+"a" = (/turf/closed/wall/mineral/bronze,/area/shuttle/escape)
+"b" = (/obj/structure/table/brass,/obj/item/toy/plush/plushvar,/obj/machinery/light/floor,/turf/open/floor/bronze,/area/shuttle/escape)
+"c" = (/obj/structure/table/brass,/obj/item/restraints/handcuffs/clockwork,/turf/open/floor/bronze,/area/shuttle/escape)
+"d" = (/obj/structure/table/brass,/obj/item/storage/firstaid/regular,/turf/open/floor/bronze,/area/shuttle/escape)
+"e" = (/obj/structure/shuttle/engine/heater{dir = 8},/obj/structure/window/bronze{dir = 4},/turf/open/floor/plating/airless,/area/shuttle/escape)
+"f" = (/obj/machinery/light/floor,/turf/open/floor/bronze,/area/shuttle/escape)
+"g" = (/obj/effect/fun_balloon/sentience/emergency_shuttle{effect_range = 5; group_name = "defenders of Rebe"},/obj/item/reagent_containers/food/snacks/spaghetti/pastatomato,/obj/machinery/light/floor{brightness = 10},/obj/machinery/light/floor{brightness = 10},/turf/open/floor/bronze,/area/shuttle/escape)
+"h" = (/obj/structure/window/reinforced/clockwork/fulltile,/obj/structure/grille/ratvar,/obj/effect/clockwork/servant_blocker,/turf/open/floor/bronze,/area/shuttle/escape)
+"i" = (/obj/machinery/door/airlock/clockwork,/turf/open/floor/bronze,/area/shuttle/escape)
+"j" = (/obj/item/clockwork/weapon/brass_sword,/obj/effect/mob_spawn/drone/cogscarab,/turf/open/floor/bronze,/area/shuttle/escape)
+"k" = (/obj/effect/clockwork/servant_blocker,/turf/closed/wall/mineral/bronze,/area/shuttle/escape)
+"l" = (/obj/machinery/sleeper/clockwork{dir = 4},/obj/machinery/light/floor{brightness = 10},/obj/machinery/power/apc{pixel_y = -24},/turf/open/floor/bronze,/area/shuttle/escape)
+"m" = (/mob/living/simple_animal/hostile/clockwork_marauder,/turf/open/floor/bronze,/area/shuttle/escape)
+"n" = (/obj/item/clockwork/weapon/brass_battlehammer,/obj/effect/mob_spawn/drone/cogscarab,/turf/open/floor/bronze,/area/shuttle/escape)
+"o" = (/obj/effect/clockwork/servant_blocker,/turf/open/floor/bronze,/area/shuttle/escape)
+"p" = (/obj/structure/table/brass,/obj/item/clockwork/clockwork_slab,/turf/open/floor/bronze,/area/shuttle/escape)
+"q" = (/obj/machinery/light/floor{brightness = 10},/turf/open/floor/bronze,/area/shuttle/escape)
+"r" = (/obj/structure/table/brass,/obj/item/storage/firstaid/regular,/obj/machinery/power/apc{pixel_y = -24},/turf/open/floor/bronze,/area/shuttle/escape)
+"s" = (/obj/machinery/door/airlock/bronze/seethru,/turf/open/floor/bronze,/area/shuttle/escape)
+"t" = (/obj/machinery/power/apc{pixel_y = -24},/turf/open/floor/bronze,/area/shuttle/escape)
+"u" = (/obj/structure/chair/brass{dir = 1},/obj/machinery/power/apc{pixel_y = -24},/turf/open/floor/bronze,/area/shuttle/escape)
+"w" = (/obj/machinery/computer/camera_advanced/ratvar{dir = 4},/turf/open/floor/bronze,/area/shuttle/escape)
+"y" = (/obj/structure/shuttle/engine/propulsion{dir = 8},/turf/open/floor/plating/airless,/area/shuttle/escape)
+"z" = (/obj/structure/table/brass,/obj/item/storage/firstaid/toxin,/obj/item/storage/firstaid/toxin{pixel_x = -4; pixel_y = 3},/obj/item/storage/firstaid/o2{pixel_x = 3; pixel_y = 3},/obj/machinery/light/floor{brightness = 10},/turf/open/floor/bronze,/area/shuttle/escape)
+"A" = (/obj/structure/table/brass,/obj/item/storage/firstaid/fire,/turf/open/floor/bronze,/area/shuttle/escape)
+"B" = (/obj/machinery/door/window/clockwork{dir = 4},/obj/structure/destructible/clockwork/sigil/vitality,/turf/open/floor/bronze,/area/shuttle/escape)
+"C" = (/obj/structure/chair/brass{dir = 8},/turf/open/floor/bronze,/area/shuttle/escape)
+"D" = (/turf/template_noop,/area/shuttle/escape)
+"E" = (/obj/structure/chair/brass{dir = 1},/turf/open/floor/bronze,/area/shuttle/escape)
+"F" = (/obj/machinery/computer/emergency_shuttle{dir = 8},/turf/open/floor/bronze,/area/shuttle/escape)
+"G" = (/obj/machinery/door/airlock/clockwork/glass,/turf/open/floor/bronze,/area/shuttle/escape)
+"H" = (/obj/structure/chair/brass{dir = 1},/obj/machinery/light/floor{brightness = 10},/obj/machinery/power/apc{pixel_y = -24},/turf/open/floor/bronze,/area/shuttle/escape)
+"I" = (/obj/structure/shuttle/engine/large{dir = 8},/turf/open/floor/plating/airless,/area/shuttle/escape)
+"J" = (/turf/open/floor/bronze,/area/shuttle/escape)
+"K" = (/obj/machinery/light/floor{brightness = 10},/obj/machinery/light/floor{brightness = 10},/turf/open/floor/bronze,/area/shuttle/escape)
+"M" = (/obj/item/reagent_containers/food/snacks/spaghetti/pastatomato,/turf/open/floor/bronze,/area/shuttle/escape)
+"N" = (/obj/item/toy/plush/moth/tyriaplush,/turf/open/floor/bronze,/area/shuttle/escape)
+"O" = (/obj/machinery/door/airlock/bronze,/obj/docking_port/mobile/emergency{name = "Ratvarian emergency shuttle"},/turf/open/floor/bronze,/area/shuttle/escape)
+"P" = (/obj/item/toy/plush/moth/ookplush,/turf/open/floor/bronze,/area/shuttle/escape)
+"Q" = (/turf/open/floor/plating/airless,/area/shuttle/escape)
+"R" = (/obj/structure/table/brass,/obj/item/restraints/handcuffs/clockwork,/obj/machinery/light/floor{brightness = 10},/turf/open/floor/bronze,/area/shuttle/escape)
+"S" = (/obj/structure/table/brass,/obj/item/storage/firstaid/brute,/turf/open/floor/bronze,/area/shuttle/escape)
+"T" = (/obj/machinery/door/airlock/bronze,/turf/open/floor/bronze,/area/shuttle/escape)
+"U" = (/obj/structure/shuttle/engine/huge{dir = 8},/turf/open/floor/plating/airless,/area/shuttle/escape)
+"V" = (/obj/structure/window/bronze{dir = 8},/turf/open/floor/bronze,/area/shuttle/escape)
+"W" = (/obj/machinery/sleeper/clockwork{dir = 4},/turf/open/floor/bronze,/area/shuttle/escape)
+"X" = (/obj/structure/table/brass,/obj/item/clockwork/replica_fabricator,/turf/open/floor/bronze,/area/shuttle/escape)
+"Y" = (/obj/item/clockwork/weapon/brass_spear,/obj/effect/mob_spawn/drone/cogscarab,/turf/open/floor/bronze,/area/shuttle/escape)
+
+(1,1,1) = {"
+aaaaakkkkkkkkkkkDDDDDDDDD
+QQeVJoaJJJJJJaPkDDDDDDDDD
+IQeVJoaJJJJJJaakkkkDDDDDD
+aaaJJoaJJJJJJadASzkDDDDDD
+QQeVqoaJJKJJJsJJJSkDDDDDD
+IQeVJoaJJJJJJaWJJAkDDDDDD
+aaaaJoaJJJJJJalJJrkDDDDDD
+TJJaJoaJJJJJJaaaGakhhhhhk
+afJiJoaJJJJJJaJJJJanmJJJh
+OJJaJoaJJJJJJaJpCJamMMMJh
+aaaaqoBJJKJJJGJbCJGjMgMFh
+QQQeVoaJJJJJJaJXCJamMMMJh
+QQQeVoaJJJJJJatJJtaYmJJJh
+UQQeVoaJJJJJJaaaGakhhhhhk
+aaaaJoaJJJJJJawJJRkDDDDDD
+TJJaJoaJJJJJJawJJckDDDDDD
+afJaqoaJJKJJJsJJJJkDDDDDD
+TJJiJoaJJJJJJaHEEukDDDDDD
+aaJaJoaJJJJJJaakkkkDDDDDD
+yeVaJoaJJJJJJaNkDDDDDDDDD
+aaaaakkkkkkkkkkkDDDDDDDDD
+"}

--- a/monkestation/_maps/shuttles/emergency_brass.dmm
+++ b/monkestation/_maps/shuttles/emergency_brass.dmm
@@ -12,14 +12,16 @@
 "l" = (/obj/machinery/sleeper/clockwork{dir = 4},/obj/machinery/light/floor{brightness = 10},/obj/machinery/power/apc{pixel_y = -24},/turf/open/floor/bronze,/area/shuttle/escape)
 "m" = (/mob/living/simple_animal/hostile/clockwork_marauder,/turf/open/floor/bronze,/area/shuttle/escape)
 "n" = (/obj/item/clockwork/weapon/brass_battlehammer,/obj/effect/mob_spawn/drone/cogscarab,/turf/open/floor/bronze,/area/shuttle/escape)
-"o" = (/obj/effect/clockwork/servant_blocker,/turf/open/floor/bronze,/area/shuttle/escape)
+"o" = (/obj/structure/chair/brass{dir = 4},/turf/open/floor/bronze,/area/shuttle/escape)
 "p" = (/obj/structure/table/brass,/obj/item/clockwork/clockwork_slab,/turf/open/floor/bronze,/area/shuttle/escape)
 "q" = (/obj/machinery/light/floor{brightness = 10},/turf/open/floor/bronze,/area/shuttle/escape)
-"r" = (/obj/structure/table/brass,/obj/item/storage/firstaid/regular,/obj/machinery/power/apc{pixel_y = -24},/turf/open/floor/bronze,/area/shuttle/escape)
+"r" = (/obj/effect/clockwork/servant_blocker,/turf/open/floor/bronze,/area/shuttle/escape)
 "s" = (/obj/machinery/door/airlock/bronze/seethru,/turf/open/floor/bronze,/area/shuttle/escape)
-"t" = (/obj/machinery/power/apc{pixel_y = -24},/turf/open/floor/bronze,/area/shuttle/escape)
-"u" = (/obj/structure/chair/brass{dir = 1},/obj/machinery/power/apc{pixel_y = -24},/turf/open/floor/bronze,/area/shuttle/escape)
+"t" = (/obj/machinery/light/floor{brightness = 10},/obj/structure/chair/brass{dir = 4},/turf/open/floor/bronze,/area/shuttle/escape)
+"u" = (/obj/structure/table/brass,/obj/item/storage/firstaid/regular,/obj/machinery/power/apc{pixel_y = -24},/turf/open/floor/bronze,/area/shuttle/escape)
+"v" = (/obj/machinery/power/apc{pixel_y = -24},/turf/open/floor/bronze,/area/shuttle/escape)
 "w" = (/obj/machinery/computer/camera_advanced/ratvar{dir = 4},/turf/open/floor/bronze,/area/shuttle/escape)
+"x" = (/obj/structure/chair/brass{dir = 1},/obj/machinery/power/apc{pixel_y = -24},/turf/open/floor/bronze,/area/shuttle/escape)
 "y" = (/obj/structure/shuttle/engine/propulsion{dir = 8},/turf/open/floor/plating/airless,/area/shuttle/escape)
 "z" = (/obj/structure/table/brass,/obj/item/storage/firstaid/toxin,/obj/item/storage/firstaid/toxin{pixel_x = -4; pixel_y = 3},/obj/item/storage/firstaid/o2{pixel_x = 3; pixel_y = 3},/obj/machinery/light/floor{brightness = 10},/turf/open/floor/bronze,/area/shuttle/escape)
 "A" = (/obj/structure/table/brass,/obj/item/storage/firstaid/fire,/turf/open/floor/bronze,/area/shuttle/escape)
@@ -30,18 +32,15 @@
 "F" = (/obj/machinery/computer/emergency_shuttle{dir = 8},/turf/open/floor/bronze,/area/shuttle/escape)
 "G" = (/obj/machinery/door/airlock/clockwork/glass,/turf/open/floor/bronze,/area/shuttle/escape)
 "H" = (/obj/structure/chair/brass{dir = 1},/obj/machinery/light/floor{brightness = 10},/obj/machinery/power/apc{pixel_y = -24},/turf/open/floor/bronze,/area/shuttle/escape)
-"I" = (/obj/structure/shuttle/engine/large{dir = 8},/turf/open/floor/plating/airless,/area/shuttle/escape)
 "J" = (/turf/open/floor/bronze,/area/shuttle/escape)
 "K" = (/obj/machinery/light/floor{brightness = 10},/obj/machinery/light/floor{brightness = 10},/turf/open/floor/bronze,/area/shuttle/escape)
-"M" = (/obj/item/reagent_containers/food/snacks/spaghetti/pastatomato,/turf/open/floor/bronze,/area/shuttle/escape)
 "N" = (/obj/item/toy/plush/moth/tyriaplush,/turf/open/floor/bronze,/area/shuttle/escape)
 "O" = (/obj/machinery/door/airlock/bronze,/obj/docking_port/mobile/emergency{name = "Ratvarian emergency shuttle"},/turf/open/floor/bronze,/area/shuttle/escape)
 "P" = (/obj/item/toy/plush/moth/ookplush,/turf/open/floor/bronze,/area/shuttle/escape)
-"Q" = (/turf/open/floor/plating/airless,/area/shuttle/escape)
+"Q" = (/obj/structure/window/bronze{dir = 8},/obj/structure/chair/brass{dir = 4},/turf/open/floor/bronze,/area/shuttle/escape)
 "R" = (/obj/structure/table/brass,/obj/item/restraints/handcuffs/clockwork,/obj/machinery/light/floor{brightness = 10},/turf/open/floor/bronze,/area/shuttle/escape)
 "S" = (/obj/structure/table/brass,/obj/item/storage/firstaid/brute,/turf/open/floor/bronze,/area/shuttle/escape)
 "T" = (/obj/machinery/door/airlock/bronze,/turf/open/floor/bronze,/area/shuttle/escape)
-"U" = (/obj/structure/shuttle/engine/huge{dir = 8},/turf/open/floor/plating/airless,/area/shuttle/escape)
 "V" = (/obj/structure/window/bronze{dir = 8},/turf/open/floor/bronze,/area/shuttle/escape)
 "W" = (/obj/machinery/sleeper/clockwork{dir = 4},/turf/open/floor/bronze,/area/shuttle/escape)
 "X" = (/obj/structure/table/brass,/obj/item/clockwork/replica_fabricator,/turf/open/floor/bronze,/area/shuttle/escape)
@@ -49,24 +48,24 @@
 
 (1,1,1) = {"
 aaaaakkkkkkkkkkkDDDDDDDDD
-QQeVJoaJJJJJJaPkDDDDDDDDD
-IQeVJoaJJJJJJaakkkkDDDDDD
-aaaJJoaJJJJJJadASzkDDDDDD
-QQeVqoaJJKJJJsJJJSkDDDDDD
-IQeVJoaJJJJJJaWJJAkDDDDDD
-aaaaJoaJJJJJJalJJrkDDDDDD
-TJJaJoaJJJJJJaaaGakhhhhhk
-afJiJoaJJJJJJaJJJJanmJJJh
-OJJaJoaJJJJJJaJpCJamMMMJh
-aaaaqoBJJKJJJGJbCJGjMgMFh
-QQQeVoaJJJJJJaJXCJamMMMJh
-QQQeVoaJJJJJJatJJtaYmJJJh
-UQQeVoaJJJJJJaaaGakhhhhhk
-aaaaJoaJJJJJJawJJRkDDDDDD
-TJJaJoaJJJJJJawJJckDDDDDD
-afJaqoaJJKJJJsJJJJkDDDDDD
-TJJiJoaJJJJJJaHEEukDDDDDD
-aaJaJoaJJJJJJaakkkkDDDDDD
-yeVaJoaJJJJJJaNkDDDDDDDDD
+yeQooraJJJJJJaPkDDDDDDDDD
+yeQooraJJJJJJaakkkkDDDDDD
+aaaJJraJJJJJJadASzkDDDDDD
+yeQotraJJKJJJsJJJSkDDDDDD
+yeQooraJJJJJJaWJJAkDDDDDD
+aaaaJraJJJJJJalJJukDDDDDD
+TJJaJraJJJJJJaaaGakhhhhhk
+afJiJraJJJJJJaJJJJanJJJJh
+OJJaJraJJJJJJaJpCJamJJJJh
+aaaaqrBJJKJJJGJbCJGjJgJFh
+yeQooraJJJJJJaJXCJamJJJJh
+yeQooraJJJJJJavJJvaYJJJJh
+yeQooraJJJJJJaaaGakhhhhhk
+aaaaJraJJJJJJawJJRkDDDDDD
+TJJaJraJJJJJJawJJckDDDDDD
+afJaqraJJKJJJsJJJJkDDDDDD
+TJJiJraJJJJJJaHEExkDDDDDD
+aaJaJraJJJJJJaakkkkDDDDDD
+yeVaJraJJJJJJaNkDDDDDDDDD
 aaaaakkkkkkkkkkkDDDDDDDDD
 "}

--- a/monkestation/code/datums/shuttles.dm
+++ b/monkestation/code/datums/shuttles.dm
@@ -26,8 +26,8 @@
 	prefix = "monkestation/_maps/shuttles/"
 	suffix = "brass"
 	name = "Ratvarian Emergency Shuttle"
-	credit_cost = 10000
+	credit_cost = 50000
 	description = "This shuttle came from a portal with the message: His light shall save us all. Message ends."
 	can_be_bought = FALSE
 	admin_notes = "Currently an admin only shuttle. Has working cogscarab shells however they lack the power to start the ark \
-	and cannot teleport unless Reebe is loaded. Shuttle thruster rotation is currently broken."
+	and cannot teleport unless Reebe is loaded."

--- a/monkestation/code/datums/shuttles.dm
+++ b/monkestation/code/datums/shuttles.dm
@@ -21,3 +21,13 @@
 	description = "A heavily retrofitted Box-Model exfiltration vessel, complete with private rooms for every non-civilian \
 	department. Rated maximum safe occupancy: 20. Exceeding this limit may result in the witholding of your health benefeits."
 	admin_notes = "Designed for lowpop rounds and will be exceedingly chaotic outside of that setting."
+
+/datum/map_template/shuttle/emergency/brass
+	prefix = "monkestation/_maps/shuttles/"
+	suffix = "brass"
+	name = "Ratvarian Emergency Shuttle"
+	credit_cost = 10000
+	description = "This shuttle came from a portal with the message: His light shall save us all. Message ends."
+	can_be_bought = FALSE
+	admin_notes = "Currently an admin only shuttle. Has working cogscarab shells however they lack the power to start the ark \
+	and cannot teleport unless Reebe is loaded. Shuttle thruster rotation is currently broken."


### PR DESCRIPTION
# About The Pull Request

Adds a new admin only escape shuttle and fixes some minor issues with some of the modular bars I added.

## Why It's Good For The Game

Clock cult shuttle to go along with the blood cult shuttle, and fixes are generally good.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>

<summary>Screenshots&Videos</summary>

The escape shuttle

![Screenshot (183)](https://user-images.githubusercontent.com/69217972/173479589-f86be456-c475-480d-9414-15c89d9b8675.png)

New version of shuttle.

![Screenshot (184)](https://user-images.githubusercontent.com/69217972/173694834-cb9fc0be-a4ff-47d1-a2ff-bc1127070957.png)

</details>

## Changelog

:cl:
add: New admin only Ratvarian escape shuttle
fix: Added grills to the clockwork bar windows
fix: Removed duplicate chairs in the magical bar
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
