### PR TITLE
fixes morgue tray icon states

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -45,9 +45,6 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 	..()
 	update_icon()
 
-/obj/structure/bodycontainer/update_icon()
-	return
-
 /obj/structure/bodycontainer/relaymove(mob/user)
 	if(user.stat || !isturf(loc))
 		return


### PR DESCRIPTION
# About The Pull Request

update_icon_state was relying on update_icon to call it, but update_icon for the bodycontainers thing was set to just return. I dont know if this was done for a reason, but removing that makes it work. I even tried with the crematorium since thats the only other subtype of bodycontainer, and that still works perfectly fine as well.

The non-ssd corpse alarm also was in update_icon_state, so that works too.

## Why It's Good For The Game

useful features working is usually useful
closes #709

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
fix: morgue trays update their sprites correctly again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
