### PR TITLE
Fixes Conveyors + Lowers Sounds in NastyTrap Room

### DIFF
--- a/_maps/RandomRooms/5x3/sk_rdm089_nastytrap.dmm
+++ b/_maps/RandomRooms/5x3/sk_rdm089_nastytrap.dmm
@@ -1,8 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/trunk{
+	low_volume = 1
+	},
 /obj/machinery/disposal/deliveryChute{
-	dir = 4
+	dir = 4;
+	low_volume = 1
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -25,7 +28,8 @@
 /area/template_noop)
 "d" = (
 /obj/structure/disposalpipe/trunk{
-	dir = 4
+	dir = 4;
+	low_volume = 1
 	},
 /turf/open/floor/plating,
 /area/template_noop)
@@ -33,7 +37,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/machinery/disposal/deliveryChute,
+/obj/machinery/disposal/deliveryChute{
+	low_volume = 1
+	},
 /turf/open/floor/plating,
 /area/template_noop)
 "f" = (
@@ -46,13 +52,15 @@
 	dir = 4
 	},
 /obj/machinery/disposal/deliveryChute{
-	dir = 1
+	dir = 1;
+	low_volume = 1
 	},
 /turf/open/floor/plating,
 /area/template_noop)
 "h" = (
 /obj/structure/disposalpipe/trunk{
-	dir = 8
+	dir = 8;
+	low_volume = 1
 	},
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/old,
@@ -70,10 +78,12 @@
 /area/template_noop)
 "j" = (
 /obj/structure/disposalpipe/trunk{
-	dir = 1
+	dir = 1;
+	low_volume = 1
 	},
 /obj/machinery/disposal/deliveryChute{
-	dir = 8
+	dir = 8;
+	low_volume = 1
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"

--- a/code/modules/recycling/conveyor/conveyor.dm
+++ b/code/modules/recycling/conveyor/conveyor.dm
@@ -266,6 +266,8 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	balloon_alert(user, "starts prying up [src].")
 	if(!crowbar.use_tool(src, user, 4 SECONDS, volume = 40))
 		return
+	if(processing_flags == START_PROCESSING_ON_INIT)
+		operating = CONVEYOR_OFF
 	set_operating(FALSE)
 	var/obj/item/stack/conveyor/belt_item = new /obj/item/stack/conveyor(loc, 1, TRUE, null, null, id)
 	if(!QDELETED(belt_item)) //God I hate stacks
@@ -385,7 +387,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 /// Updates the switch's `position` and `last_pos` variable. Useful so that the switch can properly cycle between the forwards, backwards and neutral positions.
 /obj/machinery/conveyor_switch/proc/update_position()
 	if(position == CONVEYOR_OFF)
-		if(oneway)   //is it a oneway switch
+		if(oneway) //is it a oneway switch
 			position = oneway
 		else
 			if(last_pos < CONVEYOR_OFF)
@@ -429,7 +431,6 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	balloon_alert(user, "detaching [src].")
 	if(!crowbar.use_tool(src, user, 2 SECONDS, volume = 40))
 		return
-//	crowbar.play_tool_sound(src, 50)
 	var/obj/item/conveyor_switch_construct/switch_construct = new/obj/item/conveyor_switch_construct(src.loc)
 	switch_construct.id = id
 	transfer_fingerprints_to(switch_construct)

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -12,8 +12,6 @@
 	obj_flags = CAN_BE_HIT | USES_TGUI
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
 
-
-
 	var/datum/gas_mixture/air_contents	// internal reservoir
 	var/full_pressure = FALSE
 	var/pressure_charging = TRUE
@@ -23,6 +21,7 @@
 	var/flush_every_ticks = 30 //Every 30 ticks it will look whether it is ready to flush
 	var/flush_count = 0 //this var adds 1 once per tick. When it reaches flush_every_ticks it resets and tries to flush.
 	var/last_sound = 0
+	var/low_volume = FALSE //Lower volume sounds
 	// create a new disposal
 	// find the attached trunk (if present) and init gas resvr.
 
@@ -181,10 +180,15 @@
 	flushing = TRUE
 	flushAnimation()
 	sleep(10)
-	if(last_sound < world.time + 1)
+
+	if(last_sound < world.time + 1 && low_volume == TRUE)
+		playsound(src, 'sound/machines/disposalflush.ogg', 10, FALSE, FALSE, falloff_exponent = 3)
+		last_sound = world.time
+	else
 		playsound(src, 'sound/machines/disposalflush.ogg', 50, FALSE, FALSE)
 		last_sound = world.time
 	sleep(5)
+
 	if(QDELETED(src))
 		return
 	var/obj/structure/disposalholder/H = new(src)
@@ -211,9 +215,10 @@
 // called when holder is expelled from a disposal
 /obj/machinery/disposal/proc/expel(obj/structure/disposalholder/H)
 	H.active = FALSE
-
-	playsound(src, 'sound/machines/hiss.ogg', 50, FALSE, FALSE)
-
+	if(low_volume == TRUE)
+		playsound(src, 'sound/machines/hiss.ogg', 20, FALSE, SHORT_RANGE_SOUND_EXTRARANGE)
+	else
+		playsound(src, 'sound/machines/hiss.ogg', 50, FALSE, FALSE)
 	pipe_eject(H)
 
 	H.vent_gas(loc)

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -13,10 +13,11 @@
 	armor = list("melee" = 25, "bullet" = 10, "laser" = 10, "energy" = 100, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 30, "stamina" = 0)
 	layer = DISPOSAL_PIPE_LAYER			// slightly lower than wires and other pipes
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
-	var/dpdir = NONE					// bitmask of pipe directions
-	var/initialize_dirs = NONE			// bitflags of pipe directions added on init, see \code\_DEFINES\pipe_construction.dm
-	var/flip_type						// If set, the pipe is flippable and becomes this type when flipped
 
+	var/dpdir = NONE // bitmask of pipe directions
+	var/initialize_dirs = NONE // bitflags of pipe directions added on init, see \code\_DEFINES\pipe_construction.dm
+	var/flip_type // If set, the pipe is flippable and becomes this type when flipped
+	var/low_volume = FALSE // Lower sound volumes for special traps
 
 /obj/structure/disposalpipe/Initialize(mapload, obj/structure/disposalconstruct/make_from)
 	. = ..()
@@ -107,7 +108,10 @@
 	else if(floorturf)
 		target = get_offset_target_turf(T, rand(5)-rand(5), rand(5)-rand(5))
 
-	playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
+	if(low_volume == TRUE)
+		playsound(src, 'sound/machines/hiss.ogg', 15, FALSE, SHORT_RANGE_SOUND_EXTRARANGE)
+	else
+		playsound(src, 'sound/machines/hiss.ogg', 50, FALSE, FALSE)
 	pipe_eject(H, direction, TRUE, target, eject_range)
 	H.vent_gas(T)
 	qdel(H)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Fixes Auto Conveyors deconstructing weird and running away from the player, was apparent from the nasty_trap room.
Adds a quiet mode to disposal bin and disposal pipe expel so the nasty_trap room is quieter.

## Why It's Good For The Game
Bug fix for `conveyor/auto` and the  nasty_trap random room is quieter and not as annoying.

## Testing Photographs and Procedure
Spawning in the nasty_trap room you will notice it is not as noisy (well unless you are in the middle of it) and also the deconstructing the auto conveyor's actually turns them off like they are supposed to

## Changelog
:cl:
fix: Fixed Auto Conveyors deconstructing weird and running away from the player
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
