### PR TITLE
Beam refactor

### DIFF
--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -59,9 +59,10 @@
  * direction: in what direction mover moved from.
  */
 /datum/beam/proc/redrawing(atom/movable/mover, atom/oldloc, direction)
+	SIGNAL_HANDLER
 	if(origin && target && get_dist(origin,target)<max_distance && origin.z == target.z)
 		QDEL_LIST(elements)
-		Draw()
+		INVOKE_ASYNC(src, .proc/Draw)
 	else
 		qdel(src)
 

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -1,97 +1,86 @@
-//Beam Datum and effect
-/datum/beam
-	var/atom/origin = null
-	var/atom/target = null
-	var/list/elements = list()
-	var/icon/base_icon = null
-	var/icon
-	var/icon_state = "" //icon state of the main segments of the beam
-	var/max_distance = 0
-	var/sleep_time = 3
-	var/finished = 0
-	var/target_oldloc = null
-	var/origin_oldloc = null
-	var/static_beam = 0
-	var/beam_type = /obj/effect/ebeam //must be subtype
-	var/timing_id = null
-	var/recalculating = FALSE
 
-/datum/beam/New(beam_origin,beam_target,beam_icon='icons/effects/beam.dmi',beam_icon_state="b_beam",time=50,maxdistance=10,btype = /obj/effect/ebeam,beam_sleep_time=3)
+/** # Beam Datum and Effect
+ * **IF YOU ARE LAZY AND DO NOT WANT TO READ, GO TO THE BOTTOM OF THE FILE AND USE THAT PROC!**
+ *
+ * This is the beam datum! It's a really neat effect for the game in drawing a line from one atom to another.
+ * It has two parts:
+ * The datum itself which manages redrawing the beam to constantly keep it pointing from the origin to the target.
+ * The effect which is what the beams are made out of. They're placed in a line from the origin to target, rotated towards the target and snipped off at the end.
+ * These effects are kept in a list and constantly created and destroyed (hence the proc names draw and reset, reset destroying all effects and draw creating more.)
+ *
+ * You can add more special effects to the beam itself by changing what the drawn beam effects do. For example you can make a vine that pricks people by making the beam_type
+ * include a crossed proc that damages the crosser. Examples in venus_human_trap.dm
+*/
+/datum/beam
+	///where the beam goes from
+	var/atom/origin = null
+	///where the beam goes to
+	var/atom/target = null
+	///list of beam objects. These have their visuals set by the visuals var which is created on starting
+	var/list/elements = list()
+	///icon used by the beam.
+	var/icon
+	///icon state of the main segments of the beam
+	var/icon_state = ""
+	///The beam will qdel if it's longer than this many tiles.
+	var/max_distance = 0
+	///the objects placed in the elements list
+	var/beam_type = /obj/effect/ebeam
+	///This is used as the visual_contents of beams, so you can apply one effect to this and the whole beam will look like that. never gets deleted on redrawing.
+	var/obj/effect/ebeam/visuals
+
+/datum/beam/New(beam_origin,beam_target,beam_icon='icons/effects/beam.dmi',beam_icon_state="b_beam",time=INFINITY,maxdistance=INFINITY,btype = /obj/effect/ebeam)
 	origin = beam_origin
-	origin_oldloc =	get_turf(origin)
 	target = beam_target
-	target_oldloc = get_turf(target)
-	sleep_time = beam_sleep_time
-	if(origin_oldloc == origin && target_oldloc == target)
-		static_beam = 1
 	max_distance = maxdistance
-	base_icon = new(beam_icon,beam_icon_state)
 	icon = beam_icon
 	icon_state = beam_icon_state
 	beam_type = btype
 	if(time < INFINITY)
-		addtimer(CALLBACK(src,.proc/End), time)
+		QDEL_IN(src, time)
 
+/**
+ * Proc called by the atom Beam() proc. Sets up signals, and draws the beam for the first time.
+ */
 /datum/beam/proc/Start()
+	visuals = new beam_type()
+	visuals.icon = icon
+	visuals.icon_state = icon_state
 	Draw()
-	recalculate_in(sleep_time)
+	RegisterSignal(origin, COMSIG_MOVABLE_MOVED, .proc/redrawing)
+	RegisterSignal(target, COMSIG_MOVABLE_MOVED, .proc/redrawing)
 
-/datum/beam/proc/recalculate()
-	if(recalculating)
-		recalculate_in(sleep_time)
-		return
-	recalculating = TRUE
-	timing_id = null
-	if(origin && target && get_dist(origin,target)<max_distance && origin.get_virtual_z_level() == target.get_virtual_z_level())
-		var/origin_turf = get_turf(origin)
-		var/target_turf = get_turf(target)
-		if(!static_beam && (origin_turf != origin_oldloc || target_turf != target_oldloc))
-			origin_oldloc = origin_turf //so we don't keep checking against their initial positions, leading to endless Reset()+Draw() calls
-			target_oldloc = target_turf
-			Reset()
-			Draw()
-		after_calculate()
-		recalculating = FALSE
+/**
+ * Triggered by signals set up when the beam is set up. If it's still sane to create a beam, it removes the old beam, creates a new one. Otherwise it kills the beam.
+ *
+ * Arguments:
+ * mover: either the origin of the beam or the target of the beam that moved.
+ * oldloc: from where mover moved.
+ * direction: in what direction mover moved from.
+ */
+/datum/beam/proc/redrawing(atom/movable/mover, atom/oldloc, direction)
+	if(origin && target && get_dist(origin,target)<max_distance && origin.z == target.z)
+		QDEL_LIST(elements)
+		Draw()
 	else
-		End()
-
-/datum/beam/proc/afterDraw()
-	return
-
-/datum/beam/proc/recalculate_in(time)
-	if(QDELETED(src))
-		return
-	if(timing_id)
-		deltimer(timing_id)
-	timing_id = addtimer(CALLBACK(src, .proc/recalculate), time, TIMER_STOPPABLE)
-
-/datum/beam/proc/after_calculate()
-	if((sleep_time == null) || finished)	//Does not automatically recalculate.
-		return
-	if(isnull(timing_id))
-		timing_id = addtimer(CALLBACK(src, .proc/recalculate), sleep_time, TIMER_STOPPABLE)
-
-/datum/beam/proc/End(destroy_self = TRUE)
-	finished = TRUE
-	if(!isnull(timing_id))
-		deltimer(timing_id)
-	if(!QDELETED(src) && destroy_self)
 		qdel(src)
 
-/datum/beam/proc/Reset()
-	for(var/obj/effect/ebeam/B in elements)
-		qdel(B)
-	elements.Cut()
-
 /datum/beam/Destroy()
-	Reset()
+	QDEL_LIST(elements)
+	qdel(visuals)
+	UnregisterSignal(origin, COMSIG_MOVABLE_MOVED)
+	UnregisterSignal(target, COMSIG_MOVABLE_MOVED)
 	target = null
 	origin = null
 	return ..()
 
+/**
+ * Creates the beam effects and places them in a line from the origin to the target. Sets their rotation to make the beams face the target, too.
+ */
 /datum/beam/proc/Draw()
 	var/Angle = round(get_angle(origin,target))
 	var/matrix/rot_matrix = matrix()
+	var/turf/origin_turf = get_turf(origin)
 	rot_matrix.Turn(Angle)
 
 	//Translation vector for origin and target
@@ -101,20 +90,20 @@
 	var/length = round(sqrt((DX)**2+(DY)**2)) //hypotenuse of the triangle formed by target and origin's displacement
 
 	for(N in 0 to length-1 step 32)//-1 as we want < not <=, but we want the speed of X in Y to Z and step X
-		if(QDELETED(src) || finished)
+		if(QDELETED(src))
 			break
-		var/obj/effect/ebeam/X = new beam_type(origin_oldloc)
+		var/obj/effect/ebeam/X = new beam_type(origin_turf)
 		X.owner = src
 		elements += X
 
-		//Assign icon, for main segments it's base_icon, for the end, it's icon+icon_state
-		//cropped by a transparent box of length-N pixel size
-		if(N+32>length)
-			var/icon/II = new(icon, icon_state)
-			II.DrawBox(null,1,(length-N),32,32)
+		//Assign our single visual ebeam to each ebeam's vis_contents
+		//ends are cropped by a transparent box icon of length-N pixel size laid over the visuals obj
+		if(N+32>length) //went past the target, we draw a box of space to cut away from the beam sprite so the icon actually ends at the center of the target sprite
+			var/icon/II = new(icon, icon_state)//this means we exclude the overshooting object from the visual contents which does mean those visuals don't show up for the final bit of the beam...
+			II.DrawBox(null,1,(length-N),32,32)//in the future if you want to improve this, remove the drawbox and instead use a 513 filter to cut away at the final object's icon
 			X.icon = II
 		else
-			X.icon = base_icon
+			X.vis_contents += visuals
 		X.transform = rot_matrix
 
 		//Calculate pixel offsets (If necessary)
@@ -143,7 +132,6 @@
 		X.pixel_x = Pixel_x
 		X.pixel_y = Pixel_y
 		CHECK_TICK
-	afterDraw()
 
 /obj/effect/ebeam
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
@@ -171,7 +159,7 @@
  * maxdistance: how far the beam will go before stopping itself. Used mainly for two things: preventing lag if the beam may go in that direction and setting a range to abilities that use beams.
  * beam_type: The type of your custom beam. This is for adding other wacky stuff for your beam only. Most likely, you won't (and shouldn't) change it.
  */
-/atom/proc/Beam(atom/BeamTarget,icon_state="b_beam",icon='icons/effects/beam.dmi',time=INFINITY,maxdistance=INFINITY,beam_type=/obj/effect/ebeam, beam_color = null, beam_type=/obj/effect/ebeam,beam_sleep_time = 3)
-	var/datum/beam/newbeam = new(src,BeamTarget,icon,icon_state,time,maxdistance,beam_type, beam_color,beam_sleep_time)
+/atom/proc/Beam(atom/BeamTarget,icon_state="b_beam",icon='icons/effects/beam.dmi',time=INFINITY,maxdistance=INFINITY,beam_type=/obj/effect/ebeam)
+	var/datum/beam/newbeam = new(src,BeamTarget,icon,icon_state,time,maxdistance,beam_type)
 	INVOKE_ASYNC(newbeam, /datum/beam/.proc/Start)
 	return newbeam

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -170,7 +170,7 @@
  * maxdistance: how far the beam will go before stopping itself. Used mainly for two things: preventing lag if the beam may go in that direction and setting a range to abilities that use beams.
  * beam_type: The type of your custom beam. This is for adding other wacky stuff for your beam only. Most likely, you won't (and shouldn't) change it.
  */
-/atom/proc/Beam(atom/BeamTarget,icon_state="b_beam",icon='icons/effects/beam.dmi',time=INFINITY,maxdistance=INFINITY,btype=/obj/effect/ebeam, beam_color = null)
+/atom/proc/Beam(atom/BeamTarget,icon_state="b_beam",icon='icons/effects/beam.dmi',time=INFINITY,maxdistance=INFINITY,beam_type=/obj/effect/ebeam, beam_color = null)
 	var/datum/beam/newbeam = new(src,BeamTarget,icon,icon_state,time,maxdistance,beam_type, beam_color)
 	INVOKE_ASYNC(newbeam, /datum/beam/.proc/Start)
 	return newbeam

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -28,14 +28,17 @@
 	var/beam_type = /obj/effect/ebeam
 	///This is used as the visual_contents of beams, so you can apply one effect to this and the whole beam will look like that. never gets deleted on redrawing.
 	var/obj/effect/ebeam/visuals
+	///The color of the beam we're drawing.
+	var/beam_color
 
-/datum/beam/New(beam_origin,beam_target,beam_icon='icons/effects/beam.dmi',beam_icon_state="b_beam",time=INFINITY,maxdistance=INFINITY,btype = /obj/effect/ebeam)
-	origin = beam_origin
-	target = beam_target
-	max_distance = maxdistance
-	icon = beam_icon
-	icon_state = beam_icon_state
-	beam_type = btype
+/datum/beam/New(origin, target, icon = 'icons/effects/beam.dmi', icon_state = "b_beam", time = INFINITY, max_distance = INFINITY, beam_type = /obj/effect/ebeam, beam_color = null)
+	src.origin = origin
+	src.target = target
+	src.icon = icon
+	src.icon_state = icon_state
+	src.max_distance = max_distance
+	src.beam_type = beam_type
+	src.beam_color = beam_color
 	if(time < INFINITY)
 		QDEL_IN(src, time)
 
@@ -46,6 +49,9 @@
 	visuals = new beam_type()
 	visuals.icon = icon
 	visuals.icon_state = icon_state
+	visuals.color = beam_color
+	visuals.layer = ABOVE_ALL_MOB_LAYER
+	visuals.update_appearance()
 	Draw()
 	RegisterSignal(origin, COMSIG_MOVABLE_MOVED, .proc/redrawing)
 	RegisterSignal(target, COMSIG_MOVABLE_MOVED, .proc/redrawing)
@@ -65,6 +71,10 @@
 		INVOKE_ASYNC(src, .proc/Draw)
 	else
 		qdel(src)
+
+/obj/effect/ebeam/update_overlays()
+	. = ..()
+	. += emissive_appearance(icon, icon_state)
 
 /datum/beam/Destroy()
 	QDEL_LIST(elements)
@@ -160,7 +170,7 @@
  * maxdistance: how far the beam will go before stopping itself. Used mainly for two things: preventing lag if the beam may go in that direction and setting a range to abilities that use beams.
  * beam_type: The type of your custom beam. This is for adding other wacky stuff for your beam only. Most likely, you won't (and shouldn't) change it.
  */
-/atom/proc/Beam(atom/BeamTarget,icon_state="b_beam",icon='icons/effects/beam.dmi',time=INFINITY,maxdistance=INFINITY,beam_type=/obj/effect/ebeam)
-	var/datum/beam/newbeam = new(src,BeamTarget,icon,icon_state,time,maxdistance,beam_type)
+/atom/proc/Beam(atom/BeamTarget,icon_state="b_beam",icon='icons/effects/beam.dmi',time=INFINITY,maxdistance=INFINITY,btype=/obj/effect/ebeam, beam_color = null)
+	var/datum/beam/newbeam = new(src,BeamTarget,icon,icon_state,time,maxdistance,beam_type, beam_color)
 	INVOKE_ASYNC(newbeam, /datum/beam/.proc/Start)
 	return newbeam

--- a/code/datums/dash_weapon.dm
+++ b/code/datums/dash_weapon.dm
@@ -33,13 +33,13 @@
 /datum/action/innate/dash/proc/Teleport(mob/user, atom/target)
 	if(!IsAvailable())
 		return
-	var/turf/T = get_turf(target)
-	if(user in viewers(user.client.view, T))
+	var/turf/target_turf = get_turf(target)
+	if(user in viewers(user.client.view, target_turf))
 		var/obj/spot1 = new phaseout(get_turf(user), user.dir)
-		if(do_teleport(user, T, channel = TELEPORT_CHANNEL_FREE, no_effects = TRUE))
-			playsound(T, dash_sound, 25, 1)
+		if(do_teleport(user, target_turf, channel = TELEPORT_CHANNEL_FREE, no_effects = TRUE))
+			playsound(target_turf, dash_sound, 25, 1)
 			var/obj/spot2 = new phasein(get_turf(user), user.dir)
-			spot1.Beam(spot2,beam_effect,time=20)
+			spot1.Beam(spot2, beam_effect, time= 2 SECONDS)
 			current_charges--
 			owner.update_action_buttons_icon()
 			addtimer(CALLBACK(src, .proc/charge), charge_rate)

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -445,7 +445,7 @@
 	if(!istype(PG))
 		return
 	 //has to be low sleep or it looks weird, the beam doesn't exist for very long so it's a non-issue
-	chassis.Beam(PG, icon_state = "chain", time = missile_range * 20, maxdistance = missile_range + 2, beam_sleep_time = 1)
+	chassis.Beam(PG, icon_state = "chain", time = missile_range * 20, maxdistance = missile_range + 2)
 
 /obj/item/punching_glove
 	name = "punching glove"

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -731,7 +731,7 @@ RLD
 	if(!range_check(A,user))
 		return
 	if(target_check(A,user))
-		user.Beam(A,icon_state="rped_upgrade",time=30)
+		user.Beam(A, icon_state="rped_upgrade", time=3 SECONDS)
 	rcd_create(A,user)
 
 
@@ -808,7 +808,7 @@ RLD
 			if(istype(A, /obj/machinery/light/))
 				if(checkResource(deconcost, user))
 					to_chat(user, "<span class='notice'>You start deconstructing [A]...</span>")
-					user.Beam(A,icon_state="nzcrentrs_power",time=15)
+					user.Beam(A, icon_state="nzcrentrs_power", time=1.5 SECONDS)
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, decondelay, target = A))
 						if(!useResource(deconcost, user))
@@ -822,7 +822,7 @@ RLD
 				var/turf/closed/wall/W = A
 				if(checkResource(floorcost, user))
 					to_chat(user, "<span class='notice'>You start building a wall light...</span>")
-					user.Beam(A,icon_state="nzcrentrs_power",time=15)
+					user.Beam(A, icon_state="nzcrentrs_power", time=1.5 SECONDS)
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					playsound(src.loc, 'sound/effects/light_flicker.ogg', 50, 0)
 					if(do_after(user, floordelay, target = A))
@@ -868,7 +868,7 @@ RLD
 				var/turf/open/floor/F = A
 				if(checkResource(floorcost, user))
 					to_chat(user, "<span class='notice'>You start building a floor light...</span>")
-					user.Beam(A,icon_state="nzcrentrs_power",time=15)
+					user.Beam(A, icon_state="nzcrentrs_power", time=1.5 SECONDS)
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					playsound(src.loc, 'sound/effects/light_flicker.ogg', 50, 1)
 					if(do_after(user, floordelay, target = A))

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -860,7 +860,7 @@
 		if(istype(target, /obj/anomaly) && get_dist(user, target) < 10)
 			to_chat(user, "You send [held_sausage] towards [target].")
 			playsound(src, 'sound/items/rped.ogg', 50, 1)
-			beam = user.Beam(target,icon_state="rped_upgrade",time=100)
+			beam = user.Beam( target, icon_state = "rped_upgrade", time=10 SECONDS)
 		else if (user.Adjacent(target))
 			to_chat(user, "You extend [src] towards [target].")
 			playsound(src.loc, 'sound/weapons/batonextend.ogg', 50, 1)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1083,7 +1083,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	switch(punishment)
 		if(ADMIN_PUNISHMENT_LIGHTNING)
 			var/turf/T = get_step(get_step(target, NORTH), NORTH)
-			T.Beam(target, icon_state="lightning[rand(1,12)]", time = 5)
+			T.Beam(target, icon_state = "lightning[rand(1,12)]", time = 5)
 			target.adjustFireLoss(75)
 			if(ishuman(target))
 				var/mob/living/carbon/human/H = target

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -306,7 +306,7 @@
 
 /obj/item/projectile/tentacle/fire(setAngle)
 	if(firer)
-		chain = firer.Beam(src, icon_state = "tentacle", time = INFINITY, maxdistance = INFINITY, beam_sleep_time = 1)
+		chain = firer.Beam(src, icon_state = "tentacle")
 	..()
 
 /obj/item/projectile/tentacle/proc/reset_throw(mob/living/carbon/human/H)

--- a/code/modules/antagonists/clock_cult/scriptures/abstraction_crystal.dm
+++ b/code/modules/antagonists/clock_cult/scriptures/abstraction_crystal.dm
@@ -185,7 +185,7 @@ GLOBAL_LIST_INIT(abstraction_crystals, list())
 		item.alpha = 180
 		item.flags_1 |= HOLOGRAM_1
 		tracked_items += item
-	Beam(active_hologram, icon_state="nzcrentrs_power", time=INFINITY)
+	Beam(active_hologram, icon_state = "nzcrentrs_power", time = INFINITY)
 	START_PROCESSING(SSobj, src)
 	processing = TRUE
 

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -725,7 +725,7 @@
 					H.updatehealth()
 					playsound(get_turf(H), 'sound/magic/staff_healing.ogg', 25)
 					new /obj/effect/temp_visual/cult/sparks(get_turf(H))
-					user.Beam(H,icon_state="sendbeam",time=15)
+					user.Beam(H, icon_state = "sendbeam", time = 15)
 			else
 				if(H.stat == DEAD)
 					to_chat(user,"<span class='warning'>[H.p_their(TRUE)] blood has stopped flowing, you'll have to find another way to extract it.</span>")
@@ -736,7 +736,7 @@
 				if(H.blood_volume > BLOOD_VOLUME_SAFE)
 					H.blood_volume -= 100
 					uses += 50
-					user.Beam(H,icon_state="drainbeam",time=10)
+					user.Beam(H, icon_state = "drainbeam", time = 1 SECONDS)
 					playsound(get_turf(H), 'sound/magic/enter_blood.ogg', 50)
 					H.visible_message("<span class='danger'>[user] has drained some of [H]'s blood!</span>")
 					to_chat(user,"<span class='cultitalic'>Your blood rite gains 50 charges from draining [H]'s blood.</span>")
@@ -757,7 +757,7 @@
 					M.visible_message("<span class='warning'>[M] is partially healed by [user]'s blood magic!</span>")
 					uses = 0
 				playsound(get_turf(M), 'sound/magic/staff_healing.ogg', 25)
-				user.Beam(M,icon_state="sendbeam",time=10)
+				user.Beam(M, icon_state = "sendbeam", time = 1 SECONDS)
 		if(istype(target, /obj/effect/decal/cleanable/blood))
 			blood_draw(target, user)
 		..()
@@ -781,7 +781,7 @@
 			temp += shoecheck.bloody_shoes[/datum/reagent/blood]/20
 			shoecheck.bloody_shoes[/datum/reagent/blood] = 0
 		if(temp)
-			user.Beam(T,icon_state="drainbeam",time=15)
+			user.Beam(T, icon_state = "drainbeam", time = 1.5 SECONDS)
 			new /obj/effect/temp_visual/cult/sparks(get_turf(user))
 			playsound(T, 'sound/magic/enter_blood.ogg', 50)
 			to_chat(user, "<span class='cultitalic'>Your blood rite has gained [round(temp)] charge\s from blood sources around you!</span>")

--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -453,7 +453,7 @@
 			if(distance >= 16)
 				return
 			playsound(target,'sound/magic/exit_blood.ogg')
-			attached_action.throwee.Beam(target,icon_state="sendbeam",time=4)
+			attached_action.throwee.Beam(target, icon_state = "sendbeam", time = 4)
 			attached_action.throwee.forceMove(get_turf(target))
 			new /obj/effect/temp_visual/cult/sparks(get_turf(target), ranged_ability_user.dir)
 			attached_action.throwing = FALSE

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -888,7 +888,7 @@
 						L.adjustBruteLoss(45)
 						playsound(L, 'sound/hallucinations/wail.ogg', 50, 1)
 						L.emote("scream")
-		var/datum/beam/current_beam = new(user,temp_target,time=7,beam_icon_state="blood_beam",btype=/obj/effect/ebeam/blood)
+		var/datum/beam/current_beam = new(user,temp_target,time=7, icon_state="blood_beam",beam_type=/obj/effect/ebeam/blood)
 		INVOKE_ASYNC(current_beam, /datum/beam.proc/Start)
 
 

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -46,7 +46,7 @@
 		if(obj_integrity < max_integrity)
 			M.changeNext_move(CLICK_CD_MELEE)
 			obj_integrity = min(max_integrity, obj_integrity + 5)
-			Beam(M, icon_state="sendbeam", time=4)
+			Beam(M, icon_state = "sendbeam", time = 4)
 			M.visible_message("<span class='danger'>[M] repairs \the <b>[src]</b>.</span>", \
 				"<span class='cult'>You repair <b>[src]</b>, leaving [p_they()] at <b>[round(obj_integrity * 100 / max_integrity)]%</b> stability.</span>")
 		else

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -916,7 +916,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		while(!QDELETED(affecting))
 			if(!(affecting in T))
 				user.visible_message("<span class='warning'>A spectral tendril wraps around [affecting] and pulls [affecting.p_them()] back to the rune!</span>")
-				Beam(affecting, icon_state="drainbeam", time=2)
+				Beam(affecting, icon_state = "drainbeam", time = 2)
 				affecting.forceMove(get_turf(src)) //NO ESCAPE :^)
 			if(affecting.key)
 				affecting.visible_message("<span class='warning'>[affecting] slowly relaxes, the glow around [affecting.p_them()] dimming.</span>", \

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -77,7 +77,7 @@
 											   "<span class='revenwarning'>Violet lights, dancing in your vision, receding--</span>")
 					draining = FALSE
 					return
-				var/datum/beam/B = Beam(target,icon_state="drain_life",time=INFINITY)
+				var/datum/beam/B = Beam(target, icon_state = "drain_life", time = INFINITY)
 				if(do_after(src, 46, 0, target)) //As one cannot prove the existance of ghosts, ghosts cannot prove the existance of the target they were draining.
 					change_essence_amount(essence_drained, FALSE, target)
 					if(essence_drained <= 90 && target.stat != DEAD)
@@ -219,7 +219,7 @@
 	for(var/mob/living/carbon/human/M in hearers(shock_range, L))
 		if(M == user)
 			continue
-		L.Beam(M,icon_state="purple_lightning",time=5)
+		L.Beam(M, icon_state = "purple_lightning", time = 5)
 		do_sparks(4, FALSE, M)
 		playsound(M, 'sound/machines/defib_zap.ogg', 50, 1, -1)
 		if(!M.anti_magic_check(FALSE, TRUE))

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -498,7 +498,7 @@
 
 /obj/item/projectile/hook/fire(setAngle)
 	if(firer)
-		chain = firer.Beam(src, icon_state = "chain", time = INFINITY, maxdistance = INFINITY)
+		chain = firer.Beam(src, icon_state = "chain")
 	..()
 	//TODO: root the firer until the chain returns
 

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -103,7 +103,7 @@
 		if(health < maxHealth)
 			adjustHealth(-5)
 			if(src != M)
-				Beam(M,icon_state="sendbeam",time=4)
+				Beam(M, icon_state = "sendbeam", time = 4)
 				M.visible_message("<span class='danger'>[M] repairs some of \the <b>[src]'s</b> dents.</span>", \
 							"<span class='cult'>You repair some of <b>[src]'s</b> dents, leaving <b>[src]</b> at <b>[health]/[maxHealth]</b> health.</span>")
 			else

--- a/code/modules/mob/living/simple_animal/guardian/types/lightning.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/lightning.dm
@@ -31,7 +31,7 @@
 			var/datum/beam/C = pick(enemychains)
 			qdel(C)
 			enemychains -= C
-		enemychains += Beam(target, "lightning[rand(1,12)]", time=70, maxdistance=7, beam_type=/obj/effect/ebeam/chain)
+		enemychains += Beam(target, "lightning[rand(1,12)]", time=7 SECONDS, maxdistance=7, beam_type=/obj/effect/ebeam/chain)
 
 /mob/living/simple_animal/hostile/guardian/beam/Destroy()
 	removechains()
@@ -41,7 +41,7 @@
 	. = ..()
 	if(.)
 		if(summoner)
-			summonerchain = Beam(summoner, "lightning[rand(1,12)]", time=INFINITY, maxdistance=INFINITY, beam_type=/obj/effect/ebeam/chain)
+			summonerchain = Beam(summoner, "lightning[rand(1,12)]", beam_type=/obj/effect/ebeam/chain)
 		while(loc != summoner)
 			if(successfulshocks > 5)
 				successfulshocks = 0
@@ -68,7 +68,7 @@
 	cleardeletedchains()
 	if(summoner)
 		if(!summonerchain)
-			summonerchain = Beam(summoner, "lightning[rand(1,12)]", time=INFINITY, maxdistance=INFINITY, beam_type=/obj/effect/ebeam/chain)
+			summonerchain = Beam(summoner, "lightning[rand(1,12)]", beam_type=/obj/effect/ebeam/chain)
 		. += chainshock(summonerchain)
 	if(enemychains.len)
 		for(var/chain in enemychains)

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -21,8 +21,7 @@
 	anchors += locate(x+2,y-2,z)
 
 	for(var/turf/T in anchors)
-		var/datum/beam/B = Beam(T, "vine", time=INFINITY, maxdistance=5, beam_type=/obj/effect/ebeam/vine)
-		B.sleep_time = 10 //these shouldn't move, so let's slow down updates to 1 second (any slower and the deletion of the vines would be too slow)
+		Beam(T, "vine", maxdistance=5, beam_type=/obj/effect/ebeam/vine)
 	addtimer(CALLBACK(src, .proc/bear_fruit), growth_time)
 
 /obj/structure/alien/resin/flower_bud_enemy/proc/bear_fruit()
@@ -118,7 +117,7 @@
 								continue grasping
 					if(prob(grasp_chance))
 						to_chat(L, "<span class='userdanger'>\The [src] has you entangled!</span>")
-						grasping[L] = Beam(L, "vine", time=INFINITY, maxdistance=5, beam_type=/obj/effect/ebeam/vine)
+						grasping[L] = Beam(L, "vine", beam_type=/obj/effect/ebeam/vine)
 						tethers += list(L.AddComponent(/datum/component/tether, src, grasp_range+1, /obj/effect/ebeam/vine), AddComponent(/datum/component/tether, L, grasp_range+1, /obj/effect/ebeam/vine))
 						break //only take 1 new victim per cycle
 
@@ -131,7 +130,7 @@
 			if(O.density)
 				return
 	var/dist = get_dist(src,the_target)
-	Beam(the_target, "vine", time=dist*2, maxdistance=dist+2, beam_type=/obj/effect/ebeam/vine)
+	Beam(the_target, "vine", time=dist*2, beam_type=/obj/effect/ebeam/vine)
 	the_target.attack_animal(src)
 
 

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -92,7 +92,7 @@
 			if(L.stat == DEAD)
 				var/datum/beam/B = grasping[L]
 				if(B)
-					B.End()
+					qdel(B)
 				grasping -= L
 
 			//Can attack+pull multiple times per cycle

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -50,7 +50,7 @@
 			return
 		if(health < maxHealth)
 			adjustHealth(-25)
-			Beam(M,icon_state="sendbeam",time=4)
+			Beam(M, icon_state = "sendbeam" , time = 4)
 			M.visible_message("<span class='danger'>[M] heals \the <b>[src]</b>.</span>", \
 					   "<span class='cult'>You heal <b>[src]</b>, leaving <b>[src]</b> at <b>[health]/[maxHealth]</b> health.</span>")
 		else

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -185,6 +185,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/power_changes = TRUE
 	///Disables the sm's proccessing totally.
 	var/processes = TRUE
+	///Hue shift of the zaps color based on the power of the crystal
+	var/hue_angle_shift = 0
 
 /obj/machinery/power/supermatter_crystal/Initialize()
 	. = ..()
@@ -503,6 +505,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/h2obonus = 1 - (gas_comp[GAS_H2O] * 0.25)//At min this value should be 0.75
 //		var/freonbonus = (gas_comp[/datum/gas/freon] <= 0.03) //Let's just yeet power output if this shit is high
 
+	var/zap_color = color_matrix_rotate_hue(hue_angle_shift)
+
 	threshold_mod[GAS_PLUOXIUM] = pluoxiumbonus
 
 	//No less then zero, and no greater then one, we use this to do explosions and heat to power transfer
@@ -645,7 +649,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		if(zap_count >= 1)
 			playsound(src.loc, 'sound/weapons/emitter2.ogg', 100, TRUE, extrarange = 10)
 			for(var/i in 1 to zap_count)
-				supermatter_zap(src, range, clamp(power*2, 4000, 20000), flags)
+				supermatter_zap(src, range, clamp(power*2, 4000, 20000), flags, color = zap_color)
 
 		if(prob(5))
 			supermatter_anomaly_gen(src, FLUX_ANOMALY, rand(5, 10))
@@ -997,7 +1001,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			if(PYRO_ANOMALY)
 				new /obj/effect/anomaly/pyro(listener, 200)
 
-/obj/machinery/power/supermatter_crystal/proc/supermatter_zap(atom/zapstart = src, range = 5, zap_str = 4000, zap_flags = ZAP_GENERATES_POWER, list/targets_hit = list())
+/obj/machinery/power/supermatter_crystal/proc/supermatter_zap(atom/zapstart = src, range = 5, zap_str = 4000, zap_flags = ZAP_GENERATES_POWER, list/targets_hit = list(), color = null)
 	if(QDELETED(zapstart))
 		return
 	. = zapstart.dir
@@ -1084,7 +1088,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		//Do the animation to zap to it from here
 		if(!(zap_flags & ZAP_ALLOW_DUPLICATES))
 			LAZYSET(targets_hit, target, TRUE)
-		zapstart.Beam(target, icon_state=zap_icon, time=5)
+		zapstart.Beam(target, icon_state=zap_icon, time = 0.5 SECONDS, beam_color = color)
 		var/zapdir = get_dir(zapstart, target)
 		if(zapdir)
 			. = zapdir
@@ -1138,7 +1142,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		for(var/j in 1 to zap_count)
 			if(zap_count > 1)
 				targets_hit = targets_hit.Copy() //Pass by ref begone
-			supermatter_zap(target, new_range, zap_str, zap_flags, targets_hit)
+			supermatter_zap(target, new_range, zap_str, zap_flags, targets_hit, color)
 
 #undef HALLUCINATION_RANGE
 #undef GRAVITATIONAL_ANOMALY

--- a/code/modules/projectiles/guns/misc/medbeam.dm
+++ b/code/modules/projectiles/guns/misc/medbeam.dm
@@ -53,7 +53,7 @@
 
 	current_target = target
 	active = TRUE
-	current_beam = new(user,current_target,time=6000,beam_icon_state="medbeam",btype=/obj/effect/ebeam/medical)
+	current_beam = new(user,current_target,time=6000, icon_state="medbeam",beam_type=/obj/effect/ebeam/medical)
 	INVOKE_ASYNC(current_beam, /datum/beam.proc/Start)
 
 	SSblackbox.record_feedback("tally", "gun_fired", 1, type)

--- a/code/modules/projectiles/projectile/energy/tesla.dm
+++ b/code/modules/projectiles/projectile/energy/tesla.dm
@@ -9,7 +9,7 @@
 
 /obj/item/projectile/energy/tesla/fire(setAngle)
 	if(firer)
-		chain = firer.Beam(src, icon_state = "lightning[rand(1, 12)]", time = INFINITY, maxdistance = INFINITY)
+		chain = firer.Beam(src, icon_state = "lightning[rand(1, 12)]", time = INFINITY)
 	..()
 
 /obj/item/projectile/energy/tesla/on_hit(atom/target)

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -638,7 +638,7 @@
 
 /obj/item/projectile/magic/aoe/lightning/fire(setAngle)
 	if(caster)
-		chain = caster.Beam(src, icon_state = "lightning[rand(1, 12)]", time = INFINITY, maxdistance = INFINITY)
+		chain = caster.Beam(src, icon_state = "lightning[rand(1, 12)]", time = INFINITY)
 	..()
 
 /obj/item/projectile/magic/aoe/lightning/on_hit(target)

--- a/code/modules/projectiles/projectile/special/curse.dm
+++ b/code/modules/projectiles/projectile/special/curse.dm
@@ -22,7 +22,7 @@
 
 /obj/item/projectile/curse_hand/fire(setAngle)
 	if(starting)
-		arm = starting.Beam(src, icon_state = "curse[handedness]", time = INFINITY, maxdistance = INFINITY, beam_type=/obj/effect/ebeam/curse_arm)
+		arm = starting.Beam(src, icon_state = "curse[handedness]", beam_type=/obj/effect/ebeam/curse_arm)
 	..()
 
 /obj/item/projectile/curse_hand/prehit_pierce(atom/target)
@@ -30,7 +30,6 @@
 
 /obj/item/projectile/curse_hand/Destroy()
 	if(arm)
-		arm.End()
 		QDEL_NULL(arm)
 	if((movement_type & PHASING))
 		playsound(src, 'sound/effects/curse3.ogg', 25, TRUE, -1)
@@ -39,9 +38,7 @@
 	for(var/obj/effect/temp_visual/dir_setting/curse/grasp_portal/G in starting)
 		qdel(G)
 	new /obj/effect/temp_visual/dir_setting/curse/grasp_portal/fading(starting, dir)
-	var/datum/beam/D = starting?.Beam(T, icon_state = "curse[handedness]", time = 32, maxdistance = INFINITY, beam_type=/obj/effect/ebeam/curse_arm, beam_sleep_time = 1)
-	for(var/b in D?.elements)
-		var/obj/effect/ebeam/B = b
-		animate(B, alpha = 0, time = 32)
+	var/datum/beam/D = starting.Beam(T, icon_state = "curse[handedness]", time = 32, beam_type=/obj/effect/ebeam/curse_arm)
+	animate(D.visuals, alpha = 0, time = 32)
 	return ..()
 

--- a/code/modules/spells/spell_types/lichdom.dm
+++ b/code/modules/spells/spell_types/lichdom.dm
@@ -154,7 +154,7 @@
 		var/wheres_wizdo = dir2text(get_dir(body_turf, item_turf))
 		if(wheres_wizdo)
 			old_body.visible_message("<span class='warning'>Suddenly [old_body.name]'s corpse falls to pieces! You see a strange energy rise from the remains, and speed off towards the [wheres_wizdo]!</span>")
-			body_turf.Beam(item_turf,icon_state="lichbeam",time=10+10*resurrections,maxdistance=INFINITY)
+			body_turf.Beam(item_turf, icon_state = "lichbeam", time = 10 + 10 * resurrections)
 		old_body.dust()
 
 

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -207,7 +207,7 @@
 		else
 			SSexplosions.highturf += tile
 
-	point.Beam(target, icon_state = "bsa_beam", time = 50, maxdistance = world.maxx) //ZZZAP
+	point.Beam(target, icon_state = "bsa_beam", time = 5 SECONDS) //ZZZAP
 	new /obj/effect/temp_visual/bsa_splash(point, dir)
 
 	if(!blocker)

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -158,7 +158,7 @@
 		if(get_dist(M,src) > kill_range)
 			continue
 		if(!(obj_flags & EMAGGED) && space_los(M))
-			Beam(get_turf(M),icon_state="sat_beam",time=5,maxdistance=kill_range)
+			Beam(get_turf(M), icon_state = "sat_beam", time = 5)
 			qdel(M)
 
 /obj/machinery/satellite/meteor_shield/toggle(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Port of 
https://github.com/tgstation/tgstation/pull/66639
https://github.com/tgstation/tgstation/pull/55193

Refactors our beams to not be old and yucky, also allows you to color beams based on properties used with sm zaps(not really that useful but still.)

Also Huge removal of dead vars, bad timers, and other sloppy jitteriness from beams. They go from checking movement to waiting for a signal.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less stupid lag, movement updates not needed, cleaner happier code
Allows for fishin in the future
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/82520990/185811075-b676c517-17c2-4d82-86ef-01e0f62e2ed1.png)

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
qol: supermatter zaps now change color based on the power generated, starting from red and going toward blue the higher the power emitted
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
