### PR TITLE
Health Modifier division fix

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -448,6 +448,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	if(inherent_factions)
 		for(var/i in inherent_factions)
 			C.faction -= i
+	C.maxHealth = C.maxHealth / maxhealthmod
 	C.remove_movespeed_modifier(MOVESPEED_ID_SPECIES)
 	SEND_SIGNAL(C, COMSIG_SPECIES_LOSS, src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

The species health modifier would get applied when you turn into the species, but wouldn't get removed when you lost the species. Things like changelings that can switch between them a bunch would get their health divided into nothing if they needed to switch into a simian multiple times for any reason.

## Why It's Good For The Game

Bug Bad Fix Good
closes #665 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
fix: Fixed swapping between simian and another race dividing your health into nothing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
