### PR TITLE
Quirk spawn() usage

### DIFF
--- a/monkestation/code/datums/traits/negative.dm
+++ b/monkestation/code/datums/traits/negative.dm
@@ -5,16 +5,21 @@
 
 /datum/quirk/jailbird/post_add()
 	. = ..()
-	spawn(3 SECONDS) //Deliberately delayed a while to allow for the actual data_core entry to be created
-		var/mob/living/carbon/human/H = quirk_holder
-		var/quirk_crime	= pick(world.file2list("monkestation/strings/random_crimes.txt"))
-		to_chat(H, "<span class='boldnotice'>You are on the run for your crime of: [quirk_crime]!</span>")
-		var/crime = GLOB.data_core.createCrimeEntry(quirk_crime, "Galactic Crime Broadcast", "[pick(world.file2list("monkestation/strings/random_police.txt"))]", "[(rand(9)+1)] [pick("days", "weeks", "months", "years")] ago", 0)
-		var/perpname = H.name
-		var/datum/data/record/R = find_record("name", perpname, GLOB.data_core.security)
-		GLOB.data_core.addCrime(R.fields["id"], crime)
-		R.fields["criminal"] = "Arrest"
-		H.sec_hud_set_security_status()
+	var/mob/living/carbon/human/jailbird = quirk_holder
+	var/quirk_crime	= pick(world.file2list("monkestation/strings/random_crimes.txt"))
+	to_chat(jailbird, "<span class='boldnotice'>You are on the run for your crime of: [quirk_crime]!</span>")
+	addtimer(CALLBACK(src, .proc/apply_arrest, quirk_crime), 5 SECONDS)
+
+
+/datum/quirk/jailbird/proc/apply_arrest(crime_name)
+	var/mob/living/carbon/human/jailbird = quirk_holder
+	var/crime = GLOB.data_core.createCrimeEntry(crime_name, "Galactic Crime Broadcast", "[pick(world.file2list("monkestation/strings/random_police.txt"))]", "[(rand(9)+1)] [pick("days", "weeks", "months", "years")] ago", 0)
+	var/perpname = jailbird.name
+	var/datum/data/record/jailbird_record = find_record("name", perpname, GLOB.data_core.security)
+
+	GLOB.data_core.addCrime(jailbird_record.fields["id"], crime)
+	jailbird_record.fields["criminal"] = "Arrest"
+	jailbird.sec_hud_set_security_status()
 
 /datum/quirk/stowaway
 	name = "Stowaway"
@@ -23,25 +28,27 @@
 
 /datum/quirk/stowaway/on_spawn()
 	. = ..()
-	var/mob/living/carbon/human/H = quirk_holder
-	H.Sleeping(5 SECONDS, TRUE, TRUE) //This is both flavorful and gives time for the rest of the code to work.
-	var/obj/item/card/id/trashed = H.get_item_by_slot(ITEM_SLOT_ID) //No ID
+	var/mob/living/carbon/human/stowaway = quirk_holder
+	stowaway.Sleeping(5 SECONDS, TRUE, TRUE) //This is both flavorful and gives time for the rest of the code to work.
+	var/obj/item/card/id/trashed = stowaway.get_item_by_slot(ITEM_SLOT_ID) //No ID
 	qdel(trashed)
 	if(prob(20))
-		H.drunkenness = 50 //What did I DO last night?
+		stowaway.drunkenness = 50 //What did I DO last night?
 	var/obj/structure/closet/selected_closet = get_unlocked_closed_locker() //Find your new home
 	if(selected_closet)
-		H.forceMove(selected_closet) //Move in
+		stowaway.forceMove(selected_closet) //Move in
 
 
 /datum/quirk/stowaway/post_add()
 	. = ..()
-	spawn(4 SECONDS) //Gives enough time for the data_core entry to get created
-		var/mob/living/carbon/human/H = quirk_holder
-		var/perpname = H.name
-		var/datum/data/record/R = find_record("name", perpname, GLOB.data_core.general)
-		qdel(R)
-		to_chat(H, "<span class='boldnotice'>You've awoken to find yourself inside [GLOB.station_name] without identification!</span>")
+	to_chat(quirk_holder, "<span class='boldnotice'>You've awoken to find yourself inside [GLOB.station_name] without identification!</span>")
+	addtimer(CALLBACK(src, .proc/datacore_deletion), 5 SECONDS)
+
+/datum/quirk/stowaway/proc/datacore_deletion()
+	var/mob/living/carbon/human/stowaway = quirk_holder
+	var/perpname = stowaway.name
+	var/datum/data/record/record_deletion = find_record("name", perpname, GLOB.data_core.general)
+	qdel(record_deletion)
 
 /datum/quirk/unstable_ass
 	name = "Unstable Rear"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Removes the unneeded spawn() usage in the Jailbird and Stowaway quirks.
Now uses proc callbacks.

## Why It's Good For The Game

Cleaning up my newbie code a bit.


## Changelog

:cl:
refactor: Jailbird and Stowaway should be more reliable under high server load.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
