### PR TITLE
a couple fixes where do_after was used

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/crystalized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/crystalized.dm
@@ -17,7 +17,7 @@
 
 	var/user_turf = get_turf(user)
 
-	if(!do_after(user,15 SECONDS,FALSE,user))
+	if(!do_after(user,15 SECONDS,TRUE,user))
 		return
 
 	new crystal_type(user_turf)

--- a/code/modules/research/xenobiology/crossbreeding/crystalized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/crystalized.dm
@@ -17,7 +17,7 @@
 
 	var/user_turf = get_turf(user)
 
-	if(!do_after(user,15 SECONDS,FALSE,user_turf))
+	if(!do_after(user,15 SECONDS,FALSE,user))
 		return
 
 	new crystal_type(user_turf)

--- a/monkestation/code/datums/status_effects.dm
+++ b/monkestation/code/datums/status_effects.dm
@@ -14,7 +14,7 @@
 				if(victim != owner && length(pockets))
 					var/obj/item/I = pick(pockets)
 					owner.visible_message("<span class='warning'>[owner] attempts to remove [I] from [victim]'s pocket!</span>","<span class='warning'>You attempt to remove [I] from [victim]'s pocket.</span>", FALSE, 1)
-					if(do_after(owner, I.strip_delay, null, owner) && victim.temporarilyRemoveItemFromInventory(I))
+					if(do_mob(owner, victim, I.strip_delay) && victim.temporarilyRemoveItemFromInventory(I))
 						owner.visible_message("<span class='warning'>[owner] removes [I] from [victim]'s pocket!</span>","<span class='warning'>You remove [I] from [victim]'s pocket.</span>", FALSE, 1)
 						log_admin("[key_name(usr)] picked [victim.name]'s pockets with Kleptomania trait.")
 						if(!QDELETED(I) && !owner.putItemFromInventoryInHandIfPossible(I, owner.active_hand_index, TRUE, TRUE))


### PR DESCRIPTION

# About The Pull Request

This fixes a couple bugs

With xenobio, you could spam z on a pylon to place down a bunch of that pylon, purple for example making a super healing zone.

With the monkeys, with my experience of playing simian, is super fuckin annoying if you grab from someone who just passed by you, especially if you can't move for any reason. Also it could Technically be abusable if you're super lucky.

I didn't test the kleptomania one since It's a little hard on local, but I'm like 99% sure thats how it's worked when i've used do_mob before.

## Why It's Good For The Game

Xenobio should not have that power

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
fix: Xenobio Pylons being spammable when placing one down
fix: Kleptomania still grabbing from people who moved away
/:cl:
