### PR TITLE
Sulfonal Changes

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -626,7 +626,7 @@
 /datum/reagent/toxin/sulfonal/on_mob_life(mob/living/carbon/M)
 	if(current_cycle >= 22 && prob(50))
 		M.Sleeping(2 SECONDS, 0)
-	affected.dizziness += 1
+	M.dizziness += 1
 	return ..()
 
 /datum/reagent/toxin/amanitin

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -600,16 +600,33 @@
 
 /datum/reagent/toxin/sulfonal
 	name = "Sulfonal"
-	description = "A stealthy poison that deals minor toxin damage and eventually puts the target to sleep."
+	description = "A stealthy poison that deals minor toxin damage and eventually puts the target to sleep. May cause side effects in high dosages."
 	silent_toxin = TRUE
 	reagent_state = LIQUID
 	color = "#7DC3A0"
-	metabolization_rate = 0.125 * REAGENTS_METABOLISM
+	overdose_threshold = 8 //Based off the LDLo of Sulfonmethane on a 60kg human. 8 grams would be the lethal dosage, so I'm considering that 8u
+	metabolization_rate = 0.2 * REAGENTS_METABOLISM
 	toxpwr = 0.5
 
+//MonkeStation Edit: Sulfonal Nerf/Changes
+/datum/reagent/toxin/sulfonal/overdose_process(mob/living/M)
+
+	//Side effects of Sulfonmethane/Sulfonal include dizziness, abnormal sensation and difficulties breathing.
+
+	if(HAS_TRAIT(M, TRAIT_NOBREATH))
+		return
+	if(iscarbon(M) && prob(33))
+		var/mob/living/carbon/affected = M
+		affected.adjustOxyLoss(2, 0)
+		affected.dizziness += 2
+		affected.losebreath += 1
+		if(prob(20))
+			affected.emote("gasp")
+
 /datum/reagent/toxin/sulfonal/on_mob_life(mob/living/carbon/M)
-	if(current_cycle >= 22)
-		M.Sleeping(40, 0)
+	if(current_cycle >= 22 && prob(50))
+		M.Sleeping(2 SECONDS, 0)
+	affected.dizziness += 1
 	return ..()
 
 /datum/reagent/toxin/amanitin


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Rebalances Sulfonal to no longer be a perfect knockout drug for infinite sleep.

Cuts the sleeping time in half, with a 50% chance of even triggering.
Adds minor dizziness to Sulfonal.

Adds an overdose threshold to Sulfonal. (8u)
Overdosing will cause oxyloss and dizziness, with the victim eventually suffocating in high dosages.


## Why It's Good For The Game

The strength of this chemical has always been on the extreme end of 'boring' due to players having no real counter to endless sleep.
If someone shoots you with a huge amount of this, you will die and actually get to be a ghost.
This also means that non-antagonists cannot OD someone on this drug and expect to "safely" use it on someone anymore.

## Changelog

:cl:
balance: Sulfonal is now less effective as a sleeping chemical
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
