### PR TITLE
Adds max heat protection to Atmos and CE plasmaman helmets

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -216,6 +216,7 @@
 	desc = "A space-worthy helmet specially designed for atmos technician plasmamen, the usual purple stripes being replaced by engineering's blue."
 	icon_state = "atmos_envirohelm"
 	item_state = "atmos_envirohelm"
+	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT //MONKESTATION CHANGE: The Atmospherics plasmaman helmet now gives max heat protection
 
 /obj/item/clothing/head/helmet/space/plasmaman/cargo
 	name = "cargo envirosuit helmet"
@@ -310,7 +311,8 @@
 	desc = "An envirohelmet designed for the Chief Engineer. It reeks of Poly and plasma."
 	icon_state = "ce_envirohelm"
 	item_state = "ce_envirohelm"
-
+	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT //MONKESTATION CHANGE: The Chief Engineer plasmaman helmet now gives max heat protection
+	
 /obj/item/clothing/head/helmet/space/plasmaman/cmo
 	name = "chief medical officer's envirohelmet"
 	desc = "A helmet issued to the chief of the medical staff."
@@ -420,7 +422,8 @@
 	desc = "A space-worthy helmet specially designed for atmos technician plasmamen, the usual purple stripes being replaced by engineering's blue."
 	icon_state = "atmos_envirohelm"
 	item_state = "atmos_envirohelm"
-
+	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT //MONKESTATION CHANGE: The Atmospherics plasmaman helmet now gives max heat protection
+	
 /obj/item/clothing/head/helmet/space/plasmaman/replacement/cargo
 	name = "cargo replacement envirosuit helmet"
 	desc = "An replacement envirohelmet designed for cargo techs and quartermasters."
@@ -562,7 +565,8 @@
 	icon_state = "atmos_openvirohelm"
 	item_state = "atmos_openvirohelm"
 	visor_icon = "openvisor"
-
+	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT //MONKESTATION CHANGE: The Atmospherics plasmaman helmet now gives max heat protection
+	
 /obj/item/clothing/head/helmet/space/plasmaman/cargo/mark2
 	name = "cargo Mk.II envirosuit helmet"
 	desc = "A stylish new iteration upon the original plasmaman containment helmet design for cargo techs and quartermasters. Neo-liberal grifting has never been this groovy"
@@ -626,7 +630,8 @@
 	icon_state = "ce_openvirohelm"
 	item_state = "ce_openvirohelm"
 	visor_icon = "openvisor"
-
+	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT //MONKESTATION CHANGE: The Chief Engineer plasmaman helmet now gives max heat protection
+	
 /obj/item/clothing/head/helmet/space/plasmaman/cmo/mark2
 	name = "chief medical officer's Mk.II envirohelmet"
 	desc = "A sleek new helmet issued to the chief of the medical staff. Show off that big forehead of yours to all the squares in science."
@@ -670,7 +675,8 @@
 	icon_state = "ce_armouredenvirohelm"
 	item_state = "ce_armouredenvirohelm"
 	visor_icon = "armouredenvisor"
-
+	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT //MONKESTATION CHANGE: The Chief Engineer plasmaman helmet now gives max heat protection
+	
 /obj/item/clothing/head/helmet/space/plasmaman/cmo/protective
 	name = "chief medical officer's Mk.II envirohelmet"
 	desc = "A bulky new helmet issued to the chief of the medical staff."
@@ -791,7 +797,8 @@
 	icon_state = "atmos_armouredenvirohelm"
 	item_state = "atmos_armouredenvirohelm"
 	visor_icon = "armouredenvisor"
-
+	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT //MONKESTATION CHANGE: The Atmospherics plasmaman helmet now gives max heat protection
+	
 /obj/item/clothing/head/helmet/space/plasmaman/cargo/protective
 	name = "cargo Mk.II envirosuit helmet"
 	desc = "A braced plasmaman containment helmet design for cargo techs and quartermasters."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Gives maximum heat protection to the Atmospherics and Chief Engineer plasmaman helmets.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Plasmaman Atmospheric Technicians and Chief Engineers will no longer have to take off their helmet to use firesuits or hardsuits to enter areas with extreme heat.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
balance: The Atmospherics and Chief Engineer plasmaman helmets now have maximum heat protection.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
