### PR TITLE
Crayon Logging

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -246,6 +246,7 @@
 			var/txt = stripped_input(usr,"Choose what to write.",
 				"Scribbles",default = text_buffer)
 			text_buffer = crayon_text_strip(txt)
+			log_game("[usr] ([usr.key]) inserted \"[text_buffer]\" as crayon input.")
 			. = TRUE
 			paint_mode = PAINT_NORMAL
 			drawtype = "a"
@@ -397,9 +398,10 @@
 	var/fraction = min(1, . / reagents.maximum_volume)
 	if(affected_turfs.len)
 		fraction /= affected_turfs.len
-	for(var/t in affected_turfs)
+	for(var/turf/t in affected_turfs)
 		reagents.reaction(t, TOUCH, fraction * volume_multiplier)
 		reagents.trans_to(t, ., volume_multiplier, transfered_by = user)
+		t.add_hiddenprint(user)
 	check_empty(user)
 
 /obj/item/toy/crayon/attack(mob/M, mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Adds a hidden fingerprint to the turf painted.

Adds a log to all crayon text input.

## Why It's Good For The Game

Administrative accounting assuming accurate administration actions.

## Changelog

:cl:
admin: We have 1984'd your art.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
