### PR TITLE
Small Pirate ship expansion

### DIFF
--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -562,7 +562,6 @@
 /area/shuttle/pirate)
 "by" = (
 /obj/machinery/piratepad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/pod/dark,
 /area/shuttle/pirate)
 "bA" = (
@@ -1369,7 +1368,7 @@ am
 jZ
 bm
 ri
-by
+bm
 bm
 au
 aL
@@ -1387,7 +1386,7 @@ an
 aj
 bt
 gY
-Qx
+by
 bI
 aj
 bO

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -224,19 +224,18 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/pirate)
 "ay" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/pirate)
 "az" = (
@@ -554,9 +553,6 @@
 /turf/open/floor/plasteel,
 /area/shuttle/pirate)
 "bx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -565,9 +561,8 @@
 /turf/open/floor/plasteel,
 /area/shuttle/pirate)
 "by" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/piratepad,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/pod/dark,
 /area/shuttle/pirate)
 "bA" = (
@@ -577,7 +572,6 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/pirate)
 "bB" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/pirate)
@@ -589,11 +583,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/shuttle/pirate)
 "bF" = (
@@ -819,9 +811,7 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/pirate)
 "eE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/pirate)
@@ -850,6 +840,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/shuttle/pirate)
+"iz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel,
+/area/shuttle/pirate)
 "jm" = (
 /obj/machinery/door/airlock/external/glass{
 	id_tag = "piratestarboardexternal";
@@ -866,7 +861,7 @@
 	height = 16;
 	id = "pirateship";
 	launch_status = 0;
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
+	movement_force = list("KNOCKDOWN"=0,"THROW"=0);
 	name = "Pirate Ship";
 	port_direction = 2;
 	preferred_direction = 1;
@@ -927,9 +922,10 @@
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "mD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/closet/secure_closet/personal,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/pirate)
 "np" = (
@@ -969,6 +965,11 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
+/area/shuttle/pirate)
+"ri" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
 /area/shuttle/pirate)
 "vB" = (
 /obj/effect/turf_decal/stripes/line{
@@ -1016,6 +1017,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/shuttle/pirate)
+"Dr" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/shuttle/pirate)
 "Gk" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
@@ -1023,6 +1035,11 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
+/area/shuttle/pirate)
+"GQ" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
 /area/shuttle/pirate)
 "IN" = (
 /obj/machinery/door/airlock/external/glass{
@@ -1066,6 +1083,16 @@
 /obj/item/clothing/mask/muzzle,
 /turf/open/floor/pod/light,
 /area/shuttle/pirate)
+"KC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/turf/open/floor/plasteel,
+/area/shuttle/pirate)
 "MA" = (
 /obj/machinery/door/airlock/external/glass{
 	id_tag = "pirateportexternal";
@@ -1087,11 +1114,14 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/pirate)
 "Oe" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/shuttle/pirate)
 "OD" = (
@@ -1122,6 +1152,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/pirate)
+"Qx" = (
+/turf/open/floor/pod/dark,
+/area/shuttle/pirate)
 "RY" = (
 /obj/effect/mob_spawn/human/pirate/captain{
 	dir = 4
@@ -1138,7 +1171,7 @@
 "RZ" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/cow{
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
+	atmos_requirements = list("min_oxy"=0,"max_oxy"=0,"min_tox"=0,"max_tox"=0,"min_co2"=0,"max_co2"=0,"min_n2"=0,"max_n2"=0);
 	desc = "Stolen from a cow genetics lab, she can survive in a vacuum safely, her milk is also delicious!";
 	name = "Ol Betsy"
 	},
@@ -1243,8 +1276,8 @@ af
 af
 af
 af
-af
 ey
+KC
 ay
 Oe
 OL
@@ -1261,9 +1294,9 @@ af
 af
 af
 af
-af
 aj
 az
+Dr
 bx
 bH
 aj
@@ -1276,13 +1309,13 @@ aR
 (6,1,1) = {"
 af
 af
-af
 ey
 ey
 aj
 aj
 aj
 CZ
+aj
 aj
 aj
 Gk
@@ -1293,7 +1326,6 @@ IN
 "}
 (7,1,1) = {"
 af
-af
 ey
 ey
 aC
@@ -1301,6 +1333,7 @@ aW
 aj
 bg
 gY
+Qx
 JT
 aj
 km
@@ -1311,7 +1344,6 @@ aj
 "}
 (8,1,1) = {"
 af
-af
 ey
 ab
 ae
@@ -1319,6 +1351,7 @@ oS
 aj
 bl
 fY
+bm
 ai
 aU
 be
@@ -1329,13 +1362,13 @@ aH
 "}
 (9,1,1) = {"
 af
-af
 ey
 Sk
 ag
 am
 jZ
 bm
+ri
 by
 bm
 au
@@ -1347,7 +1380,6 @@ aK
 "}
 (10,1,1) = {"
 af
-af
 ey
 ad
 ah
@@ -1355,6 +1387,7 @@ an
 aj
 bt
 gY
+Qx
 bI
 aj
 bO
@@ -1365,7 +1398,6 @@ er
 "}
 (11,1,1) = {"
 af
-af
 ey
 ey
 al
@@ -1373,6 +1405,7 @@ aB
 aj
 ek
 bA
+Qx
 vB
 aj
 np
@@ -1384,13 +1417,13 @@ aj
 (12,1,1) = {"
 af
 af
-af
 ey
 ey
 aj
 aj
 aj
 CZ
+aj
 aj
 aj
 xE
@@ -1405,8 +1438,8 @@ af
 af
 af
 af
-af
 aj
+GQ
 mD
 bB
 Ur
@@ -1423,8 +1456,8 @@ af
 af
 af
 af
-af
 ey
+iz
 eE
 bC
 bJ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Expands the pirate ship every so slightly. Expands armory, kitchen area, and the "hall" area a single tile upwards. It also moves the cargo pad over a tile so it isn't right in the entryway.

## Why It's Good For The Game
The pirate ship was cramped as hell and this makes it slightly less so. You would be pushing past your crew and it just made it annoying if you were trying to sell someone and shuffling around your fellow pirates

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
![2022 09 12-16 50 08](https://user-images.githubusercontent.com/71185626/189764854-1a65ce24-8e26-4cd6-81b1-86220260f526.png)

## Changelog

:cl:
tweak: The Pirate Ship got a small expansion to be slightly less crowded inside
/:cl: