### PR TITLE
Explosive Spear Updates [TG PORT]

### DIFF
--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -27,6 +27,7 @@
 	AddComponent(/datum/component/butchering, 100, 70) //decent in a pinch, but pretty bad.
 	AddComponent(/datum/component/jousting)
 	AddComponent(/datum/component/two_handed, force_unwielded=10, force_wielded=18, block_power_wielded=25, icon_wielded="[icon_prefix]1")
+	update_icon()
 
 /obj/item/spear/update_icon()
 	icon_state = "[icon_prefix]0"
@@ -123,13 +124,24 @@
 
 /obj/item/spear/explosive/afterattack(atom/movable/AM, mob/user, proximity)
 	. = ..()
-	if(!proximity)
+	if(!proximity || !istype(AM))
 		return
-	if(ISWIELDED(src))
-		user.say("[war_cry]", forced="spear warcry")
-		explosive.forceMove(AM)
-		explosive.prime(lanced_by=user)
-		qdel(src)
+
+///Keep this addition in mind when updating resistance flags to atom level
+//	if(AM.resistance_flags & INDESTRUCTIBLE) //due to the lich incident of 2021, embedding grenades inside of indestructible structures is forbidden
+//		return
+
+	if(ismob(AM))
+		var/mob/mob_target = AM
+		if(mob_target.status_flags & GODMODE) //no embedding grenade phylacteries inside of ghost poly either
+			return
+	if(iseffect(AM)) //and no accidentally wasting your moment of glory on graffiti
+		return
+	user.say("[war_cry]", forced="spear warcry")
+	explosive.forceMove(AM)
+	explosive.prime(lanced_by=user)
+	qdel(src)
+
 
 //GREY TIDE
 /obj/item/spear/grey_tide

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -138,8 +138,14 @@
 	if(iseffect(AM)) //and no accidentally wasting your moment of glory on graffiti
 		return
 	user.say("[war_cry]", forced="spear warcry")
-	explosive.forceMove(AM)
-	explosive.prime(lanced_by=user)
+	if(isliving(user))
+		var/mob/living/living_user = user
+		living_user.set_resting(TRUE)
+		living_user.Move(get_turf(AM))
+		explosive.forceMove(get_turf(living_user))
+		explosive.prime(lanced_by=user)
+		if(!QDELETED(living_user))
+			living_user.set_resting(TRUE)
 	qdel(src)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Explosive lances now move you onto the same tile as the person you're lancing.
Fixes update icon on creation
Refer to PR References for more information, especially https://github.com/tgstation/tgstation/pull/67060
Basically the lance was intended as a last ditch effort to take someone down with you but thanks to power gaming knowledge you could  

## Why It's Good For The Game
From Iangoofball in https://github.com/tgstation/tgstation/pull/67060
> It's possible to make an explosive mix that completely vaporizes the target while leaving all the tiles next to it relatively unharmed or at least in a revivable state. This is working as intended for explosion code. However, when applied to the concept for the explosive lance, it doesn't really mesh with the concept as Kor envisioned it when adding them:
>
> ![image](https://user-images.githubusercontent.com/101475356/175322036-54694f7f-fb06-40ad-9d35-00a6280cc4ca.png)
>
>As you can see, Kor very much intended for this to be a "if I'm dying you're coming with me" style weapon. It used to be this in the past, and the natural content churn of the game means it isn't anymore. This change should restore the weapon to it's former intended (non-meta) functionality rather than being a powergame weapon.

## Testing Photographs and Procedure
Spawning in and the attacking lunge with the explosive lance does work as intended with these changes, no runtimes detected too.

## PR References
- https://github.com/tgstation/tgstation/pull/67060
- https://github.com/tgstation/tgstation/pull/56164
- https://github.com/tgstation/tgstation/pull/62505

## Changelog
:cl: DoctorSquishy, CoffeeDragon16, ATH1909, Iamgoofball
fix: Explosive lances will properly show the grenade on them at construction.
balance: Hitting someone in melee with the explosive lance now moves you to the same tile as them before it sets off the grenade.
fix: can no longer use explosive lances to store grenade phylacteries inside of indestructible objects (including structures)), immortal mobs, or effects.
/:cl:
