### PR TITLE
APCs Break Apart Fully

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -771,7 +771,7 @@
 	if(!(machine_stat & BROKEN) && !(flags_1 & NODECONSTRUCT_1))
 		set_machine_stat(machine_stat | BROKEN)
 		SEND_SIGNAL(src, COMSIG_MACHINERY_BROKEN, damage_flag)
-		update_icon()
+		update_appearance()
 		return TRUE
 
 /obj/machinery/contents_explosion(severity, target)

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -264,6 +264,9 @@
 	if(machine_stat & BROKEN && obj_integrity <= 0)
 		if(sound_effect)
 			play_attack_sound(damage_amount, damage_type, damage_flag)
+		new /obj/item/stock_parts/cell/upgraded(loc)
+		new /obj/item/stack/sheet/iron(loc)
+		qdel(src)
 		return
 	return ..()
 
@@ -273,9 +276,9 @@
 	. = ..()
 
 /obj/machinery/power/apc/obj_break(damage_flag)
-	if(!(flags_1 & NODECONSTRUCT_1))
+	. = ..()
+	if(.)
 		set_broken()
-
 
 /obj/machinery/power/apc/proc/can_use(mob/user, loud = 0) //used by attack_hand() and Topic()
 	if(IsAdminGhost(user))
@@ -303,6 +306,7 @@
 	if(occupier)
 		malfvacate(TRUE)
 	update()
+	do_sparks(5, TRUE, src)
 
 /obj/machinery/power/apc/proc/shock(mob/user, prb)
 	if(!prob(prb))

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -264,7 +264,7 @@
 	if(machine_stat & BROKEN && obj_integrity <= 0)
 		if(sound_effect)
 			play_attack_sound(damage_amount, damage_type, damage_flag)
-		new /obj/item/stock_parts/cell/upgraded(loc)
+		new /obj/item/stock_parts/cell/upgraded/empty(loc)
 		new /obj/item/stack/sheet/iron(loc)
 		qdel(src)
 		return

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -264,7 +264,10 @@
 	if(machine_stat & BROKEN && obj_integrity <= 0)
 		if(sound_effect)
 			play_attack_sound(damage_amount, damage_type, damage_flag)
-		new /obj/item/stock_parts/cell/upgraded/empty(loc)
+		if(cell)
+			cell.forceMove(loc)
+			cell.update_appearance()
+			cell = null
 		new /obj/item/stack/sheet/iron(loc)
 		qdel(src)
 		return

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -213,6 +213,8 @@
 		area.power_change()
 		area.apc = null
 	QDEL_NULL(alarm_manager)
+	if(integration_cog)
+		QDEL_NULL(integration_cog)
 	if(occupier)
 		malfvacate(TRUE)
 	if(wires)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -223,6 +223,11 @@
 	materials = list(/datum/material/glass=50)
 	chargerate = 1000
 
+/obj/item/stock_parts/cell/upgraded/empty/Initialize(mapload)
+	. = ..()
+	charge = 0
+	update_icon()
+
 /obj/item/stock_parts/cell/upgraded/plus
 	name = "upgraded power cell+"
 	desc = "A power cell with an even higher capacity than the base model!"

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -223,11 +223,6 @@
 	materials = list(/datum/material/glass=50)
 	chargerate = 1000
 
-/obj/item/stock_parts/cell/upgraded/empty/Initialize(mapload)
-	. = ..()
-	charge = 0
-	update_icon()
-
 /obj/item/stock_parts/cell/upgraded/plus
 	name = "upgraded power cell+"
 	desc = "A power cell with an even higher capacity than the base model!"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Fixes APC broken states
APC's fully break now and drops a metal sheet and an empty power cell. Basically, it breaks once into the broken state, then when attacked again it breaks the cover, and then finally it fully breaks.
Adds Empty Upgraded Power Cell, so it can be dropped

## Why It's Good For The Game
APCs break fully apart as requested

## Testing Photographs and Procedure
I beat the crap out of an apc with a pirate saber, it sparked and broke, and then I hit it a couple more times to completely destroy it which dropped the metal sheet and a empty power cell. No Runtimes during testing.

## Changelog

:cl:
fix: Fixed APC broken icon states
tweak: APCs can fully break down
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
