### PR TITLE
Operating Computer Uses alldirs

### DIFF
--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -49,7 +49,7 @@
 		advanced_surgeries |= D.surgery
 
 /obj/machinery/computer/operating/proc/find_table()
-	for(var/direction in GLOB.cardinals)
+	for(var/direction in GLOB.alldirs)
 		table = locate(/obj/structure/table/optable) in get_step(src, direction)
 		if(table)
 			table.computer = src

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -21,7 +21,7 @@
 
 /obj/machinery/stasis/Initialize(mapload)
 	. = ..()
-	for(var/direction in GLOB.cardinals)
+	for(var/direction in GLOB.alldirs)
 		op_computer = locate(/obj/machinery/computer/operating) in get_step(src, direction)
 		if(op_computer)
 			op_computer.sbed = src

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -568,7 +568,7 @@
 
 /obj/structure/table/optable/Initialize(mapload)
 	. = ..()
-	for(var/direction in GLOB.cardinals)
+	for(var/direction in GLOB.alldirs)
 		computer = locate(/obj/machinery/computer/operating) in get_step(src, direction)
 		if(computer)
 			computer.table = src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
The operating computer only used the cardinal directions for finding its table, so this changes it so it uses the other inter-cardinal directions so you layout the operating and stasis tables in different orientations around them on maps.

## Why It's Good For The Game
More options for operation layouts

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots</summary>

![image](https://user-images.githubusercontent.com/101475356/183748832-db5b560d-5c60-4435-aa01-967d30fade7b.png)

</details>

## Changelog

:cl:
tweak: Operating Computers placed NE,NW,SE,SW from operating tables can find the table now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
