### PR TITLE
Summon Guns Change

### DIFF
--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -12,5 +12,9 @@
 
 /obj/item/projectile/bullet/a762_enchanted
 	name = "enchanted 7.62 bullet"
-	damage = 20
-	stamina = 80
+	damage = 30
+
+/obj/item/projectile/bullet/a762_enchanted/Impact(atom/A)
+	damage_type = pick(BRUTE, BURN, CLONE, TOX, STAMINA, BRAIN)
+	..()
+

--- a/code/modules/spells/spell_types/infinite_guns.dm
+++ b/code/modules/spells/spell_types/infinite_guns.dm
@@ -1,6 +1,6 @@
 /obj/effect/proc_holder/spell/targeted/infinite_guns
 	name = "Lesser Summon Guns"
-	desc = "Why reload when you have infinite guns? Summons an unending stream of bolt action rifles that deal little damage, but will knock targets down. Requires both hands free to use. Learning this spell makes you unable to learn Arcane Barrage."
+	desc = "Why reload when you have infinite guns? Summons an unending stream of bolt action rifles that deal medium damage in chaotic ways. Requires both hands free to use. Learning this spell makes you unable to learn Arcane Barrage."
 	invocation_type = "none"
 	include_user = TRUE
 	range = -1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Lesser Summon Guns damage increased per shot from 20 to 30.

Lesser Summon Guns base Stamina damage removed.

Lesser Summon Guns damage type is randomized between BRUTE, BURN, CLONE, TOX, STAMINA, BRAIN upon hitting a target.

Lesser Summon Guns description updated.


## Why It's Good For The Game

As it stands, enchanted mosins will two-shot stamcrit a target.
This is uninteresting for either player and doesn't give any real "magic" feeling.
Randomizing the damage type will give the wizard an advantage by making it so players are unable to prepare for specific attacks and overload medbay due to multiple types of damage coming in.

## Changelog

:cl:
balance:Lesser Summon Guns damage increased per shot from 20 to 30.
balance:Lesser Summon Guns base Stamina damage removed.
add:Lesser Summon Guns damage type is randomized between BRUTE, BURN, CLONE, TOX, STAMINA, BRAIN upon hitting a target.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
