### PR TITLE
Fixes Minor Harddel on Radial Menu

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -23,7 +23,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 
 /atom/movable/screen/radial/proc/handle_parent_del()
 	SIGNAL_HANDLER
-	qdel(src) // No reason for us to exist if our parent menu's gone and we don't have a new one
+	set_parent(null)
 
 /atom/movable/screen/radial/slice
 	icon_state = "radial_slice"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Using radial menus (exiting and entering) would have a minor harddel (very minor) With this change I no longer get it during debugging.

## Why It's Good For The Game
Fixes a minor harddel

## Testing Photographs and Procedure
N/A

## Changelog
No Player Facing Changes

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
