### PR TITLE
Makes alien embryo die if it's host dies

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -20,6 +20,8 @@
 
 /obj/item/organ/body_egg/alien_embryo/on_life()
 	. = ..()
+	if(owner.stat == DEAD)
+		qdel(src)
 	switch(stage)
 		if(2, 3)
 			if(prob(2))


### PR DESCRIPTION
# About The Pull Request

Mr Streamer said. also just a really good idea.

## Why It's Good For The Game

Makes it so the aliens inside people die if the host dies, preventing them from just alien at someone -> Kill, or spacing everything and planting eggs on the nearly dead people.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
balance: Alien Embryos die out if their host dies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
