### PR TITLE
Fixed Some MetaStation Bar Lighting

### DIFF
--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -617,8 +617,6 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "bar"
 	mood_bonus = 5
 	mood_message = "<span class='nicegreen'>I love being in the bar!\n</span>"
-	lighting_colour_tube = "#fff4d6"
-	lighting_colour_bulb = "#ffebc1"
 	sound_environment = SOUND_AREA_WOODFLOOR
 
 /area/crew_quarters/bar/bar_spawn_area

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -617,6 +617,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	icon_state = "bar"
 	mood_bonus = 5
 	mood_message = "<span class='nicegreen'>I love being in the bar!\n</span>"
+//	lighting_colour_tube = "#fff4d6" //MonkeStation Edit for Random Bars
+//	lighting_colour_bulb = "#ffebc1"
 	sound_environment = SOUND_AREA_WOODFLOOR
 
 /area/crew_quarters/bar/bar_spawn_area

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -20,7 +20,7 @@
 	///Amount of power used
 	var/static_power_used = 0
 	///Luminosity when on, also used in power calculation
-	var/brightness = 8
+	var/brightness = 10
 	///Basically the alpha of the emitted light source
 	var/bulb_power = 1
 	///Default colour of the light.

--- a/code/modules/power/lighting/light_mapping_helpers.dm
+++ b/code/modules/power/lighting/light_mapping_helpers.dm
@@ -43,7 +43,13 @@
 /obj/machinery/light/dim
 	nightshift_allowed = FALSE
 	bulb_colour = "#FFDDCC"
-	bulb_power = 0.6
+	bulb_power = 0.4
+
+/obj/machinery/light/extra_dim
+	nightshift_allowed = FALSE
+	bulb_colour = "#e0a181"
+	bulb_power = 0.2
+
 
 // the smaller bulb light fixture
 
@@ -83,6 +89,20 @@
 	brightness = 2
 	bulb_power = 0.9
 
+/obj/machinery/light/small/dim
+	nightshift_allowed = FALSE
+	bulb_colour = "#FFDDCC"
+	bulb_power = 0.4
+	nightshift_allowed = FALSE
+
+/obj/machinery/light/small/extra_dim
+	nightshift_allowed = FALSE
+	bulb_colour = "#e0a181"
+	bulb_power = 0.2
+	nightshift_allowed = FALSE
+
+
+
 // -------- Directional presets
 // The directions are backwards on the lights we have now
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light, 0)
@@ -120,6 +140,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/blacklight, 0)
 // ---- Dim tubes
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/dim, 0)
 
+// ---- Extra-Dim tubes
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/extra_dim, 0)
 
 // -------- Bulb lights
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small, 0)
@@ -138,3 +160,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/red, 0)
 
 // ---- Blacklight bulbs
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/blacklight, 0)
+
+// ---- Dim bulbs
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/dim, 0)
+
+// ---- Extra-Dim bulbs
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light/small/extra_dim, 0)

--- a/monkestation/_maps/RandomRooms/_Bars/Meta/default_bar.dmm
+++ b/monkestation/_maps/RandomRooms/_Bars/Meta/default_bar.dmm
@@ -199,6 +199,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"w" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "y" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -556,7 +564,7 @@ E
 O
 a
 p
-a
+w
 O
 "}
 (9,1,1) = {"

--- a/monkestation/_maps/RandomRooms/_Bars/Meta/tribal_bar.dmm
+++ b/monkestation/_maps/RandomRooms/_Bars/Meta/tribal_bar.dmm
@@ -99,11 +99,8 @@
 /turf/open/floor/grass/fakebasalt,
 /area/crew_quarters/bar)
 "p" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
 /mob/living/carbon/monkey/punpun,
+/obj/machinery/light/small/dim/directional/west,
 /turf/open/floor/grass/fakebasalt,
 /area/crew_quarters/bar)
 "r" = (
@@ -145,6 +142,13 @@
 /obj/machinery/disposal/bin,
 /obj/machinery/light_switch{
 	pixel_x = 25
+	},
+/turf/open/floor/grass/fakebasalt,
+/area/crew_quarters/bar)
+"x" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26
 	},
 /turf/open/floor/grass/fakebasalt,
 /area/crew_quarters/bar)
@@ -293,6 +297,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/beach/sand,
 /area/crew_quarters/bar)
+"T" = (
+/obj/machinery/light/small/dim/directional/east,
+/turf/open/floor/grass/fakebasalt,
+/area/crew_quarters/bar)
 "U" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -328,6 +336,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/machinery/light/small/dim/directional/west,
 /turf/open/floor/grass/fakebasalt,
 /area/crew_quarters/bar)
 
@@ -345,7 +354,7 @@ A
 (2,1,1) = {"
 p
 M
-J
+x
 J
 M
 J
@@ -417,7 +426,7 @@ y
 M
 z
 f
-J
+T
 "}
 (9,1,1) = {"
 A


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
 Added a light to MetaStation Default Bar around kitchen bar so it isn't dark there. Players would always try to build new lights there because of the issue.
Added Mapping helpers for dim Lights and extra dim lights
Added Dim Lights to Tribal bar so it doesn't have pitch black corners,
Removed BarArea lighting color. Since bars are modular they often have lighting themes, If we want to further tweak them we can either create new areas under the bar area that have the colors set or create more light presets; however, that would make things a bit annoying I think if someone wants vary lighting for a bar. Luckily, with the current light presets what is needed may already be fulfilled for current bulbs and lighting tubes.

_IDEA FOR A LATER PR:_ Thought about doing the torches for the tribalbar, but the current fire torches need a wall mount coded in so you can place them and I guess remove them. Should be an easy coding project if someone wants too.

## Why It's Good For The Game
Less player frustration from MetaStation Default Bar and crew can see a bit better in tribal bar.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/101475356/183562804-2154f2ae-a993-4007-8658-5be8a2e9ae33.png)

![image](https://user-images.githubusercontent.com/101475356/183562836-3d06707e-d825-49e4-963c-59965c10451c.png)

</details>

## Changelog

:cl:
add: Added a light to MetaStation Default Bar around kitchen bar so it isn't dark there
add: Added Mapping helpers for dim Lights and extra dim lights
add: Added Dim Lights to Tribal bar so it doesn't have pitch black corners,
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
