### PR TITLE
Mimic buffs

### DIFF
--- a/monkestation/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/monkestation/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -17,16 +17,20 @@
 	minimum_players = 30
 	requirements = list(101,101,101,30,30,30,30,30,10,10)
 	repeatable = FALSE
+	var/spawn_location
 
 /datum/dynamic_ruleset/midround/from_ghosts/mimic/execute()
 	if(!GLOB.xeno_spawn.len)
 		log_admin("Cannot accept Mimic ruleset. Couldn't find any xeno spawn points.")
 		message_admins("Cannot accept Mimic ruleset. Couldn't find any xeno spawn points.")
 		return FALSE
+	spawn_location = pick(GLOB.xeno_spawn)
 	. = ..()
 
 /datum/dynamic_ruleset/midround/from_ghosts/mimic/generate_ruleset_body(mob/applicant)
-	var/mob/living/simple_animal/hostile/alien_mimic/spawned_mimic = new(pick(GLOB.xeno_spawn))
+	if(!spawn_location) //You never know
+		spawn_location = pick(GLOB.xeno_spawn)
+	var/mob/living/simple_animal/hostile/alien_mimic/spawned_mimic = new(spawn_location)
 	var/datum/mind/player_mind = new(applicant.key)
 	player_mind.assigned_role = "Mimic"
 	player_mind.special_role = "Mimic"
@@ -38,7 +42,7 @@
 	if(spawned_mimic.mimic_count <= 1)
 		spawned_mimic.hivemind_name = pick("Mimic Leader","Mimic [pick("King","Queen","Monarch")]","The Broodmother","The Original","Mimic Prime")
 	else
-		spawned_mimic.hivemind_name = pick("Mimic Commander","Mimic Centurion","Mimic General","Mimic Lord","Mimic Legionnaire","Mimic Elder") + " [rand(1,99)]" //Unless multiple spawned, then any others get their own names
+		spawned_mimic.hivemind_name = pick("Mimic Commander","Mimic Centurion","Mimic General","Mimic Lord","Mimic Legionnaire","Mimic Elder") + " [spawned_mimic.mimic_count - 1]" //Unless multiple spawned, then any others get their own names
 
 	message_admins("[ADMIN_LOOKUPFLW(spawned_mimic)] has been made into a Mimic by the midround ruleset.")
 	log_game("DYNAMIC: [key_name(spawned_mimic)] was spawned as a Mimic by the midround ruleset.")

--- a/monkestation/code/modules/antagonists/mimic/mimic.dm
+++ b/monkestation/code/modules/antagonists/mimic/mimic.dm
@@ -360,11 +360,13 @@
 		if(disguised)
 			restore()
 		return ..()
-	if(iscyborg(target) || isAI(target)) //stinky sillicons with their no mounting rules
-		return ..()
 
 	if(!isliving(target))
 		return
+
+	if(iscyborg(target) || isAI(target)) //stinky sillicons with their no mounting rules
+		victim.apply_damage(melee_damage, BRUTE, victim.get_bodypart(BODY_ZONE_CHEST)) //mimics still get the full damage, though it does feel a little dirty to deal the same damage twice
+		return ..()
 
 	var/mob/living/victim = target
 

--- a/monkestation/code/modules/antagonists/mimic/mimic.dm
+++ b/monkestation/code/modules/antagonists/mimic/mimic.dm
@@ -364,11 +364,11 @@
 	if(!isliving(target))
 		return
 
+	var/mob/living/victim = target
+
 	if(iscyborg(target) || isAI(target)) //stinky sillicons with their no mounting rules
 		victim.apply_damage(melee_damage, BRUTE, victim.get_bodypart(BODY_ZONE_CHEST)) //mimics still get the full damage, though it does feel a little dirty to deal the same damage twice
 		return ..()
-
-	var/mob/living/victim = target
 
 	if(buckled && victim == buckled) //If you're buckled to them
 		victim.apply_damage(melee_damage, CLONE, victim.get_bodypart(BODY_ZONE_CHEST))

--- a/monkestation/code/modules/antagonists/mimic/mimic.dm
+++ b/monkestation/code/modules/antagonists/mimic/mimic.dm
@@ -23,12 +23,13 @@
 	stat_attack = UNCONSCIOUS
 	mob_size = MOB_SIZE_SMALL
 	pass_flags = PASSTABLE | PASSMOB
+	ventcrawler = VENTCRAWLER_ALWAYS
 	unsuitable_atmos_damage = 0 //They won't die in Space!
 	minbodytemp = TCMB
 	maxbodytemp = T0C + 40
 	maxHealth = 125
 	health = 125
-	melee_damage = 10
+	melee_damage = 7
 	obj_damage = 30
 	see_in_dark = 8
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
@@ -355,8 +356,6 @@
 		restore()
 		return
 
-	if(buckled && target == buckled) //If you're buckled to them
-		return ..()
 	if(!ismob(target)) //If you're attacking something or other
 		if(disguised)
 			restore()
@@ -364,8 +363,16 @@
 	if(iscyborg(target) || isAI(target)) //stinky sillicons with their no mounting rules
 		return ..()
 
-	if(isliving(target) && !buckled) //Latch onto people
-		var/mob/living/victim = target
+	if(!isliving(target))
+		return
+
+	var/mob/living/victim = target
+
+	if(buckled && victim == buckled) //If you're buckled to them
+		victim.apply_damage(melee_damage, CLONE, victim.get_bodypart(BODY_ZONE_CHEST))
+		return ..()
+
+	if(!buckled) //Latch onto people
 		if(iscarbon(victim) && victim.stat == DEAD && !HAS_TRAIT(victim, TRAIT_HUSK)) //Absorb someone to heal
 			var/mob/living/carbon/carbon_victim = victim
 			if(!carbon_victim.last_mind)


### PR DESCRIPTION
# About The Pull Request

Mimics are very weak when anyone finds them. They will now kill a little faster, while still leaving enough time for people to call out the mimic. Mimics can also vent crawl, which is very good for their mobility.

## Why It's Good For The Game

Mimics currently get gimped Hard if there isn't another antag or event to distract people. This will hopefully help them in those situations, while not completely stomping in more advantageous situations

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
balance: Mimics now deal 7 brute and 7 clone damage instead of just 10 brute.
tweak: Mimics can now vent crawl, along with breaking down doors like normal.
tweak: Mimics now spawn together when they are initially triggered
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
