### PR TITLE
Revolution Announcement Change

### DIFF
--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -2,7 +2,6 @@
 #define DECONVERTER_REVS_WIN "gamemode_revs_win"
 //How often to check for promotion possibility
 #define HEAD_UPDATE_PERIOD 30 SECONDS
-#define REV_ANNOUNCE_PERCENTAGE 0.3 //30% pop converted will trigger an announcement.
 
 /datum/antagonist/rev
 	name = "Revolutionary"
@@ -198,8 +197,6 @@
 		rev_mind.current.Stun(10 SECONDS)
 	rev_mind.add_antag_datum(/datum/antagonist/rev,rev_team)
 	rev_mind.special_role = ROLE_REV
-	if(!rev_team.announced_revolution)
-		check_for_announcement()
 	return TRUE
 
 /datum/antagonist/rev/head/proc/demote()
@@ -258,25 +255,6 @@
 		C.Unconscious(100)
 	owner.remove_antag_datum(type)
 
-/datum/antagonist/rev/proc/check_for_announcement()
-
-	if(rev_team.announced_revolution)
-		return
-
-	var/alive = 0
-	var/revolutionaries = 0
-
-	for(var/mob/player in GLOB.player_list)
-		if(player.stat != DEAD)
-			if(is_revolutionary(player) || is_head_revolutionary(player))
-				++revolutionaries
-			else
-				++alive
-	var/ratio = revolutionaries/alive
-	if(ratio > REV_ANNOUNCE_PERCENTAGE)
-		priority_announce("Behavior unacceptable to the Corporation has been detected on your station.\nAll crew are required to quell any and all unionization attempts by any means necessary.\nGlory to Nanotrasen.", null, SSstation.announcer.get_rand_report_sound(), null, "Central Command Loyalty Monitoring Division")
-		rev_team.announced_revolution = TRUE
-
 /datum/antagonist/rev/head/remove_revolutionary(borged,deconverter)
 	if(borged || deconverter == DECONVERTER_STATION_WIN || deconverter == DECONVERTER_REVS_WIN)
 		. = ..()
@@ -330,6 +308,16 @@
 	var/highest_head_count
 	var/list/ex_headrevs = list() // Dynamic removes revs on loss, used to keep a list for the roundend report.
 	var/list/ex_revs = list()
+
+/datum/team/revolution/New(starting_members)
+	. = ..()
+	addtimer(CALLBACK(src, .proc/announce_revolution), 25 MINUTES)
+
+/datum/team/revolution/proc/announce_revolution()
+	if(announced_revolution)
+		return
+	announced_revolution = TRUE
+	priority_announce("Behavior unacceptable to the Corporation has been detected on your station.\nAll crew are required to quell any and all unionization attempts by any means necessary.\nGlory to Nanotrasen.", null, SSstation.announcer.get_rand_report_sound(), null, "Central Command Loyalty Monitoring Division")
 
 /datum/team/revolution/proc/update_objectives(initial = FALSE)
 	var/untracked_heads = SSjob.get_all_heads()
@@ -585,4 +573,3 @@
 
 #undef DECONVERTER_STATION_WIN
 #undef DECONVERTER_REVS_WIN
-#undef REV_ANNOUNCE_PERCENTAGE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Removes the busted revolution announcement check and replaces it with a simple timer before announcing.

## Why It's Good For The Game

Announcement good, broken announcement bad.
Untestable code REALLY bad.

## Changelog

:cl:
tweak: The revolution announcement will no longer be televised immediately.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
