### PR TITLE
Fixes Runtime on blurry_eye proc + Harddel on plane_master_controller

### DIFF
--- a/code/_onclick/hud/map_popups.dm
+++ b/code/_onclick/hud/map_popups.dm
@@ -77,23 +77,18 @@
 		screen_maps[screen_obj.assigned_map] = list()
 	// NOTE: Possibly an expensive operation
 	var/list/screen_map = screen_maps[screen_obj.assigned_map]
-	if(!screen_map.Find(screen_obj))
-		screen_map += screen_obj
-	if(!screen.Find(screen_obj))
-		screen += screen_obj
+	screen_map |= screen_obj
+	screen |= screen_obj
 
 /**
  * Clears the map of registered screen objects.
- *
- * Not really needed most of the time, as the client's screen list gets reset
- * on relog. any of the buttons are going to get caught by garbage collection
- * anyway. they're effectively qdel'd.
  */
 /client/proc/clear_map(map_name)
-	if(!map_name || !(map_name in screen_maps))
+	if(!map_name || !screen_maps[map_name])
 		return FALSE
 	for(var/atom/movable/screen/screen_obj in screen_maps[map_name])
 		screen_maps[map_name] -= screen_obj
+		screen -= screen_obj
 		if(screen_obj.del_on_map_removal)
 			qdel(screen_obj)
 	screen_maps -= map_name

--- a/code/_onclick/hud/plane_master.dm
+++ b/code/_onclick/hud/plane_master.dm
@@ -43,11 +43,6 @@
 	appearance_flags = PLANE_MASTER
 	blend_mode = BLEND_OVERLAY
 
-/atom/movable/screen/plane_master/floor/backdrop(mob/mymob)
-	clear_filters()
-	if(istype(mymob) && mymob.eye_blurry)
-		add_filter("eye_blur", 1, gauss_blur_filter(clamp(mymob.eye_blurry * 0.1, 0.6, 3)))
-
 ///Contains most things in the game world
 /atom/movable/screen/plane_master/game_world
 	name = "game world plane master"
@@ -56,11 +51,8 @@
 	blend_mode = BLEND_OVERLAY
 
 /atom/movable/screen/plane_master/game_world/backdrop(mob/mymob)
-	clear_filters()
 	if(istype(mymob) && mymob.client && mymob.client.prefs && mymob.client.prefs.ambientocclusion)
 		add_filter("AO", 1, drop_shadow_filter(x = 0, y = -2, size = 4, color = "#04080FAA"))
-	if(istype(mymob) && mymob.eye_blurry)
-		add_filter("eye_blur", 1, gauss_blur_filter(clamp(mymob.eye_blurry * 0.1, 0.6, 3)))
 
 
 ///Contains all lighting objects

--- a/code/_onclick/hud/plane_master_controller.dm
+++ b/code/_onclick/hud/plane_master_controller.dm
@@ -13,8 +13,6 @@ INITIALIZE_IMMEDIATE(/atom/movable/plane_master_controller)
 	if(!istype(hud))
 		return
 	owner_hud = hud
-	if(istype(owner_hud))
-		return INITIALIZE_HINT_QDEL
 	var/assoc_controlled_planes = list()
 	for(var/i in controlled_planes)
 		var/atom/movable/screen/plane_master/instance = owner_hud.plane_masters["[i]"]
@@ -88,4 +86,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/plane_master_controller)
 
 /atom/movable/plane_master_controller/game
 	name = PLANE_MASTERS_GAME
-	controlled_planes = list(FLOOR_PLANE, GAME_PLANE, LIGHTING_PLANE)
+	controlled_planes = list(FLOOR_PLANE,
+		GAME_PLANE,
+		LIGHTING_PLANE
+	)

--- a/code/_onclick/hud/plane_master_controller.dm
+++ b/code/_onclick/hud/plane_master_controller.dm
@@ -23,7 +23,8 @@ INITIALIZE_IMMEDIATE(/atom/movable/plane_master_controller)
 	controlled_planes = assoc_controlled_planes
 
 /atom/movable/plane_master_controller/Destroy()
-	owner_hud = null
+	if(owner_hud)
+		owner_hud.plane_master_controllers -= src
 	controlled_planes.Cut()
 	return ..()
 
@@ -90,3 +91,5 @@ INITIALIZE_IMMEDIATE(/atom/movable/plane_master_controller)
 		GAME_PLANE,
 		LIGHTING_PLANE
 	)
+
+/datum/unit_test

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -55,10 +55,10 @@
 	cam_background.del_on_map_removal = FALSE
 
 /obj/machinery/computer/security/Destroy()
-	qdel(cam_screen)
-	qdel(cam_plane_master)
-	qdel(visual_plane_master)
-	qdel(cam_background)
+	QDEL_NULL(cam_screen)
+	QDEL_NULL(cam_plane_master)
+	QDEL_NULL(visual_plane_master)
+	QDEL_NULL(cam_background)
 	return ..()
 
 /obj/machinery/computer/security/connect_to_shuttle(obj/docking_port/mobile/port, obj/docking_port/stationary/dock, idnum, override=FALSE)

--- a/code/game/objects/items/devices/spyglasses.dm
+++ b/code/game/objects/items/devices/spyglasses.dm
@@ -9,7 +9,7 @@
 		return
 	if(!linked_bug)
 		user.audible_message("<span class='warning'>[src] lets off a shrill beep!</span>")
-	if("spypopup_map" in user.client.screen_maps) //alright, the popup this object uses is already IN use, so the window is open. no point in doing any other work here, so we're good.
+	if(user.client.screen_maps["spypopup_map"]) //alright, the popup this object uses is already IN use, so the window is open. no point in doing any other work here, so we're good.
 		return
 	user.client.setup_popup("spypopup", 3, 3, 2)
 	user.client.register_map_obj(linked_bug.cam_screen)
@@ -75,9 +75,9 @@
 /obj/item/clothing/accessory/spy_bug/Destroy()
 	if(linked_glasses)
 		linked_glasses.linked_bug = null
-	qdel(cam_screen)
+	QDEL_NULL(cam_screen)
 	QDEL_LIST(cam_plane_masters)
-	qdel(tracker)
+	QDEL_NULL(tracker)
 	return ..()
 
 /obj/item/clothing/accessory/spy_bug/proc/update_view()//this doesn't do anything too crazy, just updates the vis_contents of its screen obj

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -51,9 +51,9 @@
 	cam_background.del_on_map_removal = FALSE
 
 /datum/computer_file/program/secureye/Destroy()
-	qdel(cam_screen)
+	QDEL_NULL(cam_screen)
 	QDEL_LIST(cam_plane_masters)
-	qdel(cam_background)
+	QDEL_NULL(cam_background)
 	return ..()
 
 /datum/computer_file/program/secureye/ui_interact(mob/user, datum/tgui/ui)

--- a/code/modules/projectiles/ammunition/caseless/_caseless.dm
+++ b/code/modules/projectiles/ammunition/caseless/_caseless.dm
@@ -4,12 +4,14 @@
 	heavy_metal = FALSE
 
 /obj/item/ammo_casing/caseless/fire_casing(atom/target, mob/living/user, params, distro, quiet, zone_override, spread, spread_multiplier = 1, atom/fired_from)
-	if (..()) //successfully firing
-		moveToNullspace()
-		QDEL_NULL(src)
-		return TRUE
-	else
+	if (!..()) //failed firing
 		return FALSE
+	if(istype(fired_from, /obj/item/gun))
+		var/obj/item/gun/shot_from = fired_from
+		if(shot_from.chambered == src)
+			shot_from.chambered = null //Nuke it. Nuke it now.
+	qdel(src)
+	return TRUE
 
 /obj/item/ammo_casing/caseless/update_icon()
 	..()

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -109,11 +109,14 @@
 /obj/item/gun/ballistic/process_chamber(empty_chamber = TRUE, from_firing = TRUE, chamber_next_round = TRUE)
 	if(!semi_auto && from_firing)
 		return
-	var/obj/item/ammo_casing/AC = chambered //Find chambered round
-	if(istype(AC)) //there's a chambered round
-		if(casing_ejector || !from_firing)
-			AC.forceMove(drop_location()) //Eject casing onto ground.
-			AC.bounce_away(TRUE)
+	var/obj/item/ammo_casing/casing = chambered //Find chambered round
+	if(istype(casing)) //there's a chambered round
+		if(QDELING(casing))
+			stack_trace("Trying to move a qdeleted casing of type [casing.type]!")
+			chambered = null
+		else if(casing_ejector || !from_firing)
+			casing.forceMove(drop_location()) //Eject casing onto ground.
+			casing.bounce_away(TRUE)
 			chambered = null
 		else if(empty_chamber)
 			chambered = null

--- a/code/modules/unit_tests/create_and_destroy.dm
+++ b/code/modules/unit_tests/create_and_destroy.dm
@@ -82,6 +82,8 @@
 	ignore += typesof(/obj/structure/alien/resin/flower_bud_enemy)
 	//Expects a mob to holderize, we have nothing to give
 	ignore += typesof(/obj/item/clothing/head/mob_holder)
+	//Expects a hud, generally created for player occupied mobs. There won't be any and this causes issues for us.
+	ignore += typesof(/atom/movable/plane_master_controller)
 
 	var/list/cached_contents = spawn_at.contents.Copy()
 	var/baseturf_count = length(spawn_at.baseturfs)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
**TEST MERGE NEEDED**
Fixes runtime and weird delete in the plane_master_controller that was responsible for many runtimes and most likely the costly hard deletes too. This may also be the cause of some players vision getting stuck after being blinded even when they replace or repair their eyes. Keep an eye on that bug and see if still happens after this.

`Runtime in status_procs.dm, line 108: Cannot execute null.add filter().`
<details>

![image](https://user-images.githubusercontent.com/101475356/175304402-ce7ec36e-24f8-414a-8117-4593c64977ef.png)

</details>

## Why It's Good For The Game
Cleans up a strange runtime that should not exist

## Testing Procedure
Causing blurry eye through means of pepper spray and screwdriver into eyes aggressively.
When this line is removed I no longer get the runtimes and hard deletes on plane_master_controller that would normally happen
```
if(istype(owner_hud)) 
  return INITIALIZE_HINT_QDEL
```
## PR References
- https://github.com/BeeStation/BeeStation-Hornet/pull/6772
- https://github.com/BeeStation/BeeStation-Hornet/pull/6778
- https://github.com/tgstation/tgstation/pull/56717

## Changelog

:cl: DoctorSquishy
fix: Fixes runtime on blurry_eye. Please report if anymore permanent blindness incidents happen
fix: Fixed plane_master_controller harddel
/:cl:

