### PR TITLE
Gives Pubbystation the new clown box

### DIFF
--- a/_maps/RandomRooms/3x5/sk_rdm085_hank.dmm
+++ b/_maps/RandomRooms/3x5/sk_rdm085_hank.dmm
@@ -15,7 +15,7 @@
 /turf/open/floor/mineral/bananium,
 /area/template_noop)
 "d" = (
-/obj/structure/closet/crate/wooden/toy,
+/obj/structure/closet/crate/secure/clown/toy,
 /turf/open/floor/mineral/bananium,
 /area/template_noop)
 "e" = (

--- a/_maps/map_files/FlandStation/FlandStation.dmm
+++ b/_maps/map_files/FlandStation/FlandStation.dmm
@@ -90164,7 +90164,7 @@
 /turf/open/floor/plasteel/checker,
 /area/quartermaster/storage)
 "vcV" = (
-/obj/structure/closet/crate/wooden/toy,
+/obj/structure/closet/crate/secure/clown/toy,
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/requests_console{

--- a/monkestation/_maps/RandomRooms/_Bars/Pubby/default_bar.dmm
+++ b/monkestation/_maps/RandomRooms/_Bars/Pubby/default_bar.dmm
@@ -1197,7 +1197,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "RW" = (
-/obj/structure/closet/crate/wooden/toy,
 /obj/item/lipstick/random,
 /obj/item/clothing/gloves/color/rainbow,
 /obj/effect/turf_decal/tile/neutral{
@@ -1210,6 +1209,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/closet/crate/secure/clown/toy,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "Sp" = (

--- a/monkestation/_maps/RandomRooms/_Bars/Pubby/hobo_bar.dmm
+++ b/monkestation/_maps/RandomRooms/_Bars/Pubby/hobo_bar.dmm
@@ -327,7 +327,6 @@
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
 "pq" = (
-/obj/structure/closet/crate/wooden/toy,
 /obj/item/lipstick/random,
 /obj/item/clothing/gloves/color/rainbow,
 /obj/effect/turf_decal/tile/neutral{
@@ -340,6 +339,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/closet/crate/secure/clown/toy,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "pr" = (

--- a/monkestation/_maps/RandomRooms/_Bars/Pubby/japanese_bar.dmm
+++ b/monkestation/_maps/RandomRooms/_Bars/Pubby/japanese_bar.dmm
@@ -381,7 +381,6 @@
 	},
 /area/crew_quarters/bar)
 "pq" = (
-/obj/structure/closet/crate/wooden/toy,
 /obj/item/lipstick/random,
 /obj/item/clothing/gloves/color/rainbow,
 /obj/effect/turf_decal/tile/neutral{
@@ -394,6 +393,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/closet/crate/secure/clown/toy,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "pr" = (

--- a/monkestation/_maps/RandomRooms/_Bars/Pubby/pool_bar.dmm
+++ b/monkestation/_maps/RandomRooms/_Bars/Pubby/pool_bar.dmm
@@ -156,7 +156,7 @@
 	},
 /obj/item/clothing/gloves/color/rainbow,
 /obj/item/lipstick/random,
-/obj/structure/closet/crate/wooden/toy,
+/obj/structure/closet/crate/secure/clown/toy,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "fg" = (


### PR DESCRIPTION
# About The Pull Request

I missed some because the clown room is included in pubby's random bars, so this time I just ctrl-shift-f'd where wooden toyboxes are and changed em in strongdmm

## Why It's Good For The Game

We made a new clown box, we're gonna have the new clown box

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
tweak: Changed pubby's wooden clown toyboxes to the new clown toyboxes
/:cl:

