### PR TITLE
Clown Locker Description

### DIFF
--- a/monkestation/code/game/objects/structures/crates_lockers/closets/secure/clown.dm
+++ b/monkestation/code/game/objects/structures/crates_lockers/closets/secure/clown.dm
@@ -1,6 +1,7 @@
 /obj/structure/closet/secure_closet/clown
 	name = "\proper clown locker"
 	icon = 'monkestation/icons/obj/closet.dmi'
+	desc = "The clown's custom-made, bananium lined toy storage apparatus, a miracle of Clown technology and stolen hardware from other departments designed to insulate its contents from hazardous low humor environments."
 	max_integrity = 325 //About 14 hits with the fire axe
 	icon_state = "clown"
 


### PR DESCRIPTION
# About The Pull Request

It's not a huge problem since it's unused as of yet, but the clown locker has the same description as the default secure locker. This PR just copies it from the crate.

## Why It's Good For The Game

Will be more fun if an admin spawns it in or someone uses it in a map

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
add: Gave the clown locker a description
/:cl: