### PR TITLE
atmos analyzers report volume even for empty containers

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -583,6 +583,7 @@ GENE SCANNER
 				to_chat(user, "<span class='notice'>This node is empty!</span>")
 			else
 				to_chat(user, "<span class='notice'>[target] is empty!</span>")
+			to_chat(user, "<span class='notice'>Volume: [volume] L</span>")
 
 		if(cached_scan_results && cached_scan_results["fusion"]) //notify the user if a fusion reaction was detected
 			var/instability = round(cached_scan_results["fusion"], 0.01)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -431,7 +431,7 @@ GENE SCANNER
 	advanced = TRUE
 
 /obj/item/analyzer
-	desc = "A hand-held environmental scanner which reports current gas levels. Alt-Click to use the built in barometer function."
+	desc = "A hand-held environmental scanner which can scan the gases in the atmosphere or in a container. Can also be used to scan unusual station phenomena. Alt-Click to use the built in barometer function."
 	name = "analyzer"
 	custom_price = 10
 	icon = 'icons/obj/device.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Atmos scans (analyzer, ghost view, whatever) will now report the volume for a container, even if the container is empty.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Currently, you can only determine the capacity of a given container (pipe, canister, etc) by putting gas in it. If the container is empty, no information is shown other than it is empty; when gas is inside, it will show the volume (as well as the pressure, mol amount, etc)

This makes it so that you can tell the capacity of a given container without having to sprinkle in some gas first, ergo you can tell that an empty air pump or air scrubber can hold 1000 L.


## Testing Photographs and Procedure

https://cdn.discordapp.com/attachments/808983978459004968/1007733890636578858/unknown.png


## Changelog

:cl:
tweak: atmos analyzers/gas scan now reports volume of a container, even if it is empty
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
