### PR TITLE
Radlocker Reduction - MetaStation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -48356,7 +48356,6 @@
 	name = "Port Quarter Maintenance APC";
 	pixel_y = 24
 	},
-/obj/structure/closet/radiation,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "eEy" = (
@@ -49725,7 +49724,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/security/main)
 "fvE" = (
@@ -50976,7 +50974,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "gds" = (
@@ -63931,7 +63928,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/security/main)
 "nAE" = (
@@ -67433,11 +67429,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/tile_full,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
 "pGn" = (
@@ -70982,6 +70973,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"rPg" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "rPA" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -80336,20 +80331,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"xCZ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/structure/closet/radiation,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "xDa" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -80781,7 +80762,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/security/main)
 "xOy" = (
@@ -102094,7 +102074,7 @@ bXE
 fGy
 arL
 dux
-xgL
+rPg
 rrR
 cia
 cjD
@@ -109553,7 +109533,7 @@ cgd
 cge
 cgd
 cgd
-xCZ
+cpb
 cpb
 cqv
 cgd


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Reduces the amount of radlockers on MetaStation since I placed way too many

## Why It's Good For The Game
Less Radlockers, didn't need that many since radstorm from blowout is easily avoidable

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>N/A</summary>

</details>

## Changelog

:cl:
balance: Reduces the amount of Radlockers on MetaStation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
