### PR TITLE
Slightly nerfs the ghost of honks past

### DIFF
--- a/monkestation/code/modules/antagonists/living_lube/living_lube_abilities.dm
+++ b/monkestation/code/modules/antagonists/living_lube/living_lube_abilities.dm
@@ -1,5 +1,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/knock/living_lube
 	action_background_icon_state = "bg_hive" //closest to a pink spell color we have
+	charge_max = 30 SECONDS
+	range = 6
 	invocation = "AULIE HONKSIN FIERA"
 	invocation_type = "whisper"
 
@@ -16,7 +18,7 @@
 /obj/effect/proc_holder/spell/targeted/displacement
 	name = "Displacement"
 	desc = "Force someone through the clown dimension and launch them out somewhere else on the station."
-	charge_max = 90 SECONDS
+	charge_max = 2 MINUTES
 	clothes_req = FALSE
 	range = 7
 	invocation_type = "none"

--- a/monkestation/code/modules/antagonists/living_lube/living_lube_abilities.dm
+++ b/monkestation/code/modules/antagonists/living_lube/living_lube_abilities.dm
@@ -1,7 +1,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/knock/living_lube
 	action_background_icon_state = "bg_hive" //closest to a pink spell color we have
 	charge_max = 30 SECONDS
-	range = 6
+	range = 5
 	invocation = "AULIE HONKSIN FIERA"
 	invocation_type = "whisper"
 


### PR DESCRIPTION
# About The Pull Request

Increased the Displacement cooldown to 2 minutes. After playing as it for a round, and hearing what a couple people said, I think 2 minutes is good. maybe 2:30 - 3 minutes another time at Most if its still a problem. When I played as it, I didn't use displacement nearly as much as I could have, and I imagine using it every time the cooldown ended would cause a lot more rage than funny haha clown annoyance

Increased the Knock cooldown to 30 seconds, and increased the range to 5 to compensate for goofy double doors further than 3 tiles. The problem with knock is that the ghost had too much access everywhere. This doesn't completely nullify its access, but it does make it a bit easier to deal with when chasing or getting away from it.

## Why It's Good For The Game

funny clown is too good.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
balance: Increases honks past's displacement cooldown to 2 minutes
balance: Increases honks past's knock cooldown to 30 seconds, but also increases the range to 6
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
