### PR TITLE
Increases Experimenter Linking Range

### DIFF
--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -177,7 +177,7 @@
 		usr << browse(null, "window=experimentor")
 		return
 	if(scantype == "search")
-		var/obj/machinery/computer/rdconsole/D = locate(/obj/machinery/computer/rdconsole) in oview(3,src)
+		var/obj/machinery/computer/rdconsole/D = locate(/obj/machinery/computer/rdconsole) in oview(5,src)
 		if(D)
 			linked_console = D
 	else if(scantype == "eject")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Increases the range that the Experimentor searches to link with the R&D console from `oview(3,src)` to `oview(5,src)`.

## Why It's Good For The Game
BoxStation has the experimenter just out of range of its scanner to reach the R&D console, so I slightly increased the range. Hopefully this prevents some future weird placements of the experimenter console and gives it a bit more flexibility when mapping the lab.

## Testing Photographs and Procedure
Spawn in game  and linked the console, It links correctly now.

## Changelog

:cl:
tweak: Tweaked Experimentors linking range, so now BoxStation's Experimentor can detech the console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
