### PR TITLE
Vent Clog Maxes

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -12,10 +12,9 @@
 	var/interval 	= 2
 	var/list/vents  = list()
 	var/randomProbability = 1
-	var/reagentsAmount = 500
+	var/reagentsAmount = 300
 	//MONKESTATION EDIT
-	var/use_all_vents = TRUE //Should it use every vent
-	var/vent_percentage = 1 //How many vents it should use (0.5 = 50%)
+	var/vent_percentage = 0.25 //How many vents it should use (0.5 = 50%)
 	//MONKESTATION EDIT END
 	var/list/saferChems = list(/datum/reagent/water,/datum/reagent/carbon,/datum/reagent/consumable/flour,/datum/reagent/space_cleaner,/datum/reagent/consumable/nutriment,/datum/reagent/consumable/condensedcapsaicin,/datum/reagent/drug/mushroomhallucinogen,/datum/reagent/lube,/datum/reagent/glitter/pink,/datum/reagent/cryptobiolin,
 						 /datum/reagent/toxin/plantbgone,/datum/reagent/blood,/datum/reagent/medicine/charcoal,/datum/reagent/drug/space_drugs,/datum/reagent/medicine/morphine,/datum/reagent/water/holywater,/datum/reagent/consumable/ethanol,/datum/reagent/consumable/cocoa/hot_cocoa,/datum/reagent/toxin/acid,/datum/reagent/toxin/mindbreaker,/datum/reagent/toxin/rotatium,/datum/reagent/bluespace,
@@ -34,18 +33,15 @@
 			temp_vents += temp_vent
 	if(!temp_vents.len)
 		return kill()
-	//MONKESTATION EDIT - also changed vents to temp_vents above
-	if(!use_all_vents)
-		var/vents_counted = 0
-		var/max_vents = temp_vents.len*vent_percentage
-		shuffle_inplace(temp_vents)
-		for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/vent in temp_vents)
-			vents += vent
-			vents_counted++
-			if(vents_counted > max_vents)
-				break
-	else
-		vents = temp_vents
+	//MONKESTATION EDIT - also changed 'vents' to 'temp_vents' above
+	var/vents_counted = 0
+	var/max_vents = temp_vents.len*vent_percentage
+	shuffle_inplace(temp_vents)
+	for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/vent in temp_vents)
+		vents += vent
+		vents_counted++
+		if(vents_counted > max_vents)
+			break
 	//MONKESTATION EDIT END
 
 /datum/round_event/vent_clog/start()
@@ -80,10 +76,9 @@
 
 /datum/round_event/vent_clog/threatening
 	randomProbability = 10
-	reagentsAmount = 1000
+	reagentsAmount = 500
 	//MONKESTATION EDIT
-	use_all_vents = FALSE
-	vent_percentage = 0.5
+	vent_percentage = 0.15
 	//MONKESTATION EDIT END
 
 /datum/round_event_control/vent_clog/catastrophic
@@ -96,10 +91,9 @@
 
 /datum/round_event/vent_clog/catastrophic
 	randomProbability = 30
-	reagentsAmount = 1250
+	reagentsAmount = 700
 	//MONKESTATION EDIT
-	use_all_vents = FALSE
-	vent_percentage = 0.25
+	vent_percentage = 0.05
 	//MONKESTATION EDIT END
 
 /datum/round_event_control/vent_clog/beer

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -13,6 +13,10 @@
 	var/list/vents  = list()
 	var/randomProbability = 1
 	var/reagentsAmount = 500
+	//MONKESTATION EDIT
+	var/use_all_vents = TRUE //Should it use every vent
+	var/vent_percentage = 1 //How many vents it should use (0.5 = 50%)
+	//MONKESTATION EDIT END
 	var/list/saferChems = list(/datum/reagent/water,/datum/reagent/carbon,/datum/reagent/consumable/flour,/datum/reagent/space_cleaner,/datum/reagent/consumable/nutriment,/datum/reagent/consumable/condensedcapsaicin,/datum/reagent/drug/mushroomhallucinogen,/datum/reagent/lube,/datum/reagent/glitter/pink,/datum/reagent/cryptobiolin,
 						 /datum/reagent/toxin/plantbgone,/datum/reagent/blood,/datum/reagent/medicine/charcoal,/datum/reagent/drug/space_drugs,/datum/reagent/medicine/morphine,/datum/reagent/water/holywater,/datum/reagent/consumable/ethanol,/datum/reagent/consumable/cocoa/hot_cocoa,/datum/reagent/toxin/acid,/datum/reagent/toxin/mindbreaker,/datum/reagent/toxin/rotatium,/datum/reagent/bluespace,
 						 /datum/reagent/pax,/datum/reagent/consumable/laughter,/datum/reagent/concentrated_barbers_aid,/datum/reagent/colorful_reagent,/datum/reagent/peaceborg/confuse,/datum/reagent/peaceborg/tire,/datum/reagent/consumable/sodiumchloride,/datum/reagent/consumable/ethanol/beer,/datum/reagent/hair_dye,/datum/reagent/consumable/sugar,/datum/reagent/glitter/white,/datum/reagent/growthserum)
@@ -23,12 +27,26 @@
 
 /datum/round_event/vent_clog/setup()
 	endWhen = rand(25, 100)
+	var/list/temp_vents = list()
 	for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/temp_vent in GLOB.machines)
 		var/turf/T = get_turf(temp_vent)
 		if(T && is_station_level(T.z) && !temp_vent.welded)
-			vents += temp_vent
-	if(!vents.len)
+			temp_vents += temp_vent
+	if(!temp_vents.len)
 		return kill()
+	//MONKESTATION EDIT - also changed vents to temp_vents above
+	if(!use_all_vents)
+		var/vents_counted = 0
+		var/max_vents = temp_vents.len*vent_percentage
+		shuffle_inplace(temp_vents)
+		for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/vent in temp_vents)
+			vents += vent
+			vents_counted++
+			if(vents_counted > max_vents)
+				break
+	else
+		vents = temp_vents
+	//MONKESTATION EDIT END
 
 /datum/round_event/vent_clog/start()
 	for(var/obj/machinery/atmospherics/components/unary/vent in vents)
@@ -59,9 +77,14 @@
 	max_occurrences = 1
 	earliest_start = 35 MINUTES
 
+
 /datum/round_event/vent_clog/threatening
 	randomProbability = 10
 	reagentsAmount = 1000
+	//MONKESTATION EDIT
+	use_all_vents = FALSE
+	vent_percentage = 0.5
+	//MONKESTATION EDIT END
 
 /datum/round_event_control/vent_clog/catastrophic
 	name = "Clogged Vents: Catastrophic"
@@ -74,6 +97,10 @@
 /datum/round_event/vent_clog/catastrophic
 	randomProbability = 30
 	reagentsAmount = 1250
+	//MONKESTATION EDIT
+	use_all_vents = FALSE
+	vent_percentage = 0.25
+	//MONKESTATION EDIT END
 
 /datum/round_event_control/vent_clog/beer
 	name = "Foamy beer stationwide"


### PR DESCRIPTION
# About The Pull Request

Puts maxes on the vent clog event based on how many vents are in the map (Threatening 50%, Catastrophic 25%)

## Why It's Good For The Game

Makes less lag, causes less of a complete disaster, and more control over events is always nice

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Threatening
![image](https://user-images.githubusercontent.com/99915170/178375767-6c6da52a-9c6a-415c-8004-6669a71a4ca6.png)

Catastrophic
![image](https://user-images.githubusercontent.com/99915170/178375770-62ccf7c4-2bc2-4946-ae4a-478b57abad8b.png)


</details>

## Changelog

:cl:
tweak: made the more dangerous vent clogs only use some of the available vents
/:cl:
