### PR TITLE
Stops roundstart quirk and metacoin items from dropping or being lost

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -90,11 +90,7 @@
 /datum/quirk/musician/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/choice_beacon/music/B = new(get_turf(H))
-	var/list/slots = list (
-		"backpack" = ITEM_SLOT_BACKPACK,
-		"hands" = ITEM_SLOT_HANDS,
-	)
-	H.equip_in_one_of_slots(B, slots , qdel_on_fail = TRUE)
+	SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_INSERT, B, H, TRUE, TRUE) //insert the item, even if the backpack's full
 
 /datum/quirk/multilingual
 	name = "Multilingual"
@@ -167,14 +163,7 @@
 /datum/quirk/photographer/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/camera/camera = new(get_turf(H))
-	var/list/camera_slots = list (
-		"neck" = ITEM_SLOT_NECK,
-		"left pocket" = ITEM_SLOT_LPOCKET,
-		"right pocket" = ITEM_SLOT_RPOCKET,
-		"backpack" = ITEM_SLOT_BACKPACK,
-		"hands" = ITEM_SLOT_HANDS
-	)
-	H.equip_in_one_of_slots(camera, camera_slots , qdel_on_fail = TRUE)
+	SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_INSERT, camera, H, TRUE, TRUE) //insert the item, even if the backpack's full
 	H.regenerate_icons()
 
 /datum/quirk/selfaware
@@ -200,8 +189,10 @@
 
 /datum/quirk/spiritual/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
-	H.equip_to_slot_or_del(new /obj/item/storage/fancy/candle_box(H), ITEM_SLOT_BACKPACK)
-	H.equip_to_slot_or_del(new /obj/item/storage/box/matches(H), ITEM_SLOT_BACKPACK)
+	var/obj/item/storage/fancy/candle_box/candles = new(get_turf(H))
+	var/obj/item/storage/box/matches/matches = new(get_turf(H))
+	SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_INSERT, candles, H, TRUE, TRUE) //insert the item, even if the backpack's full
+	SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_INSERT, matches, H, TRUE, TRUE)
 
 /datum/quirk/spiritual/on_process()
 	var/comforted = FALSE
@@ -225,8 +216,7 @@
 /datum/quirk/tagger/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/toy/crayon/spraycan/spraycan = new(get_turf(H))
-	H.put_in_hands(spraycan)
-	H.equip_to_slot(spraycan, ITEM_SLOT_BACKPACK)
+	SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_INSERT, spraycan, H, TRUE, TRUE) //insert the item, even if the backpack's full
 	H.regenerate_icons()
 
 /datum/quirk/voracious

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -167,9 +167,6 @@
 			if(H.equip_to_appropriate_slot(item))
 				to_chat(M, "<span class='notice'>Placing [G.display_name] in your inventory!</span>")
 				continue
-			if(H.put_in_hands(item))
-				to_chat(M, "<span class='notice'>Placing [G.display_name] in your hands!</span>")
-				continue
 
 			var/obj/item/storage/B = (locate() in H)
 			if(B)

--- a/monkestation/code/datums/traits/good.dm
+++ b/monkestation/code/datums/traits/good.dm
@@ -38,8 +38,4 @@
 /datum/quirk/controlled_prosthetic/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/choice_beacon/prosthetic/B = new(get_turf(H))
-	var/list/slots = list (
-		"backpack" = ITEM_SLOT_BACKPACK,
-		"hands" = ITEM_SLOT_HANDS,
-	)
-	H.equip_in_one_of_slots(B, slots , qdel_on_fail = TRUE)
+	SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_INSERT, B, H, TRUE, TRUE) //insert the item, even if the backpack's full

--- a/monkestation/code/datums/traits/negative.dm
+++ b/monkestation/code/datums/traits/negative.dm
@@ -18,7 +18,7 @@
 
 /datum/quirk/stowaway
 	name = "Stowaway"
-	desc = "You're a station stowaway with no ID card that wakes up inside a random locker, who knows where you'll end up?"
+	desc = "You wake up up inside a random locker with no ID card.  You still have an employee contract on file, at least."
 	value = -2
 
 /datum/quirk/stowaway/on_spawn()

--- a/monkestation/code/datums/traits/neutral.dm
+++ b/monkestation/code/datums/traits/neutral.dm
@@ -10,7 +10,7 @@
 	W.hair_style = H.hair_style
 	log_world(H.hair_color)
 	log_world(H.hair_style)
-	H.equip_to_slot_if_possible(W, ITEM_SLOT_BACKPACK)
+	SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_INSERT, W, H, TRUE, TRUE) //insert the item, even if the backpack's full
 	W.update_icon()
 	H.dna.species.go_bald(H)
 
@@ -23,11 +23,7 @@
 /datum/quirk/anime/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/choice_beacon/anime/B = new(get_turf(H))
-	var/list/slots = list (
-		"backpack" = ITEM_SLOT_BACKPACK,
-		"hands" = ITEM_SLOT_HANDS,
-	)
-	H.equip_in_one_of_slots(B, slots , qdel_on_fail = TRUE)
+	SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_INSERT, B, H, TRUE, TRUE) //insert the item, even if the backpack's full
 
 /datum/quirk/gigantism
 	name = "Gigantism"
@@ -51,8 +47,4 @@
 /datum/quirk/nudist/on_spawn()
 	var/mob/living/carbon/human/person = quirk_holder
 	var/obj/item/clothing/under/invisible/clothing = new(get_turf(person))
-	var/list/slots = list (
-		"backpack" = ITEM_SLOT_BACKPACK,
-		"hands" = ITEM_SLOT_HANDS,
-	)
-	person.equip_in_one_of_slots(clothing , slots , qdel_on_fail = TRUE)
+	SEND_SIGNAL(person.back, COMSIG_TRY_STORAGE_INSERT, clothing, person, TRUE, TRUE) //insert the item, even if the backpack's full


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

The existing system for items added at spawn has a tendency to fuck up.  There are a lot of calls that simply delete and item that can't be put in your inventory, or drops it on the floor.  This is a particular problem with the paraplegic and stowaway quirks, which knock the player down and can cause them to drop or even lose items before the round starts.

This changes all the quirks that give items to force them into your backpack, which is likely to temporarily overload it but avoids any and all issues.

It also changes metacoin shop items to never be put in your hands, so you won't drop them immediately if you're knocked over.

This also condenses the stowaway quirk description and makes it mention employee contracts, a reminder that could be vital in some scenarios.  Which was the original goal of this PR.  Funny how things balloon.

## Why It's Good For The Game

People bought those quirks and shop items because they want them!  Weird bugs robbing players and throwing random items god-knows-where are bad!

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
I added all item-adding traits to myself, and stowaway, and respawned several times.  I retained all items and never dropped any.  I also edited metacoins so I could buy several vanity items and repeated that, and my backpack was even more overloaded but I had everything I should have.

</details>

## Changelog

:cl:
fix: fixed issues with roundstart items from quirks and the coin shop sometimes being dropped or lost
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
