### PR TITLE
Minor Metastation Fixies

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -12235,7 +12235,6 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "aRj" = (
-/obj/effect/landmark/start/station_engineer,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -16224,14 +16223,14 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "bep" = (
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/cable/yellow,
-/obj/machinery/power/apc/auto_name/west{
-	pixel_x = -24
+/obj/effect/landmark/start/station_engineer,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/chair/office/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/corner{
@@ -17274,8 +17273,12 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/starboard)
 "bhS" = (
 /obj/machinery/navbeacon{
@@ -17288,7 +17291,7 @@
 /obj/structure/sign/departments/minsky/engineering/engineering{
 	pixel_x = 32
 	},
-/obj/machinery/vending/coffee,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bhT" = (
@@ -18819,7 +18822,7 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -19385,19 +19388,33 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bpg" = (
-/obj/structure/table/reinforced,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/hallway/primary/starboard)
 "bph" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engiserv";
+	name = "Engineering Services Shutter"
+	},
 /turf/open/floor/plating,
 /area/engine/storage_shared)
 "bpi" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/engine/storage_shared)
 "bpn" = (
 /obj/structure/window/reinforced{
@@ -20774,6 +20791,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/rnd/production/circuit_imprinter/department/engineering,
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/storage_shared)
 "bvf" = (
@@ -20839,6 +20857,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/storage_shared)
 "bvj" = (
@@ -31743,8 +31762,7 @@
 /obj/machinery/button/door{
 	id = "research_shutters";
 	name = "research shutters control";
-	pixel_x = 28;
-	req_access_txt = "7"
+	pixel_x = 28
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -31753,7 +31771,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "chn" = (
@@ -33646,6 +33663,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/mob/living/simple_animal/pet/dog/corgi/borgi,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "cnV" = (
@@ -34392,7 +34410,10 @@
 /turf/open/floor/plating,
 /area/science/lab)
 "cqx" = (
-/obj/machinery/cell_charger,
+/obj/machinery/cell_charger{
+	req_access_txt = nulll;
+	req_one_access_txt = null
+	},
 /obj/item/stock_parts/cell/high{
 	charge = 100;
 	maxcharge = 15000
@@ -34408,8 +34429,7 @@
 	id = "research_shutters_2";
 	name = "research shutters control";
 	pixel_x = -26;
-	pixel_y = -26;
-	req_access_txt = "7"
+	pixel_y = -26
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -38621,9 +38641,6 @@
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -38631,14 +38648,11 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
-/obj/structure/rack,
-/obj/item/book/manual/wiki/robotics_cyborgs{
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/item/storage/belt/utility,
-/obj/item/reagent_containers/glass/beaker/large,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/modular_fabricator/autolathe,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cDf" = (
@@ -38661,10 +38675,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -2;
-	pixel_y = 4
-	},
 /obj/item/assembly/prox_sensor{
 	pixel_x = -8;
 	pixel_y = 4
@@ -38674,6 +38684,7 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/cell_charger,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cDi" = (
@@ -39019,6 +39030,8 @@
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/delivery,
+/obj/item/storage/belt/utility,
+/obj/item/reagent_containers/glass/beaker/large,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cEp" = (
@@ -40126,17 +40139,11 @@
 /area/hallway/primary/aft)
 "cII" = (
 /obj/structure/table,
-/obj/item/circular_saw,
-/obj/item/scalpel{
-	pixel_y = 12
-	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	pixel_y = 1
 	},
-/obj/item/razor{
-	pixel_y = 5
-	},
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
@@ -40205,6 +40212,10 @@
 	pixel_x = 3
 	},
 /obj/effect/turf_decal/delivery,
+/obj/item/book/manual/wiki/robotics_cyborgs{
+	pixel_x = 2;
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cIP" = (
@@ -40420,12 +40431,9 @@
 /area/hallway/secondary/exit/departure_lounge)
 "cJH" = (
 /obj/structure/table,
-/obj/item/retractor,
-/obj/item/hemostat,
 /obj/item/radio/intercom{
 	pixel_x = -29
 	},
-/obj/item/cautery,
 /turf/open/floor/plasteel/white/corner{
 	dir = 4
 	},
@@ -40447,6 +40455,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/machinery/ecto_sniffer,
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
@@ -40470,7 +40479,6 @@
 /area/science/robotics/lab)
 "cJN" = (
 /obj/structure/table,
-/obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high{
 	charge = 100;
 	maxcharge = 15000
@@ -40493,6 +40501,10 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cJQ" = (
@@ -47893,7 +47905,7 @@
 	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Shared Engineering Storage";
-	req_one_access_txt = "32;19"
+	req_one_access_txt = "32;19;10"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -47903,7 +47915,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "eoQ" = (
 /obj/effect/landmark/start/scientist,
 /obj/structure/chair/office/light{
@@ -48152,9 +48164,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "exJ" = (
-/obj/structure/table/glass,
-/obj/item/folder,
-/obj/item/toy/figure/engineer,
+/obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "eys" = (
@@ -48540,10 +48550,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "eKF" = (
-/obj/effect/turf_decal/stripes/line,
-/mob/living/simple_animal/pet/dog/corgi/borgi,
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engiserv";
+	name = "Engineering Services Shutter"
+	},
+/turf/open/floor/plating,
+/area/engine/storage_shared)
 "eKN" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -48880,6 +48894,9 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
@@ -51107,7 +51124,7 @@
 "gjJ" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Foyer";
-	req_one_access_txt = "32;19"
+	req_one_access_txt = "32;19;10"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -52510,6 +52527,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"hcX" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "hdm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -52572,20 +52595,13 @@
 /area/security/brig)
 "hfn" = (
 /obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/closed/wall,
-/area/engine/break_room)
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "hfv" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -52768,6 +52784,9 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "hkq" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "hkP" = (
@@ -54880,6 +54899,32 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"iuU" = (
+/obj/item/folder/yellow,
+/obj/item/pen,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/westright,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engiserv";
+	name = "Engineering Services Shutter"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/eastleft{
+	name = "Engineering Services Desk";
+	req_one_access_txt = "32;19;10"
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "ivM" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -63209,6 +63254,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "nkB" = (
@@ -63934,6 +63982,9 @@
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/bot,
 /obj/item/shovel,
+/obj/item/lightreplacer{
+	pixel_y = 7
+	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "nAM" = (
@@ -64183,6 +64234,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "nHP" = (
@@ -65701,7 +65753,7 @@
 /turf/closed/wall,
 /area/crew_quarters/cryopods)
 "owR" = (
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/engine/storage_shared)
 "oxl" = (
 /obj/structure/cable/yellow{
@@ -65837,6 +65889,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"oCY" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "oDx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -66023,14 +66081,8 @@
 	c_tag = "Engineering - Foyer - Shared Storage";
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/storage_shared)
@@ -66693,15 +66745,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "pgu" = (
@@ -70453,7 +70504,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "rxt" = (
@@ -72421,6 +72477,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"sQi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = engiserv;
+	name = "Engineering Services Shutter"
+	},
+/turf/open/floor/plating,
+/area/engine/storage_shared)
 "sQs" = (
 /obj/machinery/holopad,
 /obj/structure/cable/yellow{
@@ -74454,6 +74521,19 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plasteel,
 /area/science/shuttledock)
+"umc" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/table/glass,
+/obj/item/toy/figure/engineer,
+/obj/item/poster/random_contraband,
+/turf/open/floor/plasteel/dark/corner,
+/area/engine/storage_shared)
 "umh" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/light/small,
@@ -74788,7 +74868,7 @@
 	pixel_x = 32
 	},
 /turf/closed/wall/r_wall,
-/area/engine/break_room)
+/area/engine/storage_shared)
 "uvs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75089,13 +75169,16 @@
 "uEH" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Shared Engineering Storage";
-	req_one_access_txt = "32;19"
+	req_one_access_txt = "32;19;10"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "uEU" = (
@@ -76625,6 +76708,12 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/table/reinforced,
+/obj/item/folder,
+/obj/machinery/button/door{
+	id = "engiserv";
+	name = "Engineering Service Shutter";
+	pixel_y = -26
+	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 8
 	},
@@ -76990,9 +77079,6 @@
 "vLd" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -77955,9 +78041,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft/secondary)
 "wnf" = (
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark/corner,
@@ -78042,13 +78125,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wqA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/ecto_sniffer,
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
 "wqF" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -78997,16 +79073,13 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "wPB" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
+/obj/machinery/modular_fabricator/autolathe,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/closed/wall,
 /area/engine/storage_shared)
 "wPQ" = (
 /obj/machinery/door/airlock/command{
@@ -81422,6 +81495,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
@@ -110066,7 +110142,7 @@ cDb
 cEk
 cFd
 cGb
-wqA
+cGb
 cHQ
 cIJ
 cYc
@@ -110324,7 +110400,7 @@ uIx
 cFg
 cFg
 cFg
-eKF
+cHR
 cIK
 cJJ
 cCq
@@ -120803,13 +120879,13 @@ bbt
 bcF
 beg
 aWw
-bhR
+bjE
 wxT
 xYe
 bmW
 bpe
 bry
-bry
+bpg
 tul
 bry
 bry
@@ -121066,7 +121142,7 @@ utY
 ota
 pge
 wnf
-nna
+bhR
 dEc
 jwE
 nna
@@ -121321,10 +121397,10 @@ bhT
 nde
 gjJ
 bmY
-bhT
 uvc
-bhT
-bhT
+sQi
+iuU
+eKF
 bxc
 bxc
 bAA
@@ -121577,8 +121653,8 @@ bfQ
 bhU
 bjF
 vLd
-bmZ
-hfn
+bnc
+owR
 wPB
 bep
 vzO
@@ -122348,7 +122424,7 @@ byK
 bhX
 hGe
 wWj
-bnc
+bmZ
 bph
 iHl
 eTi
@@ -122862,10 +122938,10 @@ byK
 bhZ
 utO
 dQf
-bjL
+hcX
 uEH
-hkq
-hkq
+hfn
+oCY
 bvi
 bxc
 bxc
@@ -123121,7 +123197,7 @@ mkn
 blo
 bne
 owR
-owR
+umc
 oJW
 dfx
 bxc
@@ -123377,11 +123453,11 @@ bhZ
 mkn
 blp
 bjL
-bpg
 owR
 owR
 owR
-bxd
+owR
+bxc
 byX
 bAH
 bCo

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -20846,9 +20846,7 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/item/stack/sheet/mineral/copper{
-	amount = 5
-	},
+/obj/machinery/cell_charger,
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/storage_shared)
 "bvi" = (
@@ -20858,6 +20856,9 @@
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/light,
+/obj/item/stack/sheet/mineral/copper{
+	amount = 5
+	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/storage_shared)
 "bvj" = (
@@ -34410,10 +34411,7 @@
 /turf/open/floor/plating,
 /area/science/lab)
 "cqx" = (
-/obj/machinery/cell_charger{
-	req_access_txt = nulll;
-	req_one_access_txt = null
-	},
+/obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high{
 	charge = 100;
 	maxcharge = 15000
@@ -54904,7 +54902,9 @@
 /obj/item/pen,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/westright,
+/obj/machinery/door/window/westright{
+	name = "Engineerring Service Desk"
+	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "engiserv";
 	name = "Engineering Services Shutter"

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -72483,7 +72483,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = engiserv;
+	id = "engiserv";
 	name = "Engineering Services Shutter"
 	},
 /turf/open/floor/plating,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -17278,9 +17278,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/loading_area{
+/obj/structure/railing{
 	dir = 8
 	},
+/obj/effect/turf_decal/arrows,
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/starboard)
 "bhS" = (
@@ -17308,7 +17309,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/microwave,
+/obj/machinery/microwave{
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bhV" = (
@@ -19405,6 +19408,9 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
+	},
+/obj/structure/railing{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -22736,14 +22742,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bCh" = (
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/chair/office/light{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/corner{
@@ -24121,6 +24127,10 @@
 /obj/structure/sign/departments/minsky/engineering/telecommmunications{
 	pixel_y = -32
 	},
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bIG" = (
@@ -25168,6 +25178,9 @@
 /obj/structure/dresser,
 /obj/machinery/newscaster{
 	pixel_y = 32
+	},
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
@@ -27156,17 +27169,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bRP" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/kitchen";
 	name = "Kitchen APC";
 	pixel_y = -24
 	},
 /obj/structure/cable/yellow,
-/obj/machinery/deepfryer,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/book/granter/crafting_recipe/cooking_sweets_101,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bRQ" = (
@@ -45350,9 +45363,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "dim" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/structure/sign/poster/contraband/clown{
 	pixel_x = 32;
 	layer = 3.4
@@ -46721,6 +46731,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/starboard)
 "dEC" = (
@@ -46740,6 +46753,9 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/railing{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -50907,6 +50923,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"fYO" = (
+/obj/machinery/deepfryer,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "fZi" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -54927,8 +54949,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "iuU" = (
-/obj/item/folder/yellow,
-/obj/item/pen,
+/obj/item/folder/yellow{
+	pixel_y = -8;
+	pixel_x = 4
+	},
+/obj/item/pen{
+	pixel_y = -8;
+	pixel_x = 4
+	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/westright{
@@ -55139,6 +55167,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -23
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -63972,6 +64004,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nzA" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/railing/corner,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "nzR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/template_noop,
@@ -64021,6 +64061,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/item/tank/internals/oxygen/yellow,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "nAM" = (
@@ -72924,7 +72965,6 @@
 	dir = 4
 	},
 /obj/structure/table,
-/obj/item/book/granter/crafting_recipe/cooking_sweets_101,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -73280,6 +73320,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/railing/corner{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -76751,11 +76794,19 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/table/reinforced,
-/obj/item/folder,
+/obj/item/folder{
+	pixel_y = -2;
+	pixel_x = 7
+	},
 /obj/machinery/button/door{
 	id = "engiserv";
 	name = "Engineering Service Shutter";
-	pixel_y = -26
+	pixel_y = -24;
+	pixel_x = -7
+	},
+/obj/item/reagent_containers/food/drinks/mug/cocoa{
+	pixel_y = 9;
+	pixel_x = -7
 	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 8
@@ -78086,6 +78137,9 @@
 "wnf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/railing/corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/starboard)
 "wnW" = (
@@ -115801,7 +115855,7 @@ lWr
 bKh
 bLK
 lJD
-bOU
+fYO
 bQB
 bRS
 oub
@@ -120927,7 +120981,7 @@ wxT
 xYe
 bmW
 bpe
-bry
+nzA
 bpg
 tul
 bry

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -17278,6 +17278,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/starboard)
 "bhS" = (
@@ -17298,11 +17301,6 @@
 /turf/closed/wall/r_wall,
 /area/engine/break_room)
 "bhU" = (
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -17310,6 +17308,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/microwave,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bhV" = (
@@ -18336,6 +18335,15 @@
 /area/engine/break_room)
 "blp" = (
 /obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "blr" = (
@@ -19408,12 +19416,19 @@
 	id = "engiserv";
 	name = "Engineering Services Shutter"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/engine/storage_shared)
 "bpi" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/closed/wall/r_wall,
 /area/engine/storage_shared)
 "bpn" = (
@@ -45339,7 +45354,8 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/contraband/clown{
-	pixel_x = 32
+	pixel_x = 32;
+	layer = 3.4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
@@ -47015,6 +47031,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"dNu" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/closed/wall/r_wall,
+/area/engine/storage_shared)
 "dNx" = (
 /obj/machinery/doorButtons/access_button{
 	idDoor = "xeno_airlock_exterior";
@@ -48162,6 +48185,10 @@
 /area/maintenance/starboard)
 "exJ" = (
 /obj/machinery/vending/coffee,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "eys" = (
@@ -55246,6 +55273,7 @@
 "iHl" = (
 /obj/machinery/vending/tool,
 /obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "iHF" = (
@@ -63990,6 +64018,9 @@
 /obj/item/lightreplacer{
 	pixel_y = 7
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "nAM" = (
@@ -68660,6 +68691,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"qsp" = (
+/obj/item/storage/secure/safe,
+/turf/closed/wall,
+/area/crew_quarters/theatre)
 "qsO" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -119877,7 +119912,7 @@ byN
 byN
 byN
 byN
-byN
+qsp
 qPI
 byN
 byN
@@ -122176,7 +122211,7 @@ bhW
 kNT
 bjL
 bnb
-owR
+dNu
 exJ
 njX
 qdT

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -38311,17 +38311,17 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"cCn" = (
-/turf/closed/wall/r_wall,
-/area/science/robotics/mechbay)
 "cCo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics_shutters";
 	name = "robotics shutters"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "cCq" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/lab)
@@ -38616,6 +38616,9 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics_shutters";
 	name = "robotics shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
@@ -38967,19 +38970,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"cEi" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
 "cEj" = (
 /obj/structure/table/reinforced,
 /obj/item/pen,
@@ -39000,6 +38990,9 @@
 	name = "robotics shutters"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "cEk" = (
@@ -39009,6 +39002,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -39744,10 +39740,13 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cGZ" = (
-/obj/effect/spawner/structure/window,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "cHb" = (
@@ -40132,9 +40131,6 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/primary/aft)
-"cIH" = (
-/turf/closed/wall/r_wall,
-/area/hallway/primary/aft)
 "cII" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -40217,7 +40213,10 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cIP" = (
-/obj/effect/spawner/structure/window,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "cIS" = (
@@ -52395,6 +52394,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "gXM" = (
@@ -61368,8 +61370,11 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
+/area/science/robotics/lab)
 "mgi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75337,6 +75342,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -109623,14 +109631,14 @@ cxC
 cvH
 wwX
 cvH
-cvH
+cDi
 cqv
-cEi
+cpb
 cCq
 cCq
 cCq
 cCq
-cIH
+cCq
 cCq
 cCq
 inW
@@ -109880,7 +109888,7 @@ cyq
 czi
 shT
 cBg
-cCn
+cCq
 cDa
 cEj
 cCq
@@ -110651,7 +110659,7 @@ cys
 czk
 cAo
 cBi
-cCn
+cCq
 cDd
 jyE
 cFf
@@ -112457,7 +112465,7 @@ sHY
 dVZ
 cHb
 xCL
-cwN
+cHb
 wqH
 eno
 iWK

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -17309,9 +17309,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bhV" = (
@@ -33692,7 +33689,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/mob/living/simple_animal/pet/dog/corgi/borgi,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "cnV" = (
@@ -40200,6 +40196,7 @@
 /area/science/robotics/lab)
 "cIM" = (
 /obj/effect/turf_decal/delivery,
+/mob/living/simple_animal/pet/dog/corgi/borgi,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cIN" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

There are some things about MetaStation that really piss me off! Like the r&d shutters not working, I got tired of waiting for someone else to fix these. This fixes a few of Meta's idiosynchracies and I elected to add some cool new shit while I was there, like a front desk for engineering. 

## Why It's Good For The Game

- Me fix sad, bad things lame and broken, 
- Me add new thing, good, help engineers give thing without getting tided

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/14065903/183228913-0a6b39ff-a22b-49ae-9724-0e2bc6588a25.png)
![image](https://user-images.githubusercontent.com/14065903/183228877-1e0c866f-edcd-472a-9f7d-13abaeefe734.png)
![image](https://user-images.githubusercontent.com/14065903/183228900-416fda46-8b73-4f29-a9ca-02fbe0083e1d.png)


## Changelog

 :cl:
fix: Fixes the shutter buttons in Metastation R&D
tweak: Minor changes to robotics (IE the surgical tools for roboticists spawn in a surgical duffel, robotics' windows are all electrified and made of reinforced glass in parity with the rest of the department, etc)
add: Adds a lovely engineering service desk with shutter so you can serve people without letting their disgusting filth into your place of work
fix: Adjusts the doors that govern access to Engineering's foyer and lathe, _(Previously, when you wanted the HOP to give you access to engineering, he actually needed to grant "Engineering" and "Construction" to let you in the front door, now people granted the "Engineering" access can access the lathe)_
add: Adds a secret safe hidden behind the clown poster, this is a deep, philosophical nod to how the mime is overshadowed by the clown
tweak: Improves lighting conditions of the kitchen at the behest of LME
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
