### PR TITLE
Makes Servants of Rat'var needed for ark activation scale with current pop instead of shift start pop

### DIFF
--- a/code/modules/antagonists/clock_cult/helpers/clockwork_conversion_tracker.dm
+++ b/code/modules/antagonists/clock_cult/helpers/clockwork_conversion_tracker.dm
@@ -13,6 +13,7 @@ GLOBAL_VAR_INIT(conversion_warning_stage, CONVERSION_WARNING_NONE)
 	if(!silent)
 		hierophant_message("<b>[M]</b> has been successfully converted!", span = "<span class='sevtug'>", use_sanitisation=FALSE)
 	var/datum/antagonist/servant_of_ratvar/antagdatum = servant_type
+	calculate_clockcult_values()
 	if(ishuman(M) && (servant_type == /datum/antagonist/servant_of_ratvar) && GLOB.critical_servant_count)
 		if((GLOB.critical_servant_count)/2 < GLOB.human_servants_of_ratvar.len)
 			if(GLOB.conversion_warning_stage < CONVERSION_WARNING_HALFWAY)
@@ -46,8 +47,11 @@ GLOBAL_VAR_INIT(conversion_warning_stage, CONVERSION_WARNING_NONE)
 		return TRUE
 
 /proc/calculate_clockcult_values()
+	var/static/high_clockcult_value = 10
 	var/playercount = get_active_player_count()
-	GLOB.critical_servant_count = round(max((playercount/6)+6,10))
+	GLOB.critical_servant_count = round(max((playercount/6)+6,high_clockcult_value))
+	high_clockcult_value = GLOB.critical_servant_count
+
 
 /proc/check_ark_status()
 	if(!GLOB.critical_servant_count)


### PR DESCRIPTION
# About The Pull Request

The calculate_clockcult_values() proc is now called whenever someone is converted via sigil of submission meaning the amount of clock cultists required for the ark to activate now scales with current pop instead of roundstart pop. Also makes it so the critical_servant_count var cant go below its current value to avoid buggyness.

## Why It's Good For The Game

Currently the required amount of cultists for the ark to activate is only checked roundstart meaning if a large amount of people join later into the round the clockcult is put at a large disadvantage in numbers.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
balance: Cultists needed for ark activation now scales with current pop instead of roundstart pop
/:cl:
