### PR TITLE
fixes anime implant bug

### DIFF
--- a/monkestation/code/game/objects/items/anime.dm
+++ b/monkestation/code/game/objects/items/anime.dm
@@ -85,9 +85,10 @@
 	to_chat(M, msg)
 	var/list/slots = list (
 		"backpack" = ITEM_SLOT_BACKPACK,
-		"hands" = ITEM_SLOT_HANDS,
+		"hands" = ITEM_SLOT_HANDS
 	)
-	M.equip_in_one_of_slots(new_item, slots , qdel_on_fail = TRUE)
+	if(!M.equip_in_one_of_slots(new_item, slots , qdel_on_fail = FALSE))
+		new_item.forceMove(M.loc)
 
 /obj/item/choice_beacon/anime/generate_display_names()
 	var/static/list/anime


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
fixes a bug where if your hands were full and you didn't have a backpack equipped, the item would disappear.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
bug fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
fix: Anime implants now spawn on the ground if no other inventory slots are available.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
