### PR TITLE
Making Captain's Jumpskirt and gladiator uniform digitigrade compatible

### DIFF
--- a/code/modules/clothing/under/costume.dm
+++ b/code/modules/clothing/under/costume.dm
@@ -102,6 +102,7 @@
 	fitted = NO_FEMALE_UNIFORM
 	can_adjust = FALSE
 	resistance_flags = NONE
+	supports_variations = DIGITIGRADE_VARIATION_NO_NEW_ICON
 
 /obj/item/clothing/under/costume/gladiator/ash_walker
 	desc = "This gladiator uniform appears to be covered in ash and fairly dated."

--- a/code/modules/clothing/under/jobs/command.dm
+++ b/code/modules/clothing/under/jobs/command.dm
@@ -15,6 +15,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
+	supports_variations = DIGITIGRADE_VARIATION_NO_NEW_ICON
 
 /obj/item/clothing/under/rank/captain/suit
 	name = "captain's suit"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Adds digitigrade support for the Captain's Jumpskirt by adding one line of code, fixes #688. Additionally makes the gladiator and Ashwalker gladiator armor variant show the digitigrade legs as they seem to have ample space for them.

## Why It's Good For The Game

In the off-chance there is a digitigrade lizard captain, I'm sure they'd appreciate having digitigrade legs show when using the jumpskirt. Additionally, if Ashwalkers are also digitigrade in this codebase, I'm sure they'd also like seeing their different legs rather than having it revert to standard legs.

</details>

## Changelog

:cl:
fix: For lizards with digitigrade legs, the digi legs are now shown rather than the standard straight legs when using the Captain's jumpskirt. Also affects the gladiator uniform.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
