### PR TITLE
fixes warden garment bag name

### DIFF
--- a/monkestation/code/game/objects/items/storage/garment.dm
+++ b/monkestation/code/game/objects/items/storage/garment.dm
@@ -22,7 +22,7 @@
 	icon_state = "garment_bag_hos"
 
 /obj/item/storage/bag/garment/warden
-	name = "head of security's garment bag"
+	name = "warden's garment bag"
 	desc = "A bag for storing extra clothes and shoes. This one belongs to the head of security."
 	icon_state = "garment_bag_hos"
 

--- a/monkestation/code/game/objects/items/storage/garment.dm
+++ b/monkestation/code/game/objects/items/storage/garment.dm
@@ -23,7 +23,7 @@
 
 /obj/item/storage/bag/garment/warden
 	name = "warden's garment bag"
-	desc = "A bag for storing extra clothes and shoes. This one belongs to the head of security."
+	desc = "A bag for storing extra clothes and shoes. This one belongs to the warden."
 	icon_state = "garment_bag_hos"
 
 /obj/item/storage/bag/garment/research_director


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Fixes the name for the warden's garment bag

## Why It's Good For The Game
Warden's bag should be labeled correctly

## Testing Photographs and Procedure
N/A

## Changelog

:cl: DoctorSquishy

fix: fixed Warden's Garment bag name

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
