### PR TITLE
Fix overaggressive text brightness sanitization

### DIFF
--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -98,6 +98,6 @@
 	if(length(color) != length_char(color))
 		CRASH("Invalid characters in color '[color]'")
 	var/list/HSL = rgb2hsl(hex2num(copytext(color, 2, 4)), hex2num(copytext(color, 4, 6)), hex2num(copytext(color, 6, 8)))
-	HSL[3] = min(HSL[3],0.4)
+	HSL[3] = min(HSL[3],0.75)
 	var/list/RGB = hsl2rgb(arglist(HSL))
 	return "#[num2hex(RGB[1],2)][num2hex(RGB[2],2)][num2hex(RGB[3],2)]"

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -234,7 +234,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	//Sanitize
 	asaycolor		= sanitize_ooccolor(sanitize_hexcolor(asaycolor, 6, TRUE, initial(asaycolor)))
 	ooccolor		= sanitize_ooccolor(sanitize_hexcolor(ooccolor, 6, TRUE, initial(ooccolor)))
-	screentip_color = sanitize_ooccolor(sanitize_hexcolor(screentip_color, 6, 1, initial(screentip_color)))
+	screentip_color = sanitize_hexcolor(screentip_color, 6, 1, initial(screentip_color))
 	lastchangelog	= sanitize_text(lastchangelog, initial(lastchangelog))
 	UI_style		= sanitize_inlist(UI_style, GLOB.available_ui_styles, GLOB.available_ui_styles[1])
 	hotkeys			= sanitize_integer(hotkeys, FALSE, TRUE, initial(hotkeys))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

* Increases maximum brightness for OOC/ASAY colors from 0.4 to 0.75
* Removes color constraints for screentip text
* 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

* Color sanitization has not been updated since dark mode.
* It prevents you from using brighter (i.e. readable) colors, which means anyone using dark mode will find it pretty hard to read text!
* Screentip colors are purely a single-client thing and there is *no* reason to limit brightness. If you try putting in white, it will force it down to dark gray, making it difficult to read.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->


## Changelog

:cl:
fix: brightness limit raised for ooc/asay colors
fix: screentip colors no longer brightness constrained
/:cl:
