### PR TITLE
Allows medical gown and invisible jumpsuit to work with digitigrade legs

### DIFF
--- a/monkestation/code/modules/clothing/under/miscellaneous.dm
+++ b/monkestation/code/modules/clothing/under/miscellaneous.dm
@@ -7,7 +7,8 @@
 	item_state = "medical_gown"
 	alt_covers_chest = FALSE
 	fitted = NO_FEMALE_UNIFORM
-	
+	supports_variations = DIGITIGRADE_VARIATION_NO_NEW_ICON
+
 /obj/item/clothing/under/invisible
 	name = "invisible jumpsuit"
 	desc = "Some sort of jumpsuit that disappears when worn, but still behaves as a normal jumpsuit."
@@ -17,3 +18,4 @@
 	item_state = "invisible"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	can_adjust = FALSE
+	supports_variations = DIGITIGRADE_VARIATION_NO_NEW_ICON


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Currently the medical gown and invisible jumpsuit turn digitigrade lizards plantigrade when they wear them.  This doesn't make much sense as neither covers the legs.  And is particularly jarring for the invisible jumpsuit.

## Why It's Good For The Game

Consistency!

## Changelog

:cl:
fix: digitigrade legs now work properly with the medical gown and invisible jumpsuit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
