### PR TITLE
Abandoned Wall Removal

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -155,23 +155,13 @@
 	if(abandoned)
 		var/outcome = rand(1,100)
 		switch(outcome)
-			if(1 to 9)
-				var/turf/here = get_turf(src)
-				for(var/turf/closed/T in range(2, src))
-					here.PlaceOnTop(T.type)
-					qdel(src)
-					return
-				here.PlaceOnTop(/turf/closed/wall)
-				qdel(src)
-				return
-			if(9 to 11)
+			if(1 to 3)
 				lights = FALSE
+			if(4 to 7)
 				locked = TRUE
-			if(12 to 15)
-				locked = TRUE
-			if(16 to 23)
+			if(8 to 15)
 				welded = TRUE
-			if(24 to 30)
+			if(16 to 25)
 				panel_open = TRUE
 	if(cutAiWire)
 		wires.cut(WIRE_AI)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Removes the chance of a wall replacing an abandoned airlock.

## Why It's Good For The Game

With how many maint spawns we have, including both stowaway and gimmicks?
They often get trapped with no real way to get out.

## Changelog

:cl:
del: Removes abandoned airlocks creating walls
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
