### PR TITLE
Fixes processing of deleted objects in SSair

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -156,6 +156,9 @@
 
 	///Is this machine currently in the atmos machinery queue?
 	var/atmos_processing = FALSE
+	///Is this machine currently in the atmos machinery queue, but also interacting with turf air?
+	var/interacts_with_air = FALSE
+
 	/// world.time of last use by [/mob/living]
 	var/last_used_time = 0
 	/// Mobtype of last user. Typecast to [/mob/living] for initial() usage
@@ -169,7 +172,7 @@
 
 /obj/machinery/Initialize(mapload)
 	if(!armor)
-		armor = list(MELEE = 25, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 70)
+		armor = list(MELEE = 25, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 70, STAMINA = 0)
 	. = ..()
 	GLOB.machines += src
 

--- a/code/game/machinery/airlock_cycle_control.dm
+++ b/code/game/machinery/airlock_cycle_control.dm
@@ -117,12 +117,12 @@
 	qdel(wires)
 	wires = null
 	cut_links()
-	SSair.atmos_machinery -= src
+	SSair.start_processing_machine(src)
 	return ..()
 
 /obj/machinery/advanced_airlock_controller/Initialize(mapload)
 	. = ..()
-	SSair.atmos_machinery += src
+	SSair.stop_processing_machine(src)
 	scan_on_late_init = mapload
 	if(mapload && (. != INITIALIZE_HINT_QDEL))
 		return INITIALIZE_HINT_LATELOAD

--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -7,9 +7,9 @@
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "gsensor1"
 	resistance_flags = FIRE_PROOF
+	interacts_with_air = TRUE
 
 	var/on = TRUE
-
 	var/frequency = FREQ_ATMOS_STORAGE
 	var/datum/radio_frequency/radio_connection
 
@@ -75,11 +75,11 @@
 
 /obj/machinery/air_sensor/Initialize(mapload)
 	. = ..()
-	SSair.atmos_air_machinery += src
+	SSair.start_processing_machine(src)
 	set_frequency(frequency)
 
 /obj/machinery/air_sensor/Destroy()
-	SSair.atmos_air_machinery -= src
+	SSair.stop_processing_machine(src)
 	SSradio.remove_object(src, frequency)
 	return ..()
 

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -17,6 +17,7 @@
 	circuit = /obj/item/circuitboard/machine/space_heater
 	//We don't use area power, we always use the cell
 	use_power = NO_POWER_USE
+	interacts_with_air = TRUE
 
 	///The cell we spawn with
 	var/obj/item/stock_parts/cell/cell = /obj/item/stock_parts/cell
@@ -49,9 +50,10 @@
 	if(ispath(cell))
 		cell = new cell(src)
 	update_appearance()
+	SSair.start_processing_machine(src)
 
 /obj/machinery/space_heater/Destroy()
-	SSair.atmos_air_machinery -= src
+	SSair.stop_processing_machine(src)
 	return..()
 
 /obj/machinery/space_heater/on_deconstruction()
@@ -196,9 +198,9 @@
 	usr.visible_message(span_notice("[usr] switches [on ? "on" : "off"] \the [src]."), span_notice("You switch [on ? "on" : "off"] \the [src]."))
 	update_appearance()
 	if(on)
-		SSair.atmos_air_machinery += src
+		SSair.start_processing_machine(src)
 	else
-		SSair.atmos_air_machinery -= src
+		SSair.stop_processing_machine(src)
 
 /obj/machinery/space_heater/ui_state(mob/user)
 	return GLOB.physical_state

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -39,7 +39,6 @@
 	var/on = FALSE
 	/// whether it can be painted
 	var/paintable = FALSE
-	var/interacts_with_air = FALSE
 
 	///keeps the name of the object from being overridden if it's vareditted.
 	var/override_naming
@@ -65,10 +64,7 @@
 		armor = list("melee" = 25, "bullet" = 10, "laser" = 10, "energy" = 100, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 70, "stamina" = 0)
 	..()
 	if(process)
-		if(interacts_with_air)
-			SSair.atmos_air_machinery += src
-		else
-			SSair.atmos_machinery += src
+		SSair.start_processing_machine(src)
 	SetInitDirections()
 
 /obj/machinery/atmospherics/Initialize(mapload)
@@ -85,8 +81,7 @@
 	for(var/i in 1 to device_type)
 		nullifyNode(i)
 
-	SSair.atmos_machinery -= src
-	SSair.atmos_air_machinery -= src
+	SSair.stop_processing_machine(src)
 	SSair.pipenets_needing_rebuilt -= src
 
 	if(pipe_vision_img)

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -31,6 +31,7 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/Initialize(mapload)
 	. = ..()
 	initialize_directions = dir
+	SSair.start_processing_machine(src) //initialize thermomachines to SSairs list of tickable machines
 	RefreshParts()
 	update_icon()
 

--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -21,13 +21,13 @@
 /obj/machinery/meter/Initialize(mapload, new_piping_layer)
 	if(!isnull(new_piping_layer))
 		target_layer = new_piping_layer
-	SSair.atmos_machinery += src
+	SSair.start_processing_machine(src)
 	if(!target)
 		reattach_to_layer()
 	return ..()
 
 /obj/machinery/meter/Destroy()
-	SSair.atmos_machinery -= src
+	SSair.stop_processing_machine(src)
 	target = null
 	return ..()
 

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -219,7 +219,7 @@
 	if(href_list[VV_HK_MODIFY_CANISTER_GAS])
 		usr.client.modify_canister_gas(src)
 
-/obj/machinery/portable_atmospherics/canister/New(loc, datum/gas_mixture/existing_mixture)
+/obj/machinery/portable_atmospherics/canister/Initialize(mapload, datum/gas_mixture/existing_mixture)
 	. = ..()
 	if(existing_mixture)
 		air_contents.copy_from(existing_mixture)

--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -5,32 +5,26 @@
 	max_integrity = 250
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 100, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 60, "acid" = 30, "stamina" = 0)
 	anchored = FALSE
+	interacts_with_air = TRUE
 
 	var/datum/gas_mixture/air_contents
 	var/obj/machinery/atmospherics/components/unary/portables_connector/connected_port
 	var/obj/item/tank/holding
 
 	var/volume = 0
-
 	var/maximum_pressure = 90 * ONE_ATMOSPHERE
 
-/obj/machinery/portable_atmospherics/New()
-	..()
-	SSair.atmos_air_machinery += src
-
+/obj/machinery/portable_atmospherics/Initialize(mapload)
+	. = ..()
 	air_contents = new(volume)
 	air_contents.set_temperature(T20C)
-
-	return 1
+	SSair.start_processing_machine(src)
 
 /obj/machinery/portable_atmospherics/Destroy()
-	SSair.atmos_air_machinery -= src
+	SSair.stop_processing_machine(src)
 	disconnect()
 	qdel(air_contents)
 	air_contents = null
-
-	SSair.atmos_machinery -= src
-
 	return ..()
 
 /obj/machinery/portable_atmospherics/ex_act(severity, target)

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -18,7 +18,7 @@
 	. = ..()
 	find_circs()
 	connect_to_network()
-	SSair.atmos_machinery += src
+	SSair.start_processing_machine(src)
 	update_icon()
 
 /obj/machinery/power/generator/ComponentInitialize()
@@ -27,7 +27,7 @@
 
 /obj/machinery/power/generator/Destroy()
 	kill_circs()
-	SSair.atmos_machinery -= src
+	SSair.stop_processing_machine(src)
 	return ..()
 
 /obj/machinery/power/generator/update_icon()

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -88,6 +88,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	light_range = 4
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF | FREEZE_PROOF
 	critical_machine = TRUE
+	interacts_with_air = TRUE
 
 	///The id of our supermatter
 	var/unique_id = 1
@@ -188,7 +189,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 /obj/machinery/power/supermatter_crystal/Initialize()
 	. = ..()
-	SSair.atmos_air_machinery += src
+	SSair.start_processing_machine(src)
 	countdown = new(src)
 	countdown.start()
 	GLOB.poi_list |= src
@@ -207,7 +208,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 /obj/machinery/power/supermatter_crystal/Destroy()
 	investigate_log("has been destroyed.", INVESTIGATE_ENGINES)
-	SSair.atmos_air_machinery -= src
+	SSair.stop_processing_machine(src)
 	QDEL_NULL(radio)
 	GLOB.poi_list -= src
 	QDEL_NULL(countdown)

--- a/monkestation/code/modules/power/rbmk/rbmk.dm
+++ b/monkestation/code/modules/power/rbmk/rbmk.dm
@@ -628,6 +628,7 @@ The reactor CHEWS through moderator. It does not do this slowly. Be very careful
 //Shuts off the fuel rods, ambience, etc. Keep in mind that your temperature may still go up!
 /obj/machinery/atmospherics/components/trinary/nuclear_reactor/proc/shut_down()
 	STOP_PROCESSING(SSmachines, src)
+	SSair.stop_processing_machine(src)
 	stop_relay(CHANNEL_ENGINE_ALERT)
 
 	investigate_log("Reactor shutdown at [pressure] kPa and [temperature] C.", INVESTIGATE_ENGINES)

--- a/monkestation/code/modules/power/rbmk/rbmk.dm
+++ b/monkestation/code/modules/power/rbmk/rbmk.dm
@@ -526,7 +526,7 @@ The reactor CHEWS through moderator. It does not do this slowly. Be very careful
 //Results: Engineering becomes unusable and your engine irreparable
 /obj/machinery/atmospherics/components/trinary/nuclear_reactor/proc/meltdown()
 	set waitfor = FALSE
-	SSair.atmos_machinery -= src //Annd we're now just a useless brick.
+	SSair.stop_processing_machine(src) //Annd we're now just a useless brick.
 	slagged = TRUE
 	update_icon()
 	STOP_PROCESSING(SSmachines, src)
@@ -617,6 +617,7 @@ The reactor CHEWS through moderator. It does not do this slowly. Be very careful
 /obj/machinery/atmospherics/components/trinary/nuclear_reactor/proc/start_up()
 	if(slagged)
 		return // No :)
+	SSair.start_processing_machine(src)
 	START_PROCESSING(SSmachines, src)
 	desired_k = 1
 	set_light(10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Quote from Timberpoes: https://github.com/tgstation/tgstation/pull/53735
> qdel'd objects could still process in SSair because SSair utilises a cache whenever it has to resume processing runs from a partially completed state from running out of processing time.
>Of all the things that processed on SSair, only one thing actually took care to remove itself from the cache as well on deletion.
>This is an important subsystem and the processing lists should not be public. Objects don't need to know how SSair works, they just call the proc to add when they start processing and call the proc to remove when they finish.

https://github.com/shiptest-ss13/Shiptest/pull/585 (accounts for auxmos differences)

## Why It's Good For The Game
Fixes runtimes from atmos processing machines

## Testing Photographs and Procedure
Noticeable change, is that the canisters do not cause a runtime `null.return_pressure()` anymore when releasing gas.
All machines appear to be working with no noticeable differences, keep an eye on the RBMK when test merging. Haven't noticed anything, but it is a bit different compared to other machines

## Changelog

:cl: timberpoes, Ninjanomnom, CoffeeKat, DoctorSquishy
 fix: Fixed a runtime in the air subsystem, where deleted objects were still processed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
