### PR TITLE
Jukebox Soundtrack Usage

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -421,6 +421,7 @@
 #include "code\controllers\subsystem\sound.dm"
 #include "code\controllers\subsystem\sound_loops.dm"
 #include "code\controllers\subsystem\sounds.dm"
+#include "code\controllers\subsystem\soundtrack.dm"
 #include "code\controllers\subsystem\spatial_gridmap.dm"
 #include "code\controllers\subsystem\stat.dm"
 #include "code\controllers\subsystem\stickyban.dm"

--- a/code/_onclick/hud/credits.dm
+++ b/code/_onclick/hud/credits.dm
@@ -12,11 +12,15 @@ GLOBAL_LIST(end_titles)
 		GLOB.end_titles += "<br>"
 		GLOB.end_titles += "<br>"
 
+		GLOB.end_titles += "<center><h1>Music Credits</h1>"
+		if(SSticker.login_music_name)
+			GLOB.end_titles += "<center><h2>Lobby Song:"
+			GLOB.end_titles += "<center><h2>[sanitize(SSticker.login_music_name)]</h2>"
 		if(GLOB.soundtrack_this_round.len)
-			GLOB.end_titles += "<center><h1>Music Credits</h1>"
+			GLOB.end_titles += "<center><h2>Soundtrack Music:</h2>"
 			for(var/song_path in GLOB.soundtrack_this_round)
 				var/datum/soundtrack_song/song = song_path
-				GLOB.end_titles += "<center><h2>[sanitize(initial(song.artist))] - \"[sanitize(initial(song.title))]\" ([sanitize(initial(song.album))])</h2>"
+				GLOB.end_titles += "<center><h2>[sanitize(song.artist)] - \"[sanitize(song.title)]\" ([sanitize(song.album)])</h2>"
 			GLOB.end_titles += "<br>"
 			GLOB.end_titles += "<br>"
 

--- a/code/controllers/subsystem/soundtrack.dm
+++ b/code/controllers/subsystem/soundtrack.dm
@@ -1,0 +1,23 @@
+GLOBAL_LIST_EMPTY(soundtrack_datum_list)
+
+SUBSYSTEM_DEF(soundtrack)
+	name = "Soundtrack"
+	flags = SS_NO_FIRE
+
+/datum/controller/subsystem/soundtrack/Initialize(timeofday)
+	var/list/all_tracks = flist("config/jukebox_music/sounds/")
+
+	for(var/current_track in all_tracks)
+		var/datum/soundtrack_song/song = new()
+		var/list/song_data = splittext(current_track,"+")
+		if(song_data.len != 5)
+			continue
+		song.title = song_data[1]
+		song.artist = song_data[2]
+		song.album = song_data[3]
+		song.length = text2num(song_data[4])
+		song.file = file("config/jukebox_music/sounds/[current_track]")
+		song.beat = text2num(song_data[5])
+
+		GLOB.soundtrack_datum_list |= song
+	return ..()

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -18,6 +18,7 @@ SUBSYSTEM_DEF(ticker)
 	var/datum/game_mode/mode = null
 
 	var/login_music							//music played in pregame lobby
+	var/login_music_name					//Title of music played, for credits
 	var/round_end_sound						//music/jingle played when the world reboots
 	var/round_end_sound_sent = TRUE			//If all clients have loaded it
 
@@ -122,7 +123,11 @@ SUBSYSTEM_DEF(ticker)
 		music = world.file2list(ROUND_START_MUSIC_LIST, "\n")
 		login_music = pick(music)
 	else
-		login_music = "[global.config.directory]/title_music/sounds/[pick(music)]"
+		var/selected_song = pick(music)
+		login_music = "[global.config.directory]/title_music/sounds/[selected_song]"
+		var/list/L = splittext(selected_song,".")
+		if(L.len >= 2)
+			login_music_name = L[1]
 
 
 	if(!GLOB.syndicate_code_phrase)

--- a/code/datums/soundtrack.dm
+++ b/code/datums/soundtrack.dm
@@ -3,9 +3,20 @@ GLOBAL_LIST_EMPTY(soundtrack_this_round) // A running list of soundtrack songs t
 /datum/soundtrack_song
 	var/title
 	var/artist
-	var/url
 	var/album
+	var/url
 	var/file
+	var/beat
+	var/length
+
+/datum/soundtrack_song/New(title, artist, album, file, beat, length)
+	title = title
+	artist = artist
+	album = album
+	length = length
+	file = file
+	beat = beat
+
 
 /datum/soundtrack_song/bee
 	album = "BeeStation OST"

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -9,8 +9,7 @@
 	var/active = FALSE
 	var/list/rangers = list()
 	var/stop = 0
-	var/list/songs = list()
-	var/datum/track/selection = null
+	var/datum/soundtrack_song/selection = null
 	/// Volume of the songs played
 	var/volume = 100
 
@@ -31,35 +30,10 @@
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	flags_1 = NODECONSTRUCT_1
 
-/datum/track
-	var/song_name = "generic"
-	var/song_path = null
-	var/song_length = 0
-	var/song_beat = 0
-
-/datum/track/New(name, path, length, beat)
-	song_name = name
-	song_path = path
-	song_length = length
-	song_beat = beat
-
 /obj/machinery/jukebox/Initialize(mapload)
 	. = ..()
-	var/list/tracks = flist("config/jukebox_music/sounds/")
-
-	for(var/S in tracks)
-		var/datum/track/T = new()
-		T.song_path = file("config/jukebox_music/sounds/[S]")
-		var/list/L = splittext(S,"+")
-		if(L.len != 3)
-			continue
-		T.song_name = L[1]
-		T.song_length = text2num(L[2])
-		T.song_beat = text2num(L[3])
-		songs |= T
-
-	if(songs.len)
-		selection = pick(songs)
+	if(GLOB.soundtrack_datum_list)
+		selection = pick(GLOB.soundtrack_datum_list) //Random song by default
 
 /obj/machinery/jukebox/Destroy()
 	dance_over()
@@ -92,7 +66,7 @@
 		to_chat(user,"<span class='warning'>Error: Access Denied.</span>")
 		user.playsound_local(src, 'sound/misc/compiler-failure.ogg', 25, TRUE)
 		return UI_CLOSE
-	if(!songs.len && !isobserver(user))
+	if(!GLOB.soundtrack_datum_list.len && !isobserver(user))
 		to_chat(user,"<span class='warning'>Error: No music tracks have been authorized for your station. Petition Central Command to resolve this issue.</span>")
 		playsound(src, 'sound/misc/compiler-failure.ogg', 25, TRUE)
 		return UI_CLOSE
@@ -108,18 +82,18 @@
 	var/list/data = list()
 	data["active"] = active
 	data["songs"] = list()
-	for(var/datum/track/S in songs)
+	for(var/datum/soundtrack_song/S in GLOB.soundtrack_datum_list)
 		var/list/track_data = list(
-			name = S.song_name
+			name = S.title
 		)
 		data["songs"] += list(track_data)
 	data["track_selected"] = null
 	data["track_length"] = null
 	data["track_beat"] = null
 	if(selection)
-		data["track_selected"] = selection.song_name
-		data["track_length"] = DisplayTimeText(selection.song_length)
-		data["track_beat"] = selection.song_beat
+		data["track_selected"] = selection.title
+		data["track_length"] = DisplayTimeText(selection.length)
+		data["track_beat"] = selection.beat
 	data["volume"] = volume
 	return data
 
@@ -148,10 +122,10 @@
 				to_chat(usr, "<span class='warning'>Error: You cannot change the song until the current one is over.</span>")
 				return
 			var/list/available = list()
-			for(var/datum/track/S in songs)
-				available[S.song_name] = S
+			for(var/datum/soundtrack_song/S in GLOB.soundtrack_datum_list)
+				available[S.title] = S
 			var/selected = params["track"]
-			if(QDELETED(src) || !selected || !istype(available[selected], /datum/track))
+			if(QDELETED(src) || !selected || !istype(available[selected], /datum/soundtrack_song))
 				return
 			selection = available[selected]
 			return TRUE
@@ -174,7 +148,8 @@
 	active = TRUE
 	update_icon()
 	START_PROCESSING(SSmachines, src)
-	stop = world.time + selection.song_length
+	GLOB.soundtrack_this_round |= selection
+	stop = world.time + selection.length
 	ui_update()
 
 /obj/machinery/jukebox/disco/activate_music()
@@ -269,7 +244,7 @@
 				S.pixel_y = 7
 				S.forceMove(get_turf(src))
 		sleep(7)
-	if(selection.song_name == "Engineering's Ultimate High-Energy Hustle")
+	if(selection.title == "Engineering's Ultimate High-Energy Hustle")
 		sleep(280)
 	for(var/obj/reveal in sparkles)
 		reveal.alpha = 255
@@ -325,7 +300,7 @@
 				continue
 		if(prob(2))  // Unique effects for the dance floor that show up randomly to mix things up
 			INVOKE_ASYNC(src, .proc/hierofunk)
-		sleep(selection.song_beat)
+		sleep(selection.beat)
 
 #undef DISCO_INFENO_RANGE
 
@@ -426,7 +401,7 @@
 
 /obj/machinery/jukebox/process()
 	if(world.time < stop && active)
-		var/sound/song_played = sound(selection.song_path)
+		var/sound/song_played = sound(selection.file)
 
 		for(var/mob/L as() in rangers)
 			if(get_dist(src,L) > 10)

--- a/config/jukebox_music/README.txt
+++ b/config/jukebox_music/README.txt
@@ -10,6 +10,6 @@ Naming Conventions:
 
 Every sound you add must have a unique name. Avoid using the plus sign "+" and the period "." in names, as these are used internally to classify sounds.
 
-Sound names must be in the format of [song name]+[length in deciseconds]+[beat in deciseconds].ogg
+Sound names must be in the format of [song name]+[artist name]+[album]+[length in deciseconds]+[beat in deciseconds].ogg
 
 A three minute song title "SS13" that lasted 3 minutes would have a file name SS13+1800+5.ogg


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Changes how the jukebox_music config is handled, adding additional options.

Removes the redundant "track" datum on the jukebox, replacing it with the existing soundtrack_song datum.

Changes the Jukebox to use the soundtrack_song datum.

Adds round end crediting to any songs played by the jukebox.

Adds round end crediting for the selected lobby song.

Adds a no-fire Soundtrack subsystem, which generates all tracks for the jukeboxes, rather than having each jukebox generate a list for itself on initialize.

NOTE: This requires all existing jukebox music to be updated to:
[song name]+[artist name]+[album]+[length in deciseconds]+[beat in deciseconds].ogg

## Why It's Good For The Game

We have big plans with this one, music is coming Soon™ to jukeboxes.
Also, crediting artists is good!


## Changelog

:cl:
add: Jukebox music now credits the artist in the round-end credits.
add: Lobby music now displays the song name in the round-end credits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
