### PR TITLE
Making circuits better

### DIFF
--- a/code/__DEFINES/wiremod.dm
+++ b/code/__DEFINES/wiremod.dm
@@ -147,7 +147,7 @@
 #define COMP_SOUND_SLOWCLAP "Slow Clap"
 
 // Security Arrest Console
-#define COMP_STATE_ARREST "*Arrest*"
+#define COMP_STATE_ARREST "Arrest"
 #define COMP_STATE_PRISONER "Incarcerated"
 #define COMP_STATE_PAROL "Paroled"
 #define COMP_STATE_DISCHARGED "Discharged"

--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -81,7 +81,7 @@
 	if(shell_flags & SHELL_FLAG_USB_PORT)
 		examine_text += "<span class='notice'>There is a <b>USB port</b> on the front.</span>"
 
-	if(parent.anchored)
+	if(shell_flags & SHELL_FLAG_REQUIRE_ANCHOR)
 		examine_text += span_notice("The shell does not require a battery to function and will draw from the area's APC while anchored.")
 
 

--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -78,8 +78,11 @@
 	var/obj/item/stock_parts/cell/cell = attached_circuit.cell
 	examine_text += "<span class='notice'>The charge meter reads [cell ? round(cell.percent(), 1) : 0]%.</span>"
 
-	if (shell_flags & SHELL_FLAG_USB_PORT)
+	if(shell_flags & SHELL_FLAG_USB_PORT)
 		examine_text += "<span class='notice'>There is a <b>USB port</b> on the front.</span>"
+
+	if(shell.anchored)
+		examine_text += span_notice("The shell does not require a battery to function and will draw from the area's APC while anchored.")
 
 
 /**

--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -101,14 +101,25 @@
 		source.balloon_alert(attacker, "Can't pull cell in directly!")
 		return
 
-	if(attached_circuit?.owner_id && item == attached_circuit.owner_id.resolve())
-		locked = !locked
-		source.balloon_alert(attacker, "[locked? "Locked" : "Unlocked"] [source]")
+	if(istype(item, /obj/item/inducer))
+		var/obj/item/inducer/inducer = item
+		INVOKE_ASYNC(inducer, /obj/item.proc/attack_obj, attached_circuit, attacker, list())
 		return COMPONENT_NO_AFTERATTACK
 
-	if(attached_circuit && istype(item, /obj/item/circuit_component))
-		attached_circuit.add_component(item, attacker)
-		return
+	if(attached_circuit)
+		if(attached_circuit.owner_id && item == attached_circuit.owner_id.resolve())
+			locked = !locked
+			source.balloon_alert(attacker, "[locked? "Locked" : "Unlocked"] [source]")
+			return COMPONENT_NO_AFTERATTACK
+
+		if(!attached_circuit.owner_id && istype(item, /obj/item/card/id))
+			source.balloon_alert(attacker, "owner id set for [item]")
+			attached_circuit.owner_id = WEAKREF(item)
+			return COMPONENT_NO_AFTERATTACK
+
+		if(istype(item, /obj/item/circuit_component))
+			attached_circuit.add_component(item, attacker)
+			return
 
 	if(!istype(item, /obj/item/integrated_circuit))
 		return

--- a/code/datums/components/shell.dm
+++ b/code/datums/components/shell.dm
@@ -81,7 +81,7 @@
 	if(shell_flags & SHELL_FLAG_USB_PORT)
 		examine_text += "<span class='notice'>There is a <b>USB port</b> on the front.</span>"
 
-	if(shell.anchored)
+	if(parent.anchored)
 		examine_text += span_notice("The shell does not require a battery to function and will draw from the area's APC while anchored.")
 
 

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -64,7 +64,7 @@
 	update_icon()
 	myarea = get_area(src)
 	LAZYADD(myarea.firealarms, src)
-	AddComponent(/datum/component/shell, list(new /obj/item/circuit_component/firealarm()), SHELL_CAPACITY_LARGE)
+	AddComponent(/datum/component/shell, list(new /obj/item/circuit_component/firealarm()), SHELL_CAPACITY_MEDIUM)
 
 /obj/machinery/firealarm/Destroy()
 	myarea.firereset(src)
@@ -421,12 +421,10 @@ Ported from /tg/station: PR #64985
 	is_on.set_output(1)
 	output_set.set_output(COMPONENT_SIGNAL)
 
-
 /obj/item/circuit_component/firealarm/proc/on_firealarm_reset(atom/source)
 	SIGNAL_HANDLER
 	is_on.set_output(0)
 	output_reset.set_output(COMPONENT_SIGNAL)
-
 
 /obj/item/circuit_component/firealarm/input_received(datum/port/input/port)
 	. = ..()

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -15,11 +15,9 @@
 
 /obj/machinery/light_switch/Initialize(mapload)
 	. = ..()
-/*
-	AddComponent(/datum/component/usb_port, list(
-		/obj/item/circuit_component/light_switch,
-	))
-*/
+
+	AddComponent(/datum/component/shell, list(new /obj/item/circuit_component/light_switch()), SHELL_CAPACITY_SMALL)
+
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light_switch, 26)
 
 /obj/machinery/light_switch/Initialize(mapload)
@@ -94,7 +92,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light_switch, 26)
 	if(do_after(eminence, 20, target=get_turf(eminence)))
 		interact(eminence)
 
-/* WIREMOD
+//Monkestation Edit - Readds the commented out lightswitch circuit
+//Circuit Component
 /obj/item/circuit_component/light_switch
 	display_name = "Light Switch"
 	desc = "Allows to control the lights of an area."
@@ -104,28 +103,39 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light_switch, 26)
 	var/datum/port/input/on_setting
 	///Whether the lights are turned on
 	var/datum/port/output/is_on
+	///Triggers whenever the switch is toggled
+	var/datum/port/output/toggled
 
-	var/obj/machinery/light_switch/attached_switch
-
-/obj/item/circuit_component/light_switch/populate_ports()
+/obj/item/circuit_component/light_switch/Initialize(mapload)
+	. = ..()
 	on_setting = add_input_port("On", PORT_TYPE_NUMBER)
 	is_on = add_output_port("Is On", PORT_TYPE_NUMBER)
+	toggled = add_output_port("Toggled", PORT_TYPE_SIGNAL)
 
-/obj/item/circuit_component/light_switch/register_usb_parent(atom/movable/parent)
-	. = ..()
-	if(istype(parent, /obj/machinery/light_switch))
-		attached_switch = parent
-		RegisterSignal(parent, COMSIG_LIGHT_SWITCH_SET, .proc/on_light_switch_set)
+/obj/item/circuit_component/light_switch/register_shell(atom/movable/shell)
+	RegisterSignal(shell, COMSIG_LIGHT_SWITCH_SET, .proc/on_light_switch_set)
 
-/obj/item/circuit_component/light_switch/unregister_usb_parent(atom/movable/parent)
-	attached_switch = null
-	UnregisterSignal(parent, COMSIG_LIGHT_SWITCH_SET)
-	return ..()
+/obj/item/circuit_component/light_switch/unregister_shell(atom/movable/shell)
+	UnregisterSignal(shell, COMSIG_LIGHT_SWITCH_SET)
 
 /obj/item/circuit_component/light_switch/proc/on_light_switch_set(datum/source, status)
 	SIGNAL_HANDLER
 	is_on.set_output(status)
+	toggled.set_output(COMPONENT_SIGNAL)
+
+/obj/item/circuit_component/light_switch/Destroy()
+	on_setting = null
+	is_on = null
+	toggled = null
+	return ..()
 
 /obj/item/circuit_component/light_switch/input_received(datum/port/input/port)
-	attached_switch?.set_lights(on_setting.value ? TRUE : FALSE)
-*/
+	. = ..()
+	if(.)
+		return
+
+	var/obj/machinery/light_switch/shell = parent.shell
+	if(!istype(shell))
+		return
+	shell.set_lights(on_setting.input_value ? TRUE : FALSE)
+

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -134,8 +134,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light_switch, 26)
 	if(.)
 		return
 
-	if(!COMPONENT_TRIGGERED_BY(trigger,port))
-		return
 
 	var/obj/machinery/light_switch/shell = parent.shell
 	if(!istype(shell))

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -134,6 +134,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/light_switch, 26)
 	if(.)
 		return
 
+	if(!COMPONENT_TRIGGERED_BY(trigger,port))
+		return
+
 	var/obj/machinery/light_switch/shell = parent.shell
 	if(!istype(shell))
 		return

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -34,6 +34,8 @@
 	if(admin)
 		can_rotate = FALSE
 
+	AddComponent(/datum/component/shell, list(new /obj/item/circuit_component/reflector()), SHELL_CAPACITY_MEDIUM)
+
 /obj/structure/reflector/examine(mob/user)
 	. = ..()
 	if(finished)
@@ -266,3 +268,32 @@
 		return
 	else
 		return ..()
+
+/*
+Ported from /tg/station: PR #64037
+*/
+/obj/item/circuit_component/reflector
+	display_name = "Reflector"
+	desc = "Allows you to adjust the angle of a reflector."
+	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL
+
+	///angle the reflector will be set to at trigger unless locked
+	var/datum/port/input/angle
+
+/obj/item/circuit_component/reflector/Initialize(mapload)
+	. = ..()
+	angle = add_input_port("Angle", PORT_TYPE_NUMBER)
+
+/obj/item/circuit_component/reflector/Destroy()
+	angle = null
+	return ..()
+
+/obj/item/circuit_component/reflector/input_received(datum/port/input/port)
+	. = ..()
+	if(.)
+		return
+
+	var/obj/structure/reflector/shell = parent.shell
+	if(!istype(shell))
+		return
+	shell.setAngle(angle.input_value)

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -293,6 +293,9 @@ Ported from /tg/station: PR #64037
 	if(.)
 		return
 
+	if(!COMPONENT_TRIGGERED_BY(trigger,port))
+		return
+
 	var/obj/structure/reflector/shell = parent.shell
 	if(!istype(shell))
 		return

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -293,8 +293,6 @@ Ported from /tg/station: PR #64037
 	if(.)
 		return
 
-	if(!COMPONENT_TRIGGERED_BY(trigger,port))
-		return
 
 	var/obj/structure/reflector/shell = parent.shell
 	if(!istype(shell))

--- a/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/valve.dm
@@ -84,13 +84,11 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 
 /obj/machinery/atmospherics/components/binary/valve/digital/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/usb_port, list(/obj/item/circuit_component/digital_valve))
+	AddComponent(/datum/component/shell, list(new /obj/item/circuit_component/digital_valve), SHELL_CAPACITY_SMALL)
 
 /obj/item/circuit_component/digital_valve
 	display_name = "Digital Valve"
 	display_desc = "The interface for communicating with a digital valve."
-
-	var/obj/machinery/atmospherics/components/binary/valve/digital/attached_valve
 
 	/// Opens the digital valve
 	var/datum/port/input/open
@@ -113,16 +111,20 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	opened = add_output_port("Opened", PORT_TYPE_SIGNAL)
 	closed = add_output_port("Closed", PORT_TYPE_SIGNAL)
 
-/obj/item/circuit_component/digital_valve/register_usb_parent(atom/movable/shell)
-	. = ..()
-	if(istype(shell, /obj/machinery/atmospherics/components/binary/valve/digital))
-		attached_valve = shell
-		RegisterSignal(attached_valve, COMSIG_VALVE_SET_OPEN, .proc/handle_valve_toggled)
+/obj/item/circuit_component/digital_valve/Initialize(mapload)
+	open = null
+	close = null
 
-/obj/item/circuit_component/digital_valve/unregister_usb_parent(atom/movable/shell)
-	UnregisterSignal(attached_valve, COMSIG_VALVE_SET_OPEN)
-	attached_valve = null
+	is_open = null
+	opened = null
+	closed = null
 	return ..()
+
+/obj/item/circuit_component/digital_valve/register_shell(atom/movable/shell)
+	RegisterSignal(shell, COMSIG_VALVE_SET_OPEN, .proc/handle_valve_toggled)
+
+/obj/item/circuit_component/digital_valve/unregister_shell(atom/movable/shell)
+	UnregisterSignal(shell, COMSIG_VALVE_SET_OPEN)
 
 /obj/item/circuit_component/digital_valve/proc/handle_valve_toggled(datum/source, on)
 	is_open.set_output(on)
@@ -136,14 +138,18 @@ It's like a regular ol' straight pipe, but you can turn it on and off.
 	if(.)
 		return
 
-	if(!attached_valve)
+
+	var/obj/machinery/atmospherics/components/binary/valve/digital/shell = parent.shell
+	if(!istype(shell))
 		return
 
-	if(COMPONENT_TRIGGERED_BY(open, port) && !attached_valve.on)
-		attached_valve.set_open(TRUE)
-	if(COMPONENT_TRIGGERED_BY(close, port) && attached_valve.on)
-		attached_valve.set_open(FALSE)
+	if(shell.switching)
+		return
 
+	if(COMPONENT_TRIGGERED_BY(open, port) && !shell.on)
+		shell.set_open(TRUE)
+	if(COMPONENT_TRIGGERED_BY(close, port) && shell.on)
+		shell.set_open(FALSE)
 
 /obj/machinery/atmospherics/components/binary/valve/digital/update_icon_nopipes(animation)
 	if(!is_operational)

--- a/code/modules/wiremod/component.dm
+++ b/code/modules/wiremod/component.dm
@@ -189,6 +189,9 @@
 	if(!parent?.on)
 		return TRUE
 
+	if((circuit_flags & CIRCUIT_FLAG_INPUT_SIGNAL) && !COMPONENT_TRIGGERED_BY(trigger_input, port))
+		return TRUE
+
 	if(parent.shell?.anchored)
 		var/area/location = get_area(parent)
 		if(location.powered(AREA_USAGE_EQUIP))
@@ -197,9 +200,6 @@
 
 	var/obj/item/stock_parts/cell/cell = parent.get_cell()
 	if(!cell?.use(power_usage_per_input))
-		return TRUE
-
-	if((circuit_flags & CIRCUIT_FLAG_INPUT_SIGNAL) && !COMPONENT_TRIGGERED_BY(trigger_input, port))
 		return TRUE
 
 /// Called when this component is about to be added to an integrated_circuit.

--- a/code/modules/wiremod/component.dm
+++ b/code/modules/wiremod/component.dm
@@ -189,6 +189,12 @@
 	if(!parent?.on)
 		return TRUE
 
+	if(parent.shell?.anchored)
+		var/area/location = get_area(parent)
+		if(location.powered(AREA_USAGE_EQUIP))
+			location.use_power(power_usage_per_input, AREA_USAGE_EQUIP)
+			return FALSE
+
 	var/obj/item/stock_parts/cell/cell = parent.get_cell()
 	if(!cell?.use(power_usage_per_input))
 		return TRUE

--- a/monkestation/code/datums/action.dm
+++ b/monkestation/code/datums/action.dm
@@ -10,7 +10,7 @@
 /datum/action/item_action/use_circuit_goggles/Trigger()
 	if(IsAvailable())
 		owner.click_intercept = src
-		to_chat(owner, "<span class='notice'>[target] circuit goggles activates. Click on a target!</span>")
+		to_chat(owner, "<span class='notice'>[target] circuit goggles activate. Click on a target!</span>")
 		return TRUE
 
 /datum/action/item_action/use_circuit_goggles/proc/InterceptClickOn(mob/living/carbon/caller, params, atom/target)


### PR DESCRIPTION
# About The Pull Request

Ports:
tgstation/tgstation#60227
tgstation/tgstation#64037
tgstation/tgstation#62907
And uncomments all the commented out usb circuit code and replaces them as circuit shells

QoL-
Inducers can be used directly on shells instead of circuits themselves
You can also scan your id on the shell instead of only the circuit
Anchored shells draw from the room APCs when possible (makes a constant battery checking cell charger even more feasible)

New Shells-
Reflector Shell- You can set the angle of reflectors using circuits. (Inputs: Angle, Trigger)
Light Switch- You can turn light switches on and off (Inputs: On, Trigger, Outputs: Is On, Trigger)
Security Records Computer- You can set and check a crewmember's status
Digital Valve- You can turn the digital valve on and off (Inputs: Open, Close, Outputs: Is Open, Opened, Closed)

## Why It's Good For The Game

big circuitry fan over here

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

No video included cause a majority of these already worked and just were commented out (I did test them all though)

</details>

## Changelog

:cl:
add: Made Light Switches, Sec Computers, Digital Valves, and Reflectors into shells
add: Inducers and IDs can be used on the shell rather than the circuit directly
add; Anchored shells draw power from the room's APC rather than a battery when possible
/:cl:
