### PR TITLE
Fixes sleeper nulled circuits on mapload

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -34,9 +34,6 @@
 
 /obj/machinery/sleeper/Initialize(mapload)
 	. = ..()
-	if(mapload)
-		LAZYREMOVE(component_parts, circuit)
-		QDEL_NULL(circuit)
 	occupant_typecache = GLOB.typecache_living
 	update_appearance()
 	reset_chem_buttons()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
TG code apparently nulls the circuit and components for sleepers because they are not used anymore in most of the game and I did not know about this. I should of noticed it by looking at the initialize, but I did not really think about it at all when updating the machine code. Really highlights the issues that come with changing a lot of code at once, real easy to miss something like this.

## Why It's Good For The Game
You can deconstruct and upgrade sleepers from mapload again.

## Testing Photographs and Procedure
Tested the normal deconstruction process and upgrading process, all working as intended.


## Changelog

:cl:
fix: You can deconstruct and upgrade sleepers from mapload again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
