### PR TITLE
Add new turf decal colors

### DIFF
--- a/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
+++ b/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
@@ -187,35 +187,35 @@
 	name = "gray tile"
 	icon_state = "tile_full"
 
-/obj/effect/turf_decal/tile/darkpurple
+/obj/effect/turf_decal/tile/dark_purple
 	name = "dark purple corner"
 	color = "#6C1282"
 
-/obj/effect/turf_decal/tile/darkpurple/tile_marquee
+/obj/effect/turf_decal/tile/dark_purple/tile_marquee
 	name = "dark purple marquee"
 	icon_state = "tile_marquee"
 
-/obj/effect/turf_decal/tile/darkpurple/tile_side
+/obj/effect/turf_decal/tile/dark_purple/tile_side
 	name = "dark purple side"
 	icon_state = "tile_side"
 
-/obj/effect/turf_decal/tile/darkpurple/tile_full
+/obj/effect/turf_decal/tile/dark_purple/tile_full
 	name = "dark purple tile"
 	icon_state = "tile_full"
 
-/obj/effect/turf_decal/tile/darkred
+/obj/effect/turf_decal/tile/dark_red
 	name = "dark red corner"
 	color = "#4F0000"
 
-/obj/effect/turf_decal/tile/darkred/tile_marquee
+/obj/effect/turf_decal/tile/dark_red/tile_marquee
 	name = "dark red marquee"
 	icon_state = "tile_marquee"
 
-/obj/effect/turf_decal/tile/darkred/tile_side
+/obj/effect/turf_decal/tile/dark_red/tile_side
 	name = "dark red side"
 	icon_state = "tile_side"
 
-/obj/effect/turf_decal/tile/darkred/tile_full
+/obj/effect/turf_decal/tile/dark_red/tile_full
 	name = "dark red tile"
 	icon_state = "tile_full"
 
@@ -235,51 +235,51 @@
 	name = "orange tile"
 	icon_state = "tile_full"
 
-/obj/effect/turf_decal/tile/darkgreen
+/obj/effect/turf_decal/tile/dark_green
 	name = "dark green corner"
 	color = "#055205"
 
-/obj/effect/turf_decal/tile/darkgreen/tile_marquee
+/obj/effect/turf_decal/tile/dark_green/tile_marquee
 	name = "dark green marquee"
 	icon_state = "tile_marquee"
 
-/obj/effect/turf_decal/tile/darkgreen/tile_side
+/obj/effect/turf_decal/tile/dark_green/tile_side
 	name = "dark green side"
 	icon_state = "tile_side"
 
-/obj/effect/turf_decal/tile/darkgreen/tile_full
+/obj/effect/turf_decal/tile/dark_green/tile_full
 	name = "dark green tile"
 	icon_state = "tile_full"
 
-/obj/effect/turf_decal/tile/pissyellow
+/obj/effect/turf_decal/tile/piss_yellow
 	name = "piss yellow corner"
 	color = "#BAC700"
 
-/obj/effect/turf_decal/tile/pissyellow/tile_marquee
+/obj/effect/turf_decal/tile/piss_yellow/tile_marquee
 	name = "piss yellow marquee"
 	icon_state = "tile_marquee"
 
-/obj/effect/turf_decal/tile/pissyellow/tile_side
+/obj/effect/turf_decal/tile/piss_yellow/tile_side
 	name = "piss yellow side"
 	icon_state = "tile_side"
 
-/obj/effect/turf_decal/tile/pissyellow/tile_full
+/obj/effect/turf_decal/tile/piss_yellow/tile_full
 	name = "piss yellow tile"
 	icon_state = "tile_full"
 
-/obj/effect/turf_decal/tile/hotpink
+/obj/effect/turf_decal/tile/hot_pink
 	name = "hot pink corner"
 	color = "#ff69b4"
 
-/obj/effect/turf_decal/tile/hotpink/tile_marquee
+/obj/effect/turf_decal/tile/hot_pink/tile_marquee
 	name = "hot pink marquee"
 	icon_state = "tile_marquee"
 
-/obj/effect/turf_decal/tile/hotpink/tile_side
+/obj/effect/turf_decal/tile/hot_pink/tile_side
 	name = "hot pink side"
 	icon_state = "tile_side"
 
-/obj/effect/turf_decal/tile/hotpink/tile_full
+/obj/effect/turf_decal/tile/hot_pink/tile_full
 	name = "hot pink tile"
 	icon_state = "tile_full"
 
@@ -781,102 +781,102 @@
 /obj/effect/turf_decal/trimline/gray/filled/shrink_ccw
 	icon_state = "trimline_shrink_ccw"
 
-/obj/effect/turf_decal/trimline/darkpurple
+/obj/effect/turf_decal/trimline/dark_purple
 	color = "#6C1282"
 	alpha = 150
 
-/obj/effect/turf_decal/trimline/darkpurple/line
+/obj/effect/turf_decal/trimline/dark_purple/line
 	icon_state = "trimline"
 
-/obj/effect/turf_decal/trimline/darkpurple/corner
+/obj/effect/turf_decal/trimline/dark_purple/corner
 	icon_state = "trimline_corner"
 
-/obj/effect/turf_decal/trimline/darkpurple/end
+/obj/effect/turf_decal/trimline/dark_purple/end
 	icon_state = "trimline_end"
 
-/obj/effect/turf_decal/trimline/darkpurple/arrow_cw
+/obj/effect/turf_decal/trimline/dark_purple/arrow_cw
 	icon_state = "trimline_arrow_cw"
 
-/obj/effect/turf_decal/trimline/darkpurple/arrow_ccw
+/obj/effect/turf_decal/trimline/dark_purple/arrow_ccw
 	icon_state = "trimline_arrow_ccw"
 
-/obj/effect/turf_decal/trimline/darkpurple/warning
+/obj/effect/turf_decal/trimline/dark_purple/warning
 	icon_state = "trimline_warn"
 
-/obj/effect/turf_decal/trimline/darkpurple/filled
+/obj/effect/turf_decal/trimline/dark_purple/filled
 	icon_state = "trimline_box_fill"
 
-/obj/effect/turf_decal/trimline/darkpurple/filled/line
+/obj/effect/turf_decal/trimline/dark_purple/filled/line
 	icon_state = "trimline_fill"
 
-/obj/effect/turf_decal/trimline/darkpurple/filled/corner
+/obj/effect/turf_decal/trimline/dark_purple/filled/corner
 	icon_state = "trimline_corner_fill"
 
-/obj/effect/turf_decal/trimline/darkpurple/filled/end
+/obj/effect/turf_decal/trimline/dark_purple/filled/end
 	icon_state = "trimline_end_fill"
 
-/obj/effect/turf_decal/trimline/darkpurple/filled/arrow_cw
+/obj/effect/turf_decal/trimline/dark_purple/filled/arrow_cw
 	icon_state = "trimline_arrow_cw_fill"
 
-/obj/effect/turf_decal/trimline/darkpurple/filled/arrow_ccw
+/obj/effect/turf_decal/trimline/dark_purple/filled/arrow_ccw
 	icon_state = "trimline_arrow_ccw_fill"
 
-/obj/effect/turf_decal/trimline/darkpurple/filled/warning
+/obj/effect/turf_decal/trimline/dark_purple/filled/warning
 	icon_state = "trimline_warn_fill"
 
-/obj/effect/turf_decal/trimline/darkpurple/filled/shrink_cw
+/obj/effect/turf_decal/trimline/dark_purple/filled/shrink_cw
 	icon_state = "trimline_shrink_cw"
 
-/obj/effect/turf_decal/trimline/darkpurple/filled/shrink_ccw
+/obj/effect/turf_decal/trimline/dark_purple/filled/shrink_ccw
 	icon_state = "trimline_shrink_ccw"
 
-/obj/effect/turf_decal/trimline/darkred
+/obj/effect/turf_decal/trimline/dark_red
 	color = "#4F0000"
 	alpha = 150
 
-/obj/effect/turf_decal/trimline/darkred/line
+/obj/effect/turf_decal/trimline/dark_red/line
 	icon_state = "trimline"
 
-/obj/effect/turf_decal/trimline/darkred/corner
+/obj/effect/turf_decal/trimline/dark_red/corner
 	icon_state = "trimline_corner"
 
-/obj/effect/turf_decal/trimline/darkred/end
+/obj/effect/turf_decal/trimline/dark_red/end
 	icon_state = "trimline_end"
 
-/obj/effect/turf_decal/trimline/darkred/arrow_cw
+/obj/effect/turf_decal/trimline/dark_red/arrow_cw
 	icon_state = "trimline_arrow_cw"
 
-/obj/effect/turf_decal/trimline/darkred/arrow_ccw
+/obj/effect/turf_decal/trimline/dark_red/arrow_ccw
 	icon_state = "trimline_arrow_ccw"
 
-/obj/effect/turf_decal/trimline/darkred/warning
+/obj/effect/turf_decal/trimline/dark_red/warning
 	icon_state = "trimline_warn"
 
-/obj/effect/turf_decal/trimline/darkred/filled
+/obj/effect/turf_decal/trimline/dark_red/filled
 	icon_state = "trimline_box_fill"
 
-/obj/effect/turf_decal/trimline/darkred/filled/line
+/obj/effect/turf_decal/trimline/dark_red/filled/line
 	icon_state = "trimline_fill"
 
-/obj/effect/turf_decal/trimline/darkred/filled/corner
+/obj/effect/turf_decal/trimline/dark_red/filled/corner
 	icon_state = "trimline_corner_fill"
 
-/obj/effect/turf_decal/trimline/darkred/filled/end
+/obj/effect/turf_decal/trimline/dark_red/filled/end
 	icon_state = "trimline_end_fill"
 
-/obj/effect/turf_decal/trimline/darkred/filled/arrow_cw
+/obj/effect/turf_decal/trimline/dark_red/filled/arrow_cw
 	icon_state = "trimline_arrow_cw_fill"
 
-/obj/effect/turf_decal/trimline/darkred/filled/arrow_ccw
+/obj/effect/turf_decal/trimline/dark_red/filled/arrow_ccw
 	icon_state = "trimline_arrow_ccw_fill"
 
-/obj/effect/turf_decal/trimline/darkred/filled/warning
+/obj/effect/turf_decal/trimline/dark_red/filled/warning
 	icon_state = "trimline_warn_fill"
 
-/obj/effect/turf_decal/trimline/darkred/filled/shrink_cw
+/obj/effect/turf_decal/trimline/dark_red/filled/shrink_cw
 	icon_state = "trimline_shrink_cw"
 
-/obj/effect/turf_decal/trimline/darkred/filled/shrink_ccw
+/obj/effect/turf_decal/trimline/dark_red/filled/shrink_ccw
 	icon_state = "trimline_shrink_ccw"
 
 /obj/effect/turf_decal/trimline/orange
@@ -928,149 +928,149 @@
 /obj/effect/turf_decal/trimline/orange/filled/shrink_ccw
 	icon_state = "trimline_shrink_ccw"
 
-/obj/effect/turf_decal/trimline/darkgreen
+/obj/effect/turf_decal/trimline/dark_green
 	color = "#055205"
 	alpha = 150
 
-/obj/effect/turf_decal/trimline/darkgreen/line
+/obj/effect/turf_decal/trimline/dark_green/line
 	icon_state = "trimline"
 
-/obj/effect/turf_decal/trimline/darkgreen/corner
+/obj/effect/turf_decal/trimline/dark_green/corner
 	icon_state = "trimline_corner"
 
-/obj/effect/turf_decal/trimline/darkgreen/end
+/obj/effect/turf_decal/trimline/dark_green/end
 	icon_state = "trimline_end"
 
-/obj/effect/turf_decal/trimline/darkgreen/arrow_cw
+/obj/effect/turf_decal/trimline/dark_green/arrow_cw
 	icon_state = "trimline_arrow_cw"
 
-/obj/effect/turf_decal/trimline/darkgreen/arrow_ccw
+/obj/effect/turf_decal/trimline/dark_green/arrow_ccw
 	icon_state = "trimline_arrow_ccw"
 
-/obj/effect/turf_decal/trimline/darkgreen/warning
+/obj/effect/turf_decal/trimline/dark_green/warning
 	icon_state = "trimline_warn"
 
-/obj/effect/turf_decal/trimline/darkgreen/filled
+/obj/effect/turf_decal/trimline/dark_green/filled
 	icon_state = "trimline_box_fill"
 
-/obj/effect/turf_decal/trimline/darkgreen/filled/line
+/obj/effect/turf_decal/trimline/dark_green/filled/line
 	icon_state = "trimline_fill"
 
-/obj/effect/turf_decal/trimline/darkgreen/filled/corner
+/obj/effect/turf_decal/trimline/dark_green/filled/corner
 	icon_state = "trimline_corner_fill"
 
-/obj/effect/turf_decal/trimline/darkgreen/filled/end
+/obj/effect/turf_decal/trimline/dark_green/filled/end
 	icon_state = "trimline_end_fill"
 
-/obj/effect/turf_decal/trimline/darkgreen/filled/arrow_cw
+/obj/effect/turf_decal/trimline/dark_green/filled/arrow_cw
 	icon_state = "trimline_arrow_cw_fill"
 
-/obj/effect/turf_decal/trimline/darkgreen/filled/arrow_ccw
+/obj/effect/turf_decal/trimline/dark_green/filled/arrow_ccw
 	icon_state = "trimline_arrow_ccw_fill"
 
-/obj/effect/turf_decal/trimline/darkgreen/filled/warning
+/obj/effect/turf_decal/trimline/dark_green/filled/warning
 	icon_state = "trimline_warn_fill"
 
-/obj/effect/turf_decal/trimline/darkgreen/filled/shrink_cw
+/obj/effect/turf_decal/trimline/dark_green/filled/shrink_cw
 	icon_state = "trimline_shrink_cw"
 
-/obj/effect/turf_decal/trimline/darkgreen/filled/shrink_ccw
+/obj/effect/turf_decal/trimline/dark_green/filled/shrink_ccw
 	icon_state = "trimline_shrink_ccw"
 
-/obj/effect/turf_decal/trimline/pissyellow
+/obj/effect/turf_decal/trimline/piss_yellow
 	color = "#BAC700"
 	alpha = 150
 
-/obj/effect/turf_decal/trimline/pissyellow/line
+/obj/effect/turf_decal/trimline/piss_yellow/line
 	icon_state = "trimline"
 
-/obj/effect/turf_decal/trimline/pissyellow/corner
+/obj/effect/turf_decal/trimline/piss_yellow/corner
 	icon_state = "trimline_corner"
 
-/obj/effect/turf_decal/trimline/pissyellow/end
+/obj/effect/turf_decal/trimline/piss_yellow/end
 	icon_state = "trimline_end"
 
-/obj/effect/turf_decal/trimline/pissyellow/arrow_cw
+/obj/effect/turf_decal/trimline/piss_yellow/arrow_cw
 	icon_state = "trimline_arrow_cw"
 
-/obj/effect/turf_decal/trimline/pissyellow/arrow_ccw
+/obj/effect/turf_decal/trimline/piss_yellow/arrow_ccw
 	icon_state = "trimline_arrow_ccw"
 
-/obj/effect/turf_decal/trimline/pissyellow/warning
+/obj/effect/turf_decal/trimline/piss_yellow/warning
 	icon_state = "trimline_warn"
 
-/obj/effect/turf_decal/trimline/pissyellow/filled
+/obj/effect/turf_decal/trimline/piss_yellow/filled
 	icon_state = "trimline_box_fill"
 
-/obj/effect/turf_decal/trimline/pissyellow/filled/line
+/obj/effect/turf_decal/trimline/piss_yellow/filled/line
 	icon_state = "trimline_fill"
 
-/obj/effect/turf_decal/trimline/pissyellow/filled/corner
+/obj/effect/turf_decal/trimline/piss_yellow/filled/corner
 	icon_state = "trimline_corner_fill"
 
-/obj/effect/turf_decal/trimline/pissyellow/filled/end
+/obj/effect/turf_decal/trimline/piss_yellow/filled/end
 	icon_state = "trimline_end_fill"
 
-/obj/effect/turf_decal/trimline/pissyellow/filled/arrow_cw
+/obj/effect/turf_decal/trimline/piss_yellow/filled/arrow_cw
 	icon_state = "trimline_arrow_cw_fill"
 
-/obj/effect/turf_decal/trimline/pissyellow/filled/arrow_ccw
+/obj/effect/turf_decal/trimline/piss_yellow/filled/arrow_ccw
 	icon_state = "trimline_arrow_ccw_fill"
 
-/obj/effect/turf_decal/trimline/pissyellow/filled/warning
+/obj/effect/turf_decal/trimline/piss_yellow/filled/warning
 	icon_state = "trimline_warn_fill"
 
-/obj/effect/turf_decal/trimline/pissyellow/filled/shrink_cw
+/obj/effect/turf_decal/trimline/piss_yellow/filled/shrink_cw
 	icon_state = "trimline_shrink_cw"
 
-/obj/effect/turf_decal/trimline/pissyellow/filled/shrink_ccw
+/obj/effect/turf_decal/trimline/piss_yellow/filled/shrink_ccw
 	icon_state = "trimline_shrink_ccw"
 
-/obj/effect/turf_decal/trimline/hotpink
+/obj/effect/turf_decal/trimline/hot_pink
 	color = "#ff69b4"
 	alpha = 150
 
-/obj/effect/turf_decal/trimline/hotpink/line
+/obj/effect/turf_decal/trimline/hot_pink/line
 	icon_state = "trimline"
 
-/obj/effect/turf_decal/trimline/hotpink/corner
+/obj/effect/turf_decal/trimline/hot_pink/corner
 	icon_state = "trimline_corner"
 
-/obj/effect/turf_decal/trimline/hotpink/end
+/obj/effect/turf_decal/trimline/hot_pink/end
 	icon_state = "trimline_end"
 
-/obj/effect/turf_decal/trimline/hotpink/arrow_cw
+/obj/effect/turf_decal/trimline/hot_pink/arrow_cw
 	icon_state = "trimline_arrow_cw"
 
-/obj/effect/turf_decal/trimline/hotpink/arrow_ccw
+/obj/effect/turf_decal/trimline/hot_pink/arrow_ccw
 	icon_state = "trimline_arrow_ccw"
 
-/obj/effect/turf_decal/trimline/hotpink/warning
+/obj/effect/turf_decal/trimline/hot_pink/warning
 	icon_state = "trimline_warn"
 
-/obj/effect/turf_decal/trimline/hotpink/filled
+/obj/effect/turf_decal/trimline/hot_pink/filled
 	icon_state = "trimline_box_fill"
 
-/obj/effect/turf_decal/trimline/hotpink/filled/line
+/obj/effect/turf_decal/trimline/hot_pink/filled/line
 	icon_state = "trimline_fill"
 
-/obj/effect/turf_decal/trimline/hotpink/filled/corner
+/obj/effect/turf_decal/trimline/hot_pink/filled/corner
 	icon_state = "trimline_corner_fill"
 
-/obj/effect/turf_decal/trimline/hotpink/filled/end
+/obj/effect/turf_decal/trimline/hot_pink/filled/end
 	icon_state = "trimline_end_fill"
 
-/obj/effect/turf_decal/trimline/hotpink/filled/arrow_cw
+/obj/effect/turf_decal/trimline/hot_pink/filled/arrow_cw
 	icon_state = "trimline_arrow_cw_fill"
 
-/obj/effect/turf_decal/trimline/hotpink/filled/arrow_ccw
+/obj/effect/turf_decal/trimline/hot_pink/filled/arrow_ccw
 	icon_state = "trimline_arrow_ccw_fill"
 
-/obj/effect/turf_decal/trimline/hotpink/filled/warning
+/obj/effect/turf_decal/trimline/hot_pink/filled/warning
 	icon_state = "trimline_warn_fill"
 
-/obj/effect/turf_decal/trimline/hotpink/filled/shrink_cw
+/obj/effect/turf_decal/trimline/hot_pink/filled/shrink_cw
 	icon_state = "trimline_shrink_cw"
 
-/obj/effect/turf_decal/trimline/hotpink/filled/shrink_ccw
+/obj/effect/turf_decal/trimline/hot_pink/filled/shrink_ccw
 	icon_state = "trimline_shrink_ccw"

--- a/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
+++ b/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
@@ -15,15 +15,15 @@
 
 /obj/effect/turf_decal/tile/blue/tile_marquee
 	name = "blue marquee"
-	icon_state = "tile_opposing_corners"
+	icon_state = "tile_marquee"
 
 /obj/effect/turf_decal/tile/blue/tile_side
 	name = "blue side"
-	icon_state = "tile_half_contrasted"
+	icon_state = "tile_side"
 
 /obj/effect/turf_decal/tile/blue/tile_full
 	name = "blue tile"
-	icon_state = "tile_fourcorners"
+	icon_state = "tile_full"
 
 /obj/effect/turf_decal/tile/green
 	name = "green corner"
@@ -31,15 +31,15 @@
 
 /obj/effect/turf_decal/tile/green/tile_marquee
 	name = "green marquee"
-	icon_state = "tile_opposing_corners"
+	icon_state = "tile_marquee"
 
 /obj/effect/turf_decal/tile/green/tile_side
 	name = "green side"
-	icon_state = "tile_half_contrasted"
+	icon_state = "tile_side"
 
 /obj/effect/turf_decal/tile/green/tile_full
 	name = "green tile"
-	icon_state = "tile_fourcorners"
+	icon_state = "tile_full"
 
 /obj/effect/turf_decal/tile/yellow
 	name = "yellow corner"
@@ -47,15 +47,15 @@
 
 /obj/effect/turf_decal/tile/yellow/tile_marquee
 	name = "yellow marquee"
-	icon_state = "tile_opposing_corners"
+	icon_state = "tile_marquee"
 
 /obj/effect/turf_decal/tile/yellow/tile_side
 	name = "yellow side"
-	icon_state = "tile_half_contrasted"
+	icon_state = "tile_side"
 
 /obj/effect/turf_decal/tile/yellow/tile_full
 	name = "yellow tile"
-	icon_state = "tile_fourcorners"
+	icon_state = "tile_full"
 
 /obj/effect/turf_decal/tile/red
 	name = "red corner"
@@ -63,15 +63,15 @@
 
 /obj/effect/turf_decal/tile/red/tile_marquee
 	name = "red marquee"
-	icon_state = "tile_opposing_corners"
+	icon_state = "tile_marquee"
 
 /obj/effect/turf_decal/tile/red/tile_side
 	name = "red side"
-	icon_state = "tile_half_contrasted"
+	icon_state = "tile_side"
 
 /obj/effect/turf_decal/tile/red/tile_full
 	name = "red tile"
-	icon_state = "tile_fourcorners"
+	icon_state = "tile_full"
 
 /obj/effect/turf_decal/tile/bar
 	name = "bar corner"
@@ -80,15 +80,15 @@
 
 /obj/effect/turf_decal/tile/bar/tile_marquee
 	name = "bar marquee"
-	icon_state = "tile_opposing_corners"
+	icon_state = "tile_marquee"
 
 /obj/effect/turf_decal/tile/bar/tile_side
 	name = "bar side"
-	icon_state = "tile_half_contrasted"
+	icon_state = "tile_side"
 
 /obj/effect/turf_decal/tile/bar/tile_full
 	name = "bar tile"
-	icon_state = "tile_fourcorners"
+	icon_state = "tile_full"
 
 /obj/effect/turf_decal/tile/purple
 	name = "purple corner"
@@ -96,15 +96,15 @@
 
 /obj/effect/turf_decal/tile/purple/tile_marquee
 	name = "purple marquee"
-	icon_state = "tile_opposing_corners"
+	icon_state = "tile_marquee"
 
 /obj/effect/turf_decal/tile/purple/tile_side
 	name = "purple side"
-	icon_state = "tile_half_contrasted"
+	icon_state = "tile_side"
 
 /obj/effect/turf_decal/tile/purple/tile_full
 	name = "purple tile"
-	icon_state = "tile_fourcorners"
+	icon_state = "tile_full"
 
 /obj/effect/turf_decal/tile/brown
 	name = "brown corner"
@@ -112,15 +112,15 @@
 
 /obj/effect/turf_decal/tile/brown/tile_marquee
 	name = "brown marquee"
-	icon_state = "tile_opposing_corners"
+	icon_state = "tile_marquee"
 
 /obj/effect/turf_decal/tile/brown/tile_side
 	name = "brown side"
-	icon_state = "tile_half_contrasted"
+	icon_state = "tile_side"
 
 /obj/effect/turf_decal/tile/brown/tile_full
 	name = "brown tile"
-	icon_state = "tile_fourcorners"
+	icon_state = "tile_full"
 
 /obj/effect/turf_decal/tile/darkblue
 	name = "dark blue corner"
@@ -128,15 +128,15 @@
 
 /obj/effect/turf_decal/tile/darkblue/tile_marquee
 	name = "dark blue marquee"
-	icon_state = "tile_opposing_corners"
+	icon_state = "tile_marquee"
 
 /obj/effect/turf_decal/tile/darkblue/tile_side
 	name = "dark blue side"
-	icon_state = "tile_half_contrasted"
+	icon_state = "tile_side"
 
 /obj/effect/turf_decal/tile/darkblue/tile_full
 	name = "dark blue tile"
-	icon_state = "tile_fourcorners"
+	icon_state = "tile_full"
 
 /obj/effect/turf_decal/tile/neutral
 	name = "neutral corner"
@@ -145,15 +145,15 @@
 
 /obj/effect/turf_decal/tile/neutral/tile_marquee
 	name = "neutral marquee"
-	icon_state = "tile_opposing_corners"
+	icon_state = "tile_marquee"
 
 /obj/effect/turf_decal/tile/neutral/tile_side
 	name = "neutral side"
-	icon_state = "tile_half_contrasted"
+	icon_state = "tile_side"
 
 /obj/effect/turf_decal/tile/neutral/tile_full
 	name = "neutral tile"
-	icon_state = "tile_fourcorners"
+	icon_state = "tile_full"
 
 /obj/effect/turf_decal/tile/random // so many colors
 	name = "colorful corner"
@@ -161,15 +161,15 @@
 
 /obj/effect/turf_decal/tile/random/tile_marquee
 	name = "colorful marquee"
-	icon_state = "tile_opposing_corners"
+	icon_state = "tile_marquee"
 
 /obj/effect/turf_decal/tile/random/tile_side
 	name = "colorful side"
-	icon_state = "tile_half_contrasted"
+	icon_state = "tile_side"
 
 /obj/effect/turf_decal/tile/random/tile_full
 	name = "colorful tile"
-	icon_state = "tile_fourcorners"
+	icon_state = "tile_full"
 
 /obj/effect/turf_decal/tile/gray
 	name = "gray corner"
@@ -177,15 +177,15 @@
 
 /obj/effect/turf_decal/tile/gray/tile_marquee
 	name = "gray marquee"
-	icon_state = "tile_opposing_corners"
+	icon_state = "tile_marquee"
 
 /obj/effect/turf_decal/tile/gray/tile_side
 	name = "gray side"
-	icon_state = "tile_half_contrasted"
+	icon_state = "tile_side"
 
 /obj/effect/turf_decal/tile/gray/tile_full
 	name = "gray tile"
-	icon_state = "tile_fourcorners"
+	icon_state = "tile_full"
 
 /obj/effect/turf_decal/tile/darkpurple
 	name = "dark purple corner"
@@ -193,15 +193,15 @@
 
 /obj/effect/turf_decal/tile/darkpurple/tile_marquee
 	name = "dark purple marquee"
-	icon_state = "tile_opposing_corners"
+	icon_state = "tile_marquee"
 
 /obj/effect/turf_decal/tile/darkpurple/tile_side
 	name = "dark purple side"
-	icon_state = "tile_half_contrasted"
+	icon_state = "tile_side"
 
 /obj/effect/turf_decal/tile/darkpurple/tile_full
 	name = "dark purple tile"
-	icon_state = "tile_fourcorners"
+	icon_state = "tile_full"
 
 /obj/effect/turf_decal/tile/darkred
 	name = "dark red corner"
@@ -209,15 +209,15 @@
 
 /obj/effect/turf_decal/tile/darkred/tile_marquee
 	name = "dark red marquee"
-	icon_state = "tile_opposing_corners"
+	icon_state = "tile_marquee"
 
 /obj/effect/turf_decal/tile/darkred/tile_side
 	name = "dark red side"
-	icon_state = "tile_half_contrasted"
+	icon_state = "tile_side"
 
 /obj/effect/turf_decal/tile/darkred/tile_full
 	name = "dark red tile"
-	icon_state = "tile_fourcorners"
+	icon_state = "tile_full"
 
 /obj/effect/turf_decal/tile/orange
 	name = "orange corner"
@@ -225,15 +225,15 @@
 
 /obj/effect/turf_decal/tile/orange/tile_marquee
 	name = "orange marquee"
-	icon_state = "tile_opposing_corners"
+	icon_state = "tile_marquee"
 
 /obj/effect/turf_decal/tile/orange/tile_side
 	name = "orange side"
-	icon_state = "tile_half_contrasted"
+	icon_state = "tile_side"
 
 /obj/effect/turf_decal/tile/orange/tile_full
 	name = "orange tile"
-	icon_state = "tile_fourcorners"
+	icon_state = "tile_full"
 
 /obj/effect/turf_decal/tile/darkgreen
 	name = "dark green corner"
@@ -241,15 +241,15 @@
 
 /obj/effect/turf_decal/tile/darkgreen/tile_marquee
 	name = "dark green marquee"
-	icon_state = "tile_opposing_corners"
+	icon_state = "tile_marquee"
 
 /obj/effect/turf_decal/tile/darkgreen/tile_side
 	name = "dark green side"
-	icon_state = "tile_half_contrasted"
+	icon_state = "tile_side"
 
 /obj/effect/turf_decal/tile/darkgreen/tile_full
 	name = "dark green tile"
-	icon_state = "tile_fourcorners"
+	icon_state = "tile_full"
 
 /obj/effect/turf_decal/tile/pissyellow
 	name = "piss yellow corner"
@@ -257,15 +257,15 @@
 
 /obj/effect/turf_decal/tile/pissyellow/tile_marquee
 	name = "piss yellow marquee"
-	icon_state = "tile_opposing_corners"
+	icon_state = "tile_marquee"
 
 /obj/effect/turf_decal/tile/pissyellow/tile_side
 	name = "piss yellow side"
-	icon_state = "tile_half_contrasted"
+	icon_state = "tile_side"
 
 /obj/effect/turf_decal/tile/pissyellow/tile_full
 	name = "piss yellow tile"
-	icon_state = "tile_fourcorners"
+	icon_state = "tile_full"
 
 /obj/effect/turf_decal/tile/hotpink
 	name = "hot pink corner"
@@ -273,15 +273,15 @@
 
 /obj/effect/turf_decal/tile/hotpink/tile_marquee
 	name = "hot pink marquee"
-	icon_state = "tile_opposing_corners"
+	icon_state = "tile_marquee"
 
 /obj/effect/turf_decal/tile/hotpink/tile_side
 	name = "hot pink side"
-	icon_state = "tile_half_contrasted"
+	icon_state = "tile_side"
 
 /obj/effect/turf_decal/tile/hotpink/tile_full
 	name = "hot pink tile"
-	icon_state = "tile_fourcorners"
+	icon_state = "tile_full"
 
 
 /obj/effect/turf_decal/tile/random/Initialize(mapload)

--- a/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
+++ b/code/game/objects/effects/decals/turfdecal/tilecoloring.dm
@@ -15,15 +15,15 @@
 
 /obj/effect/turf_decal/tile/blue/tile_marquee
 	name = "blue marquee"
-	icon_state = "tile_marquee"
+	icon_state = "tile_opposing_corners"
 
 /obj/effect/turf_decal/tile/blue/tile_side
 	name = "blue side"
-	icon_state = "tile_side"
+	icon_state = "tile_half_contrasted"
 
 /obj/effect/turf_decal/tile/blue/tile_full
 	name = "blue tile"
-	icon_state = "tile_full"
+	icon_state = "tile_fourcorners"
 
 /obj/effect/turf_decal/tile/green
 	name = "green corner"
@@ -31,15 +31,15 @@
 
 /obj/effect/turf_decal/tile/green/tile_marquee
 	name = "green marquee"
-	icon_state = "tile_marquee"
+	icon_state = "tile_opposing_corners"
 
 /obj/effect/turf_decal/tile/green/tile_side
 	name = "green side"
-	icon_state = "tile_side"
+	icon_state = "tile_half_contrasted"
 
 /obj/effect/turf_decal/tile/green/tile_full
 	name = "green tile"
-	icon_state = "tile_full"
+	icon_state = "tile_fourcorners"
 
 /obj/effect/turf_decal/tile/yellow
 	name = "yellow corner"
@@ -47,15 +47,15 @@
 
 /obj/effect/turf_decal/tile/yellow/tile_marquee
 	name = "yellow marquee"
-	icon_state = "tile_marquee"
+	icon_state = "tile_opposing_corners"
 
 /obj/effect/turf_decal/tile/yellow/tile_side
 	name = "yellow side"
-	icon_state = "tile_side"
+	icon_state = "tile_half_contrasted"
 
 /obj/effect/turf_decal/tile/yellow/tile_full
 	name = "yellow tile"
-	icon_state = "tile_full"
+	icon_state = "tile_fourcorners"
 
 /obj/effect/turf_decal/tile/red
 	name = "red corner"
@@ -63,15 +63,15 @@
 
 /obj/effect/turf_decal/tile/red/tile_marquee
 	name = "red marquee"
-	icon_state = "tile_marquee"
+	icon_state = "tile_opposing_corners"
 
 /obj/effect/turf_decal/tile/red/tile_side
 	name = "red side"
-	icon_state = "tile_side"
+	icon_state = "tile_half_contrasted"
 
 /obj/effect/turf_decal/tile/red/tile_full
 	name = "red tile"
-	icon_state = "tile_full"
+	icon_state = "tile_fourcorners"
 
 /obj/effect/turf_decal/tile/bar
 	name = "bar corner"
@@ -80,15 +80,15 @@
 
 /obj/effect/turf_decal/tile/bar/tile_marquee
 	name = "bar marquee"
-	icon_state = "tile_marquee"
+	icon_state = "tile_opposing_corners"
 
 /obj/effect/turf_decal/tile/bar/tile_side
 	name = "bar side"
-	icon_state = "tile_side"
+	icon_state = "tile_half_contrasted"
 
 /obj/effect/turf_decal/tile/bar/tile_full
 	name = "bar tile"
-	icon_state = "tile_full"
+	icon_state = "tile_fourcorners"
 
 /obj/effect/turf_decal/tile/purple
 	name = "purple corner"
@@ -96,15 +96,15 @@
 
 /obj/effect/turf_decal/tile/purple/tile_marquee
 	name = "purple marquee"
-	icon_state = "tile_marquee"
+	icon_state = "tile_opposing_corners"
 
 /obj/effect/turf_decal/tile/purple/tile_side
 	name = "purple side"
-	icon_state = "tile_side"
+	icon_state = "tile_half_contrasted"
 
 /obj/effect/turf_decal/tile/purple/tile_full
 	name = "purple tile"
-	icon_state = "tile_full"
+	icon_state = "tile_fourcorners"
 
 /obj/effect/turf_decal/tile/brown
 	name = "brown corner"
@@ -112,15 +112,15 @@
 
 /obj/effect/turf_decal/tile/brown/tile_marquee
 	name = "brown marquee"
-	icon_state = "tile_marquee"
+	icon_state = "tile_opposing_corners"
 
 /obj/effect/turf_decal/tile/brown/tile_side
 	name = "brown side"
-	icon_state = "tile_side"
+	icon_state = "tile_half_contrasted"
 
 /obj/effect/turf_decal/tile/brown/tile_full
 	name = "brown tile"
-	icon_state = "tile_full"
+	icon_state = "tile_fourcorners"
 
 /obj/effect/turf_decal/tile/darkblue
 	name = "dark blue corner"
@@ -128,15 +128,15 @@
 
 /obj/effect/turf_decal/tile/darkblue/tile_marquee
 	name = "dark blue marquee"
-	icon_state = "tile_marquee"
+	icon_state = "tile_opposing_corners"
 
 /obj/effect/turf_decal/tile/darkblue/tile_side
 	name = "dark blue side"
-	icon_state = "tile_side"
+	icon_state = "tile_half_contrasted"
 
 /obj/effect/turf_decal/tile/darkblue/tile_full
 	name = "dark blue tile"
-	icon_state = "tile_full"
+	icon_state = "tile_fourcorners"
 
 /obj/effect/turf_decal/tile/neutral
 	name = "neutral corner"
@@ -145,15 +145,15 @@
 
 /obj/effect/turf_decal/tile/neutral/tile_marquee
 	name = "neutral marquee"
-	icon_state = "tile_marquee"
+	icon_state = "tile_opposing_corners"
 
 /obj/effect/turf_decal/tile/neutral/tile_side
 	name = "neutral side"
-	icon_state = "tile_side"
+	icon_state = "tile_half_contrasted"
 
 /obj/effect/turf_decal/tile/neutral/tile_full
 	name = "neutral tile"
-	icon_state = "tile_full"
+	icon_state = "tile_fourcorners"
 
 /obj/effect/turf_decal/tile/random // so many colors
 	name = "colorful corner"
@@ -161,15 +161,128 @@
 
 /obj/effect/turf_decal/tile/random/tile_marquee
 	name = "colorful marquee"
-	icon_state = "tile_marquee"
+	icon_state = "tile_opposing_corners"
 
 /obj/effect/turf_decal/tile/random/tile_side
 	name = "colorful side"
-	icon_state = "tile_side"
+	icon_state = "tile_half_contrasted"
 
 /obj/effect/turf_decal/tile/random/tile_full
 	name = "colorful tile"
-	icon_state = "tile_full"
+	icon_state = "tile_fourcorners"
+
+/obj/effect/turf_decal/tile/gray
+	name = "gray corner"
+	color = "#2E2E2E"
+
+/obj/effect/turf_decal/tile/gray/tile_marquee
+	name = "gray marquee"
+	icon_state = "tile_opposing_corners"
+
+/obj/effect/turf_decal/tile/gray/tile_side
+	name = "gray side"
+	icon_state = "tile_half_contrasted"
+
+/obj/effect/turf_decal/tile/gray/tile_full
+	name = "gray tile"
+	icon_state = "tile_fourcorners"
+
+/obj/effect/turf_decal/tile/darkpurple
+	name = "dark purple corner"
+	color = "#6C1282"
+
+/obj/effect/turf_decal/tile/darkpurple/tile_marquee
+	name = "dark purple marquee"
+	icon_state = "tile_opposing_corners"
+
+/obj/effect/turf_decal/tile/darkpurple/tile_side
+	name = "dark purple side"
+	icon_state = "tile_half_contrasted"
+
+/obj/effect/turf_decal/tile/darkpurple/tile_full
+	name = "dark purple tile"
+	icon_state = "tile_fourcorners"
+
+/obj/effect/turf_decal/tile/darkred
+	name = "dark red corner"
+	color = "#4F0000"
+
+/obj/effect/turf_decal/tile/darkred/tile_marquee
+	name = "dark red marquee"
+	icon_state = "tile_opposing_corners"
+
+/obj/effect/turf_decal/tile/darkred/tile_side
+	name = "dark red side"
+	icon_state = "tile_half_contrasted"
+
+/obj/effect/turf_decal/tile/darkred/tile_full
+	name = "dark red tile"
+	icon_state = "tile_fourcorners"
+
+/obj/effect/turf_decal/tile/orange
+	name = "orange corner"
+	color = "#D15802"
+
+/obj/effect/turf_decal/tile/orange/tile_marquee
+	name = "orange marquee"
+	icon_state = "tile_opposing_corners"
+
+/obj/effect/turf_decal/tile/orange/tile_side
+	name = "orange side"
+	icon_state = "tile_half_contrasted"
+
+/obj/effect/turf_decal/tile/orange/tile_full
+	name = "orange tile"
+	icon_state = "tile_fourcorners"
+
+/obj/effect/turf_decal/tile/darkgreen
+	name = "dark green corner"
+	color = "#055205"
+
+/obj/effect/turf_decal/tile/darkgreen/tile_marquee
+	name = "dark green marquee"
+	icon_state = "tile_opposing_corners"
+
+/obj/effect/turf_decal/tile/darkgreen/tile_side
+	name = "dark green side"
+	icon_state = "tile_half_contrasted"
+
+/obj/effect/turf_decal/tile/darkgreen/tile_full
+	name = "dark green tile"
+	icon_state = "tile_fourcorners"
+
+/obj/effect/turf_decal/tile/pissyellow
+	name = "piss yellow corner"
+	color = "#BAC700"
+
+/obj/effect/turf_decal/tile/pissyellow/tile_marquee
+	name = "piss yellow marquee"
+	icon_state = "tile_opposing_corners"
+
+/obj/effect/turf_decal/tile/pissyellow/tile_side
+	name = "piss yellow side"
+	icon_state = "tile_half_contrasted"
+
+/obj/effect/turf_decal/tile/pissyellow/tile_full
+	name = "piss yellow tile"
+	icon_state = "tile_fourcorners"
+
+/obj/effect/turf_decal/tile/hotpink
+	name = "hot pink corner"
+	color = "#ff69b4"
+
+/obj/effect/turf_decal/tile/hotpink/tile_marquee
+	name = "hot pink marquee"
+	icon_state = "tile_opposing_corners"
+
+/obj/effect/turf_decal/tile/hotpink/tile_side
+	name = "hot pink side"
+	icon_state = "tile_half_contrasted"
+
+/obj/effect/turf_decal/tile/hotpink/tile_full
+	name = "hot pink tile"
+	icon_state = "tile_fourcorners"
+
 
 /obj/effect/turf_decal/tile/random/Initialize(mapload)
 	color = "#[random_short_color()]"
@@ -618,4 +731,346 @@
 	icon_state = "trimline_shrink_cw"
 
 /obj/effect/turf_decal/trimline/neutral/filled/shrink_ccw
+	icon_state = "trimline_shrink_ccw"
+
+/obj/effect/turf_decal/trimline/gray
+	color = "#2E2E2E"
+
+/obj/effect/turf_decal/trimline/gray/line
+	icon_state = "trimline"
+
+/obj/effect/turf_decal/trimline/gray/corner
+	icon_state = "trimline_corner"
+
+/obj/effect/turf_decal/trimline/gray/end
+	icon_state = "trimline_end"
+
+/obj/effect/turf_decal/trimline/gray/arrow_cw
+	icon_state = "trimline_arrow_cw"
+
+/obj/effect/turf_decal/trimline/gray/arrow_ccw
+	icon_state = "trimline_arrow_ccw"
+
+/obj/effect/turf_decal/trimline/gray/warning
+	icon_state = "trimline_warn"
+
+/obj/effect/turf_decal/trimline/gray/filled
+	icon_state = "trimline_box_fill"
+
+/obj/effect/turf_decal/trimline/gray/filled/line
+	icon_state = "trimline_fill"
+
+/obj/effect/turf_decal/trimline/gray/filled/corner
+	icon_state = "trimline_corner_fill"
+
+/obj/effect/turf_decal/trimline/gray/filled/end
+	icon_state = "trimline_end_fill"
+
+/obj/effect/turf_decal/trimline/gray/filled/arrow_cw
+	icon_state = "trimline_arrow_cw_fill"
+
+/obj/effect/turf_decal/trimline/gray/filled/arrow_ccw
+	icon_state = "trimline_arrow_ccw_fill"
+
+/obj/effect/turf_decal/trimline/gray/filled/warning
+	icon_state = "trimline_warn_fill"
+
+/obj/effect/turf_decal/trimline/gray/filled/shrink_cw
+	icon_state = "trimline_shrink_cw"
+
+/obj/effect/turf_decal/trimline/gray/filled/shrink_ccw
+	icon_state = "trimline_shrink_ccw"
+
+/obj/effect/turf_decal/trimline/darkpurple
+	color = "#6C1282"
+	alpha = 150
+
+/obj/effect/turf_decal/trimline/darkpurple/line
+	icon_state = "trimline"
+
+/obj/effect/turf_decal/trimline/darkpurple/corner
+	icon_state = "trimline_corner"
+
+/obj/effect/turf_decal/trimline/darkpurple/end
+	icon_state = "trimline_end"
+
+/obj/effect/turf_decal/trimline/darkpurple/arrow_cw
+	icon_state = "trimline_arrow_cw"
+
+/obj/effect/turf_decal/trimline/darkpurple/arrow_ccw
+	icon_state = "trimline_arrow_ccw"
+
+/obj/effect/turf_decal/trimline/darkpurple/warning
+	icon_state = "trimline_warn"
+
+/obj/effect/turf_decal/trimline/darkpurple/filled
+	icon_state = "trimline_box_fill"
+
+/obj/effect/turf_decal/trimline/darkpurple/filled/line
+	icon_state = "trimline_fill"
+
+/obj/effect/turf_decal/trimline/darkpurple/filled/corner
+	icon_state = "trimline_corner_fill"
+
+/obj/effect/turf_decal/trimline/darkpurple/filled/end
+	icon_state = "trimline_end_fill"
+
+/obj/effect/turf_decal/trimline/darkpurple/filled/arrow_cw
+	icon_state = "trimline_arrow_cw_fill"
+
+/obj/effect/turf_decal/trimline/darkpurple/filled/arrow_ccw
+	icon_state = "trimline_arrow_ccw_fill"
+
+/obj/effect/turf_decal/trimline/darkpurple/filled/warning
+	icon_state = "trimline_warn_fill"
+
+/obj/effect/turf_decal/trimline/darkpurple/filled/shrink_cw
+	icon_state = "trimline_shrink_cw"
+
+/obj/effect/turf_decal/trimline/darkpurple/filled/shrink_ccw
+	icon_state = "trimline_shrink_ccw"
+
+/obj/effect/turf_decal/trimline/darkred
+	color = "#4F0000"
+	alpha = 150
+
+/obj/effect/turf_decal/trimline/darkred/line
+	icon_state = "trimline"
+
+/obj/effect/turf_decal/trimline/darkred/corner
+	icon_state = "trimline_corner"
+
+/obj/effect/turf_decal/trimline/darkred/end
+	icon_state = "trimline_end"
+
+/obj/effect/turf_decal/trimline/darkred/arrow_cw
+	icon_state = "trimline_arrow_cw"
+
+/obj/effect/turf_decal/trimline/darkred/arrow_ccw
+	icon_state = "trimline_arrow_ccw"
+
+/obj/effect/turf_decal/trimline/darkred/warning
+	icon_state = "trimline_warn"
+
+/obj/effect/turf_decal/trimline/darkred/filled
+	icon_state = "trimline_box_fill"
+
+/obj/effect/turf_decal/trimline/darkred/filled/line
+	icon_state = "trimline_fill"
+
+/obj/effect/turf_decal/trimline/darkred/filled/corner
+	icon_state = "trimline_corner_fill"
+
+/obj/effect/turf_decal/trimline/darkred/filled/end
+	icon_state = "trimline_end_fill"
+
+/obj/effect/turf_decal/trimline/darkred/filled/arrow_cw
+	icon_state = "trimline_arrow_cw_fill"
+
+/obj/effect/turf_decal/trimline/darkred/filled/arrow_ccw
+	icon_state = "trimline_arrow_ccw_fill"
+
+/obj/effect/turf_decal/trimline/darkred/filled/warning
+	icon_state = "trimline_warn_fill"
+
+/obj/effect/turf_decal/trimline/darkred/filled/shrink_cw
+	icon_state = "trimline_shrink_cw"
+
+/obj/effect/turf_decal/trimline/darkred/filled/shrink_ccw
+	icon_state = "trimline_shrink_ccw"
+
+/obj/effect/turf_decal/trimline/orange
+	color = "#D15802"
+	alpha = 150
+
+/obj/effect/turf_decal/trimline/orange/line
+	icon_state = "trimline"
+
+/obj/effect/turf_decal/trimline/orange/corner
+	icon_state = "trimline_corner"
+
+/obj/effect/turf_decal/trimline/orange/end
+	icon_state = "trimline_end"
+
+/obj/effect/turf_decal/trimline/orange/arrow_cw
+	icon_state = "trimline_arrow_cw"
+
+/obj/effect/turf_decal/trimline/orange/arrow_ccw
+	icon_state = "trimline_arrow_ccw"
+
+/obj/effect/turf_decal/trimline/orange/warning
+	icon_state = "trimline_warn"
+
+/obj/effect/turf_decal/trimline/orange/filled
+	icon_state = "trimline_box_fill"
+
+/obj/effect/turf_decal/trimline/orange/filled/line
+	icon_state = "trimline_fill"
+
+/obj/effect/turf_decal/trimline/orange/filled/corner
+	icon_state = "trimline_corner_fill"
+
+/obj/effect/turf_decal/trimline/orange/filled/end
+	icon_state = "trimline_end_fill"
+
+/obj/effect/turf_decal/trimline/orange/filled/arrow_cw
+	icon_state = "trimline_arrow_cw_fill"
+
+/obj/effect/turf_decal/trimline/orange/filled/arrow_ccw
+	icon_state = "trimline_arrow_ccw_fill"
+
+/obj/effect/turf_decal/trimline/orange/filled/warning
+	icon_state = "trimline_warn_fill"
+
+/obj/effect/turf_decal/trimline/orange/filled/shrink_cw
+	icon_state = "trimline_shrink_cw"
+
+/obj/effect/turf_decal/trimline/orange/filled/shrink_ccw
+	icon_state = "trimline_shrink_ccw"
+
+/obj/effect/turf_decal/trimline/darkgreen
+	color = "#055205"
+	alpha = 150
+
+/obj/effect/turf_decal/trimline/darkgreen/line
+	icon_state = "trimline"
+
+/obj/effect/turf_decal/trimline/darkgreen/corner
+	icon_state = "trimline_corner"
+
+/obj/effect/turf_decal/trimline/darkgreen/end
+	icon_state = "trimline_end"
+
+/obj/effect/turf_decal/trimline/darkgreen/arrow_cw
+	icon_state = "trimline_arrow_cw"
+
+/obj/effect/turf_decal/trimline/darkgreen/arrow_ccw
+	icon_state = "trimline_arrow_ccw"
+
+/obj/effect/turf_decal/trimline/darkgreen/warning
+	icon_state = "trimline_warn"
+
+/obj/effect/turf_decal/trimline/darkgreen/filled
+	icon_state = "trimline_box_fill"
+
+/obj/effect/turf_decal/trimline/darkgreen/filled/line
+	icon_state = "trimline_fill"
+
+/obj/effect/turf_decal/trimline/darkgreen/filled/corner
+	icon_state = "trimline_corner_fill"
+
+/obj/effect/turf_decal/trimline/darkgreen/filled/end
+	icon_state = "trimline_end_fill"
+
+/obj/effect/turf_decal/trimline/darkgreen/filled/arrow_cw
+	icon_state = "trimline_arrow_cw_fill"
+
+/obj/effect/turf_decal/trimline/darkgreen/filled/arrow_ccw
+	icon_state = "trimline_arrow_ccw_fill"
+
+/obj/effect/turf_decal/trimline/darkgreen/filled/warning
+	icon_state = "trimline_warn_fill"
+
+/obj/effect/turf_decal/trimline/darkgreen/filled/shrink_cw
+	icon_state = "trimline_shrink_cw"
+
+/obj/effect/turf_decal/trimline/darkgreen/filled/shrink_ccw
+	icon_state = "trimline_shrink_ccw"
+
+/obj/effect/turf_decal/trimline/pissyellow
+	color = "#BAC700"
+	alpha = 150
+
+/obj/effect/turf_decal/trimline/pissyellow/line
+	icon_state = "trimline"
+
+/obj/effect/turf_decal/trimline/pissyellow/corner
+	icon_state = "trimline_corner"
+
+/obj/effect/turf_decal/trimline/pissyellow/end
+	icon_state = "trimline_end"
+
+/obj/effect/turf_decal/trimline/pissyellow/arrow_cw
+	icon_state = "trimline_arrow_cw"
+
+/obj/effect/turf_decal/trimline/pissyellow/arrow_ccw
+	icon_state = "trimline_arrow_ccw"
+
+/obj/effect/turf_decal/trimline/pissyellow/warning
+	icon_state = "trimline_warn"
+
+/obj/effect/turf_decal/trimline/pissyellow/filled
+	icon_state = "trimline_box_fill"
+
+/obj/effect/turf_decal/trimline/pissyellow/filled/line
+	icon_state = "trimline_fill"
+
+/obj/effect/turf_decal/trimline/pissyellow/filled/corner
+	icon_state = "trimline_corner_fill"
+
+/obj/effect/turf_decal/trimline/pissyellow/filled/end
+	icon_state = "trimline_end_fill"
+
+/obj/effect/turf_decal/trimline/pissyellow/filled/arrow_cw
+	icon_state = "trimline_arrow_cw_fill"
+
+/obj/effect/turf_decal/trimline/pissyellow/filled/arrow_ccw
+	icon_state = "trimline_arrow_ccw_fill"
+
+/obj/effect/turf_decal/trimline/pissyellow/filled/warning
+	icon_state = "trimline_warn_fill"
+
+/obj/effect/turf_decal/trimline/pissyellow/filled/shrink_cw
+	icon_state = "trimline_shrink_cw"
+
+/obj/effect/turf_decal/trimline/pissyellow/filled/shrink_ccw
+	icon_state = "trimline_shrink_ccw"
+
+/obj/effect/turf_decal/trimline/hotpink
+	color = "#ff69b4"
+	alpha = 150
+
+/obj/effect/turf_decal/trimline/hotpink/line
+	icon_state = "trimline"
+
+/obj/effect/turf_decal/trimline/hotpink/corner
+	icon_state = "trimline_corner"
+
+/obj/effect/turf_decal/trimline/hotpink/end
+	icon_state = "trimline_end"
+
+/obj/effect/turf_decal/trimline/hotpink/arrow_cw
+	icon_state = "trimline_arrow_cw"
+
+/obj/effect/turf_decal/trimline/hotpink/arrow_ccw
+	icon_state = "trimline_arrow_ccw"
+
+/obj/effect/turf_decal/trimline/hotpink/warning
+	icon_state = "trimline_warn"
+
+/obj/effect/turf_decal/trimline/hotpink/filled
+	icon_state = "trimline_box_fill"
+
+/obj/effect/turf_decal/trimline/hotpink/filled/line
+	icon_state = "trimline_fill"
+
+/obj/effect/turf_decal/trimline/hotpink/filled/corner
+	icon_state = "trimline_corner_fill"
+
+/obj/effect/turf_decal/trimline/hotpink/filled/end
+	icon_state = "trimline_end_fill"
+
+/obj/effect/turf_decal/trimline/hotpink/filled/arrow_cw
+	icon_state = "trimline_arrow_cw_fill"
+
+/obj/effect/turf_decal/trimline/hotpink/filled/arrow_ccw
+	icon_state = "trimline_arrow_ccw_fill"
+
+/obj/effect/turf_decal/trimline/hotpink/filled/warning
+	icon_state = "trimline_warn_fill"
+
+/obj/effect/turf_decal/trimline/hotpink/filled/shrink_cw
+	icon_state = "trimline_shrink_cw"
+
+/obj/effect/turf_decal/trimline/hotpink/filled/shrink_ccw
 	icon_state = "trimline_shrink_ccw"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Add new tile and trimline decal colors for mappers to use. Some of these colors are also being used in #682. Adds the following colors: darkgreen, darkpruple, darkred, gray, hotpink, orange, and pissyellow. Examples of what they look like in screenshots.

## Why It's Good For The Game

More colors for mappers to use

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![Screenshot_534](https://user-images.githubusercontent.com/71185626/189499178-c4e4d5f0-5ec3-47b7-966b-19bbfdefd923.png)
![Screenshot_533](https://user-images.githubusercontent.com/71185626/189499164-ec8a5384-90dd-456e-97d6-f96d8c28ba1e.png)


</details>