### PR TITLE
Mothroach Fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mothroach.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mothroach.dm
@@ -30,7 +30,7 @@
 	verb_exclaim = "flutters loudly"
 	verb_yell = "flutters loudly"
 	response_help = "pets"
-	attacked_sound = 'sound/voice/moth/scream_moth.ogg'
+	attacked_sound = null
 
 	faction = list("neutral")
 
@@ -46,14 +46,14 @@
 		icon_state = "mothroach"
 	regenerate_icons()
 
-/mob/living/basic/mothroach/attack_hand(mob/living/carbon/human/user, list/modifiers)
+/mob/living/simple_animal/mothroach/attack_hand(mob/living/carbon/human/user, list/modifiers)
 	. = ..()
 	if(src.stat == DEAD)
 		return
 	else
 		playsound(loc, 'sound/voice/moth/scream_moth.ogg', 50, TRUE)
 
-/mob/living/basic/mothroach/attackby(obj/item/attacking_item, mob/living/user, params)
+/mob/living/simple_animal/mothroach/attackby(obj/item/attacking_item, mob/living/user, params)
 	. = ..()
 	if(src.stat == DEAD)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Mothroaches no longer scream in death.

Removes the double definition of Mothroaches.


## Why It's Good For The Game

Didn't catch these when reviewing, easy fixes.

## Changelog

:cl:
fix: The moffroaches are happy again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
