### PR TITLE
Life Loop Movements

### DIFF
--- a/code/datums/components/infective.dm
+++ b/code/datums/components/infective.dm
@@ -37,7 +37,7 @@
 	else if(istype(parent, /obj/effect/decal/cleanable/blood/gibs))
 		RegisterSignal(parent, COMSIG_GIBS_STREAK, .proc/try_infect_streak)
 
-/datum/component/infective/proc/try_infect_eat(datum/source, mob/living/eater, mob/living/feeder)
+/datum/component/infective/proc/try_infect_eat(datum/source, mob/living/carbon/eater, mob/living/carbon/feeder)
 	SIGNAL_HANDLER
 
 	for(var/V in diseases)
@@ -66,7 +66,7 @@
 	if(isliving(A))
 		try_infect(A)
 
-/datum/component/infective/proc/try_infect_impact_zone(datum/source, mob/living/target, hit_zone)
+/datum/component/infective/proc/try_infect_impact_zone(datum/source, mob/living/carbon/target, hit_zone)
 	SIGNAL_HANDLER
 
 	try_infect(target, hit_zone)
@@ -77,14 +77,11 @@
 	try_infect(user, BODY_ZONE_L_ARM)
 	try_infect(target, hit_zone)
 
-/datum/component/infective/proc/try_infect_attack(datum/source, mob/living/target, mob/living/user)
+/datum/component/infective/proc/try_infect_attack(datum/source, mob/living/carbon/target, mob/living/user)
 	SIGNAL_HANDLER
-
-	if(!iscarbon(target)) //this case will be handled by try_infect_attack_zone
-		try_infect(target)
 	try_infect(user, BODY_ZONE_L_ARM)
 
-/datum/component/infective/proc/try_infect_equipped(datum/source, mob/living/L, slot)
+/datum/component/infective/proc/try_infect_equipped(datum/source, mob/living/carbon/L, slot)
 	SIGNAL_HANDLER
 
 	var/old_permeability
@@ -111,7 +108,7 @@
 
 	output_diseases |= diseases
 
-/datum/component/infective/proc/try_infect(mob/living/L, target_zone)
+/datum/component/infective/proc/try_infect(mob/living/carbon/L, target_zone)
 	for(var/V in diseases)
 		L.ContactContractDisease(V, target_zone)
 

--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -1,5 +1,5 @@
 
-/mob/living/proc/HasDisease(datum/disease/D)
+/mob/living/carbon/proc/HasDisease(datum/disease/D)
 	for(var/thing in diseases)
 		var/datum/disease/DD = thing
 		if(D.IsSame(DD))
@@ -7,7 +7,7 @@
 	return FALSE
 
 
-/mob/living/proc/CanContractDisease(datum/disease/D)
+/mob/living/carbon/proc/CanContractDisease(datum/disease/D)
 	if(stat == DEAD && !D.process_dead)
 		return FALSE
 
@@ -31,7 +31,7 @@
 	return TRUE
 
 
-/mob/living/proc/ContactContractDisease(datum/disease/D)
+/mob/living/carbon/proc/ContactContractDisease(datum/disease/D)
 	if(!CanContractDisease(D))
 		return FALSE
 	D.try_infect(src)
@@ -110,20 +110,15 @@
 	if(passed)
 		D.try_infect(src)
 
-/mob/living/proc/AirborneContractDisease(datum/disease/D, force_spread)
+/mob/living/carbon/proc/AirborneContractDisease(datum/disease/D, force_spread)
+	if(internal || HAS_TRAIT(src, TRAIT_NOBREATH))
+		return
 	if( ((D.spread_flags & DISEASE_SPREAD_AIRBORNE) || force_spread) && prob((50*D.permeability_mod) - 1))
 		ForceContractDisease(D)
 
-/mob/living/carbon/AirborneContractDisease(datum/disease/D, force_spread)
-	if(internal)
-		return
-	if(HAS_TRAIT(src, TRAIT_NOBREATH))
-		return
-	..()
-
 
 //Proc to use when you 100% want to try to infect someone (ignoreing protective clothing and such), as long as they aren't immune
-/mob/living/proc/ForceContractDisease(datum/disease/D, make_copy = TRUE, del_on_fail = FALSE)
+/mob/living/carbon/proc/ForceContractDisease(datum/disease/D, make_copy = TRUE, del_on_fail = FALSE)
 	if(!CanContractDisease(D))
 		if(del_on_fail)
 			qdel(D)
@@ -145,8 +140,5 @@
 			return FALSE
 	return ..()
 
-/mob/living/proc/CanSpreadAirborneDisease()
-	return !is_mouth_covered()
-
-/mob/living/carbon/CanSpreadAirborneDisease()
+/mob/living/carbon/proc/CanSpreadAirborneDisease()
 	return !((head && (head.flags_cover & HEADCOVERSMOUTH) && (head.get_armor_rating("bio", src) >= 25)) || (wear_mask && (wear_mask.flags_cover & MASKCOVERSMOUTH) && (wear_mask.get_armor_rating("bio", src) >= 25)))

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -42,13 +42,13 @@
 	SSdisease.active_diseases.Remove(src)
 
 //add this disease if the host does not already have too many
-/datum/disease/proc/try_infect(var/mob/living/infectee, make_copy = TRUE)
+/datum/disease/proc/try_infect(var/mob/living/carbon/infectee, make_copy = TRUE)
 	infect(infectee, make_copy)
 	return TRUE
 
 //add the disease with no checks
-/datum/disease/proc/infect(var/mob/living/infectee, make_copy = TRUE)
-	var/datum/disease/D = make_copy ? Copy() : src	
+/datum/disease/proc/infect(var/mob/living/carbon/infectee, make_copy = TRUE)
+	var/datum/disease/D = make_copy ? Copy() : src
 	infectee.diseases += D
 	D.affected_mob = infectee
 	SSdisease.active_diseases += D //Add it to the active diseases list, now that it's actually in a mob and being processed.
@@ -66,8 +66,7 @@
 /datum/disease/proc/stage_act()
 	var/cure = has_cure()
 
-	var/mob/living/L = affected_mob
-	if(L.IsInStasis())
+	if(affected_mob.IsInStasis())
 		return
 
 	if(carrier && !cure)

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -73,7 +73,7 @@
 			S.End(src)
 	return ..()
 
-/datum/disease/advance/try_infect(mob/living/infectee, make_copy = TRUE)
+/datum/disease/advance/try_infect(mob/living/carbon/infectee, make_copy = TRUE)
 	//see if we are more transmittable than enough diseases to replace them
 	//diseases replaced in this way do not confer immunity
 	var/list/advance_diseases = list()
@@ -543,7 +543,7 @@
 		message_admins("[key_name_admin(user)] has triggered a custom virus outbreak of [D.admin_details()]")
 		log_virus("[key_name(user)] has triggered a custom virus outbreak of [D.admin_details()]!")
 
-/datum/disease/advance/infect(var/mob/living/infectee, make_copy = TRUE)
+/datum/disease/advance/infect(var/mob/living/carbon/infectee, make_copy = TRUE)
 	var/datum/disease/advance/A = make_copy ? Copy() : src
 	if(!initial && A.mutable && (spread_flags & DISEASE_SPREAD_CONTACT_FLUIDS))
 		var/minimum = 1

--- a/code/datums/diseases/advance/symptoms/beard.dm
+++ b/code/datums/diseases/advance/symptoms/beard.dm
@@ -34,7 +34,7 @@ BONUS
 /datum/symptom/beard/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/index = min(max(beard_order.Find(H.facial_hair_style)+1, A.stage-1), beard_order.len)

--- a/code/datums/diseases/advance/symptoms/beesymptom.dm
+++ b/code/datums/diseases/advance/symptoms/beesymptom.dm
@@ -34,7 +34,7 @@
 /datum/symptom/beesease/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(2)
 			if(prob(2))

--- a/code/datums/diseases/advance/symptoms/blobspores.dm
+++ b/code/datums/diseases/advance/symptoms/blobspores.dm
@@ -36,7 +36,7 @@
 /datum/symptom/blobspores/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(1)
 			if(prob(2))
@@ -66,7 +66,7 @@
 /datum/symptom/blobspores/OnDeath(datum/disease/advance/A)
 	if(neutered) //Stops this symptom from making people scared even if this is useless
 		return FALSE
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	M.visible_message("<span class='danger'>[M] starts swelling grotesquely!</span>")
 	addtimer(CALLBACK(src, .proc/blob_the_mob, A, M), 10 SECONDS)
 

--- a/code/datums/diseases/advance/symptoms/braindamage.dm
+++ b/code/datums/diseases/advance/symptoms/braindamage.dm
@@ -33,7 +33,7 @@
 /datum/symptom/braindamage/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(1)
 			if(prob(10))

--- a/code/datums/diseases/advance/symptoms/choking.dm
+++ b/code/datums/diseases/advance/symptoms/choking.dm
@@ -51,7 +51,7 @@ Bonus
 /datum/symptom/asphyxiation/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	if(HAS_TRAIT(M, TRAIT_NOBREATH)) //if they don't breath, why would being unable to breath kill them?
 		return
 	switch(A.stage)

--- a/code/datums/diseases/advance/symptoms/cockroach.dm
+++ b/code/datums/diseases/advance/symptoms/cockroach.dm
@@ -28,7 +28,7 @@
 /datum/symptom/cockroach/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(2)
 			if(prob(50))
@@ -53,7 +53,7 @@
 	if(!..())
 		return
 	if(death_roaches)
-		var/mob/living/M = A.affected_mob
+		var/mob/living/carbon/M = A.affected_mob
 		to_chat(M, "<span class='warning'>Your pores explode into a colony of roaches!</span>")
 		for(var/i in 1 to rand(1,5))
 			new /mob/living/simple_animal/cockroach(M.loc)

--- a/code/datums/diseases/advance/symptoms/cough.dm
+++ b/code/datums/diseases/advance/symptoms/cough.dm
@@ -60,7 +60,7 @@ BONUS
 /datum/symptom/cough/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(1, 2, 3)
 			if(prob(base_message_chance) && !suppress_warning)

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -52,7 +52,7 @@ Bonus
 /datum/symptom/fire/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(3)
 			if(prob(base_message_chance) && !suppress_warning)
@@ -148,7 +148,7 @@ Bonus
 /datum/symptom/alkali/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(3)
 			if(prob(base_message_chance))

--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -47,7 +47,7 @@ Bonus
 /datum/symptom/flesh_eating/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(2,3)
 			if(prob(base_message_chance))
@@ -139,7 +139,7 @@ Bonus
 /datum/symptom/flesh_death/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(2,3)
 			if(MOB_UNDEAD in M.mob_biotypes)//i dont wanna do it like this but i gotta

--- a/code/datums/diseases/advance/symptoms/headache.dm
+++ b/code/datums/diseases/advance/symptoms/headache.dm
@@ -56,7 +56,7 @@ BONUS
 /datum/symptom/headache/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	if(power < 2)
 		if(prob(base_message_chance) || A.stage >=4)
 			to_chat(M, "<span class='warning'>[pick("Your head hurts.", "Your head pounds.")]</span>")

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -25,7 +25,7 @@
 /datum/symptom/heal/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(4, 5)
 			var/effectiveness = CanHeal(A)
@@ -119,7 +119,7 @@
 	REMOVE_TRAIT(A.affected_mob, TRAIT_NOCRITDAMAGE, DISEASE_TRAIT)
 
 /datum/symptom/heal/coma/CanHeal(datum/disease/advance/A)
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	if(stabilize)
 		ADD_TRAIT(M, TRAIT_NOCRITDAMAGE, DISEASE_TRAIT)
 	if(HAS_TRAIT(M, TRAIT_DEATHCOMA))
@@ -135,7 +135,7 @@
 		active_coma = TRUE
 		addtimer(CALLBACK(src, .proc/coma, M), 60)
 
-/datum/symptom/heal/coma/proc/coma(mob/living/M)
+/datum/symptom/heal/coma/proc/coma(mob/living/carbon/M)
 	if(deathgasp)
 		M.fakedeath(TRAIT_REGEN_COMA)
 	else

--- a/code/datums/diseases/advance/symptoms/lubefeet.dm
+++ b/code/datums/diseases/advance/symptoms/lubefeet.dm
@@ -32,7 +32,7 @@
 /datum/symptom/lubefeet/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(1, 2)
 			if(prob(15))

--- a/code/datums/diseases/advance/symptoms/macrophage.dm
+++ b/code/datums/diseases/advance/symptoms/macrophage.dm
@@ -36,7 +36,7 @@
 /datum/symptom/macrophage/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(1-3)
 			to_chat(M, "<span class='notice'>Your skin crawls.</span>")
@@ -52,7 +52,7 @@
 				phagecounter += 5
 				Burst(A, M)
 
-/datum/symptom/macrophage/proc/Burst(datum/disease/advance/A, var/mob/living/M, var/gigagerms = FALSE)
+/datum/symptom/macrophage/proc/Burst(datum/disease/advance/A, var/mob/living/carbon/M, var/gigagerms = FALSE)
 	var/mob/living/simple_animal/hostile/macrophage/phage
 	if(gigagerms)
 		phage = new /mob/living/simple_animal/hostile/macrophage/aggro(M.loc)

--- a/code/datums/diseases/advance/symptoms/narcolepsy.dm
+++ b/code/datums/diseases/advance/symptoms/narcolepsy.dm
@@ -46,7 +46,7 @@ Bonus
 		symptom_delay_max = 20
 
 /datum/symptom/narcolepsy/Activate(var/datum/disease/advance/A)
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	//this ticks even when on cooldown
 	switch(sleep_level) //Works sorta like morphine
 		if(10 to 19)

--- a/code/datums/diseases/advance/symptoms/necropolis.dm
+++ b/code/datums/diseases/advance/symptoms/necropolis.dm
@@ -109,7 +109,7 @@
 /datum/symptom/necroseed/OnDeath(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	if(chest && A.stage >= 5 && M.sethellbound())
 		to_chat(M, "<span class='danger'>Your soul is ripped from your body!</span>")
 		M.visible_message("<span class='danger'>An unearthly roar shakes the ground as [M] explodes into a shower of gore, leaving behind an ominous, fleshy chest.</span>")

--- a/code/datums/diseases/advance/symptoms/pierrot.dm
+++ b/code/datums/diseases/advance/symptoms/pierrot.dm
@@ -38,7 +38,7 @@
 /datum/symptom/pierrot/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(1)
 			if(prob(30))

--- a/code/datums/diseases/advance/symptoms/radiation.dm
+++ b/code/datums/diseases/advance/symptoms/radiation.dm
@@ -29,7 +29,7 @@
 /datum/symptom/radiation/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(1)
 			if(prob(10))

--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -30,7 +30,7 @@
 /datum/symptom/mind_restoration/Activate(var/datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 
 
 	if(A.stage >= 3)
@@ -80,7 +80,7 @@
 /datum/symptom/sensory_restoration/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	var/obj/item/organ/eyes/eyes = M.getorganslot(ORGAN_SLOT_EYES)
 	if (!eyes)
 		return

--- a/code/datums/diseases/advance/symptoms/shedding.dm
+++ b/code/datums/diseases/advance/symptoms/shedding.dm
@@ -32,7 +32,7 @@ BONUS
 	if(!..())
 		return
 
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	if(prob(base_message_chance))
 		to_chat(M, "<span class='warning'>[pick("Your scalp itches.", "Your skin feels flaky.")]</span>")
 	if(ishuman(M))

--- a/code/datums/diseases/advance/symptoms/skin.dm
+++ b/code/datums/diseases/advance/symptoms/skin.dm
@@ -32,7 +32,7 @@ BONUS
 
 /datum/symptom/vitiligo/Start(datum/disease/advance/A)
 	. = ..()
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(SKINTONES in H.dna.species.species_traits)
@@ -43,7 +43,7 @@ BONUS
 /datum/symptom/vitiligo/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.skin_tone == "albino")
@@ -62,7 +62,7 @@ BONUS
 
 /datum/symptom/vitiligo/End(datum/disease/advance/A)
 	. = ..()
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(SKINTONES in H.dna.species.species_traits)
@@ -104,7 +104,7 @@ BONUS
 
 /datum/symptom/revitiligo/Start(datum/disease/advance/A)
 	. = ..()
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(SKINTONES in H.dna.species.species_traits)
@@ -115,7 +115,7 @@ BONUS
 /datum/symptom/revitiligo/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.skin_tone == "african2")
@@ -134,7 +134,7 @@ BONUS
 
 /datum/symptom/revitiligo/End(datum/disease/advance/A)
 	. = ..()
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(SKINTONES in H.dna.species.species_traits)
@@ -177,7 +177,7 @@ BONUS
 /datum/symptom/polyvitiligo/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(5)
 			var/static/list/banned_reagents = list(/datum/reagent/colorful_reagent/powder/invisible, /datum/reagent/colorful_reagent/powder/white)
@@ -256,7 +256,7 @@ BONUS
 /datum/symptom/skineggs/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	var/list/diseases = list(A)
 	switch(A.stage)
 		if(5)

--- a/code/datums/diseases/advance/symptoms/sneeze.dm
+++ b/code/datums/diseases/advance/symptoms/sneeze.dm
@@ -39,7 +39,7 @@ Bonus
 /datum/symptom/sneeze/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(1, 2, 3)
 			if(!suppress_warning)

--- a/code/datums/diseases/advance/symptoms/viral.dm
+++ b/code/datums/diseases/advance/symptoms/viral.dm
@@ -103,7 +103,7 @@ Bonus
 	if(time_to_cure > 0)
 		time_to_cure--
 	else
-		var/mob/living/M = A.affected_mob
+		var/mob/living/carbon/M = A.affected_mob
 		Heal(M, A)
 
 /datum/symptom/viralreverse/proc/Heal(mob/living/M, datum/disease/advance/A)

--- a/code/datums/diseases/advance/symptoms/vomit.dm
+++ b/code/datums/diseases/advance/symptoms/vomit.dm
@@ -54,7 +54,7 @@ Bonus
 /datum/symptom/vomit/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(1, 2, 3, 4)
 			if(prob(base_message_chance) && !suppress_warning)

--- a/code/datums/diseases/advance/symptoms/weight.dm
+++ b/code/datums/diseases/advance/symptoms/weight.dm
@@ -38,7 +38,7 @@ Bonus
 	. = ..()
 	if(A.stealth >= 2) //warn less often
 		severity -= 3
-	
+
 
 /datum/symptom/weight_loss/Start(datum/disease/advance/A)
 	if(!..())
@@ -50,7 +50,7 @@ Bonus
 /datum/symptom/weight_loss/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(1, 2, 3, 4)
 			if(prob(base_message_chance))

--- a/code/datums/diseases/advance/symptoms/wizarditis.dm
+++ b/code/datums/diseases/advance/symptoms/wizarditis.dm
@@ -34,7 +34,7 @@
 /datum/symptom/wizarditis/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(2)
 			if(prob(30) && prob(50))

--- a/code/datums/diseases/advance/symptoms/youth.dm
+++ b/code/datums/diseases/advance/symptoms/youth.dm
@@ -34,7 +34,7 @@ BONUS
 /datum/symptom/youth/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		switch(A.stage)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -369,11 +369,12 @@ GENE SCANNER
 		var/tdelta = round(world.time - M.timeofdeath)
 		if(tdelta < (DEFIB_TIME_LIMIT * 10))
 			combined_msg += "<span class='alert'><b>Subject died [DisplayTimeText(tdelta)] ago, defibrillation may be possible!</b></span>"
-
-	for(var/thing in M.diseases)
-		var/datum/disease/D = thing
-		if(!(D.visibility_flags & HIDDEN_SCANNER))
-			combined_msg += "<span class='alert'><b>Warning: [D.form] detected</b>\nName: [D.name].\nType: [D.spread_text].\nStage: [D.stage]/[D.max_stages].\nPossible Cure: [D.cure_text]</span>"
+	if(iscarbon(M))
+		var/mob/living/carbon/scanned = M
+		for(var/thing in scanned.diseases)
+			var/datum/disease/D = thing
+			if(!(D.visibility_flags & HIDDEN_SCANNER))
+				combined_msg += "<span class='alert'><b>Warning: [D.form] detected</b>\nName: [D.name].\nType: [D.spread_text].\nStage: [D.stage]/[D.max_stages].\nPossible Cure: [D.cure_text]</span>"
 
 	// Blood Level
 	if(M.has_dna())

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -697,22 +697,25 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 /turf/proc/add_vomit_floor(mob/living/M, toxvomit = NONE)
 
-	var/obj/effect/decal/cleanable/vomit/V = new /obj/effect/decal/cleanable/vomit(src, M.get_static_viruses())
+	var/obj/effect/decal/cleanable/vomit/V = new /obj/effect/decal/cleanable/vomit(src)
 
 	//if the vomit combined, apply toxicity and reagents to the old vomit
 	if (QDELETED(V))
 		V = locate() in src
 	if(!V)
 		return
-	// Make toxins and blazaam vomit look different
-	if(toxvomit == VOMIT_PURPLE)
-		V.icon_state = "vomitpurp_[pick(1,4)]"
-	else if (toxvomit == VOMIT_TOXIC)
-		V.icon_state = "vomittox_[pick(1,4)]"
 	if (iscarbon(M))
 		var/mob/living/carbon/C = M
 		if(C.reagents)
 			clear_reagents_to_vomit_pool(C,V)
+	// Make toxins and blazaam vomit look different
+	switch(toxvomit)
+		if(NONE)
+			return
+		if(VOMIT_PURPLE)
+			V.icon_state = "vomitpurp_[pick(1,4)]"
+		if (VOMIT_TOXIC)
+			V.icon_state = "vomittox_[pick(1,4)]"
 
 /proc/clear_reagents_to_vomit_pool(mob/living/carbon/M, obj/effect/decal/cleanable/vomit/V)
 	M.reagents.trans_to(V, M.reagents.total_volume / 10, transfered_by = M)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -651,15 +651,15 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 			message_admins("<span class='adminnotice'>[key_name_admin(usr)] removed the spell [S] from [key_name_admin(T)].</span>")
 			SSblackbox.record_feedback("tally", "admin_verb", 1, "Remove Spell") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/client/proc/give_disease(mob/living/T in GLOB.mob_living_list)
+/client/proc/give_disease(mob/living/carbon/T in GLOB.mob_living_list)
 	set category = "Fun"
 	set name = "Give Disease"
 	set desc = "Gives a Disease to a mob."
 	if(!istype(T))
-		to_chat(src, "<span class='notice'>You can only give a disease to a mob of type /mob/living.</span>")
+		to_chat(src, "<span class='notice'>You can only give a disease to a mob of type /mob/living/carbon.</span>")
 		return
 	var/datum/disease/D = input("Choose the disease to give to that guy", "ACHOO") as null|anything in sortList(SSdisease.diseases, /proc/cmp_typepaths_asc)
-	if(!D)
+	if(!D || !iscarbon(T))
 		return
 	T.ForceContractDisease(new D, FALSE, TRUE)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Give Disease") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -23,7 +23,9 @@
 		to_chat(user, "<span class='notice'>We have revived ourselves.</span>")
 	else
 		to_chat(user, "<span class='notice'>We begin our stasis, preparing energy to arise once more.</span>")
-		user.fakedeath("changeling") //play dead
+		if(iscarbon(user))
+			var/mob/living/carbon/affected = user
+			affected.fakedeath("changeling") //play dead
 		user.update_stat()
 		user.update_mobility()
 		addtimer(CALLBACK(src, .proc/ready_to_regenerate, user), LING_FAKEDEATH_TIME, TIMER_UNIQUE)

--- a/code/modules/antagonists/monkey/monkey.dm
+++ b/code/modules/antagonists/monkey/monkey.dm
@@ -24,10 +24,12 @@
 	owner.special_role = "Infected Monkey"
 
 	var/datum/disease/D = new /datum/disease/transformation/jungle_fever/monkeymode
-	if(!owner.current.HasDisease(D))
-		owner.current.ForceContractDisease(D)
-	else
-		QDEL_NULL(D)
+	if(iscarbon(owner.current))
+		var/mob/living/carbon/returned = owner.current
+		if(!returned.HasDisease(D))
+			returned.ForceContractDisease(D)
+		else
+			QDEL_NULL(D)
 
 /datum/antagonist/monkey/greet()
 	to_chat(owner, "<b>You are a monkey now!</b>")
@@ -42,10 +44,11 @@
 /datum/antagonist/monkey/on_removal()
 	owner.special_role = null
 	SSticker.mode.ape_infectees -= owner
-
-	var/datum/disease/transformation/jungle_fever/D =  locate() in owner.current.diseases
-	if(D)
-		qdel(D)
+	if(iscarbon(owner.current))
+		var/mob/living/carbon/removal = owner.current
+		var/datum/disease/transformation/jungle_fever/D =  locate() in removal.diseases
+		if(D)
+			qdel(D)
 
 	. = ..()
 

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -89,8 +89,9 @@
 		M.gender = mob_gender
 	if(faction)
 		M.faction = list(faction)
-	if(disease)
-		M.ForceContractDisease(new disease)
+	if(disease && iscarbon(M))
+		var/mob/living/carbon/infective = M
+		infective.ForceContractDisease(new disease)
 	if(death)
 		M.death(1) //Kills the new mob
 

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -163,7 +163,10 @@
 
 	var/obj/item/food/meat/slab/allmeat[meat_produced]
 	var/obj/item/stack/sheet/animalhide/skin
-	var/list/datum/disease/diseases = mob_occupant.get_static_viruses()
+	var/list/datum/disease/diseases
+	if(iscarbon(mob_occupant))
+		var/mob/living/carbon/infective = mob_occupant
+		diseases = infective.get_static_viruses()
 
 	if(ishuman(occupant))
 		var/mob/living/carbon/human/gibee = occupant

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -269,8 +269,9 @@
 			else
 				temp_blood_DNA = drop.return_blood_DNA() //we transfer the dna from the drip to the splatter
 				qdel(drop)//the drip is replaced by a bigger splatter
-		else
-			drop = new(T, get_static_viruses())
+		else if(iscarbon(src))
+			var/mob/living/carbon/infective = src
+			drop = new(T, infective.get_static_viruses())
 			drop.color = initial(blood_type.color) // poor mans gags this doesn't need its own config
 			drop.transfer_mob_blood_dna(src)
 			return
@@ -278,8 +279,9 @@
 
 	// Find a blood decal or create a new one.
 	var/obj/effect/decal/cleanable/blood/B = locate() in T
-	if(!B)
-		B = new /obj/effect/decal/cleanable/blood/splatter(T, get_static_viruses())
+	if(!B && iscarbon(src))
+		var/mob/living/carbon/infective = src
+		B = new /obj/effect/decal/cleanable/blood/splatter(T, infective.get_static_viruses())
 	if(QDELETED(B)) //Give it up
 		return
 	if(B.count < 10 )

--- a/code/modules/mob/living/brain/life.dm
+++ b/code/modules/mob/living/brain/life.dm
@@ -32,8 +32,5 @@
 /mob/living/brain/handle_status_effects()
 	return
 
-/mob/living/brain/handle_traits()
-	return
-
 
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -15,6 +15,7 @@
 	QDEL_LIST(internal_organs)
 	QDEL_LIST(bodyparts)
 	QDEL_LIST(implants)
+	QDEL_LIST(diseases)
 	remove_from_all_data_huds()
 	QDEL_NULL(dna)
 	GLOB.carbon_list -= src

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -426,3 +426,13 @@
 	var/obj/item/organ/ears/ears = getorganslot(ORGAN_SLOT_EARS)
 	if(istype(ears) && !ears.deaf)
 		. = TRUE
+
+/mob/living/carbon/extrapolator_act(mob/user, var/obj/item/extrapolator/E, scan = TRUE)
+	if(istype(E) && diseases.len)
+		if(scan)
+			E.scan(src, diseases, user)
+		else
+			E.extrapolate(src, diseases, user)
+		return TRUE
+	else
+		return FALSE

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -11,6 +11,10 @@
 	var/dreaming = 0 //How many dream images we have left to send
 	var/obj/item/handcuffed = null //Whether or not the mob is handcuffed
 	var/obj/item/legcuffed = null  //Same as handcuffs but for legs. Bear traps use this.
+	//List of active diseases
+	var/list/diseases = list()
+	// list of all diseases in a mob
+	var/list/disease_resistances = list()
 
 	var/disgust = 0
 

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -35,3 +35,32 @@
 			adjust_nutrition(-(HUNGER_FACTOR/10))
 			if(m_intent == MOVE_INTENT_RUN)
 				adjust_nutrition(-(HUNGER_FACTOR/10))
+/mob/living/carbon/MobBump(mob/M)
+	. = ..()
+	if(iscarbon(M))
+		var/mob/living/carbon/affected = M
+		//spread diseases
+		for(var/thing in diseases)
+			var/datum/disease/D = thing
+			if(D.spread_flags & DISEASE_SPREAD_CONTACT_SKIN)
+				affected.ContactContractDisease(D)
+
+		for(var/thing in affected.diseases)
+			var/datum/disease/D = thing
+			if(D.spread_flags & DISEASE_SPREAD_CONTACT_SKIN)
+				ContactContractDisease(D)
+
+/mob/living/carbon/start_pulling(atom/movable/AM, state, force, supress_message)
+	. = ..()
+	//Share diseases that are spread by touch
+	if(iscarbon(AM))
+		var/mob/living/carbon/affected = AM
+		for(var/thing in diseases)
+			var/datum/disease/D = thing
+			if(D.spread_flags & DISEASE_SPREAD_CONTACT_SKIN)
+				affected.ContactContractDisease(D)
+
+		for(var/thing in affected.diseases)
+			var/datum/disease/D = thing
+			if(D.spread_flags & DISEASE_SPREAD_CONTACT_SKIN)
+				ContactContractDisease(D)

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -24,6 +24,9 @@
 		visible_message("<span class='danger'>[M] bursts out of [src]!</span>")
 	..()
 
+/mob/living/carbon/spawn_gibs()
+	new /obj/effect/gibspawner/generic(drop_location(), src, get_static_viruses())
+
 /mob/living/carbon/spill_organs(no_brain, no_organs, no_bodyparts)
 	var/atom/Tsec = drop_location()
 	if(!no_bodyparts)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -45,6 +45,10 @@
 			adjustBruteLoss(2)
 
 		if(stat != DEAD)
+			//Random events (vomiting etc)
+			handle_random_events()
+
+		if(stat != DEAD)
 			//Handle hygiene
 			if(HAS_TRAIT(src, TRAIT_ALWAYS_CLEAN))
 				set_hygiene(HYGIENE_LEVEL_CLEAN)
@@ -309,7 +313,7 @@
 
 	return min(1,thermal_protection)
 
-/mob/living/carbon/human/handle_random_events()
+/mob/living/carbon/human/proc/handle_random_events()
 	//Puke if toxloss is too high
 	if(!stat)
 		if(getToxLoss() >= 45 && nutrition > 20)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -10,6 +10,12 @@
 
 	if(!IsInStasis())
 
+		// DEAD check is in the proc itself; we want it to spread even if the mob is dead, but to handle its disease-y properties only if you're not.
+		handle_diseases()
+
+		if(QDELETED(src))
+			return
+
 		//Reagent processing needs to come before breathing, to prevent edge cases.
 		if(stat != DEAD)
 			for(var/V in internal_organs)
@@ -21,10 +27,13 @@
 					var/obj/item/organ/O = V
 					O.on_death() //Needed so organs decay while inside the body.
 
+		if(stat != DEAD)
+			//Breathing
+			handle_breathing(times_fired)
+
 		. = ..()
 
-		if(QDELETED(src))
-			return
+
 
 		if(.) //not dead
 			handle_blood()
@@ -34,6 +43,12 @@
 			if(bprv & BODYPART_LIFE_UPDATE_HEALTH)
 				update_stamina() //needs to go before updatehealth to remove stamcrit
 				updatehealth()
+
+		if(stat != DEAD)
+			//Mutations and radiation
+			handle_mutations_and_radiation()
+			// eye, ear, brain damages
+			handle_traits()
 
 		if(stat != DEAD) //Handle brain damage
 			for(var/T in get_traumas())
@@ -51,16 +66,6 @@
 			var/datum/addiction/addiction = SSaddiction.all_addictions[key]
 			addiction.process_addiction(src, delta_time, times_fired)
 
-	//Updates the number of stored chemicals for changeling powers
-	if(hud_used?.lingchemdisplay && !isalien(src) && mind)
-		var/datum/antagonist/changeling/changeling = mind.has_antag_datum(/datum/antagonist/changeling)
-		if(changeling)
-			changeling.regenerate()
-			hud_used.lingchemdisplay.invisibility = 0
-			hud_used.lingchemdisplay.maptext = MAPTEXT("<div align='center' valign='middle' style='position:relative; top:0px; left:6px'><font color='#dd66dd'>[round(changeling.chem_charges)]</font></div>")
-		else
-			hud_used.lingchemdisplay.invisibility = INVISIBILITY_ABSTRACT
-
 	if(stat != DEAD)
 		return 1
 
@@ -69,7 +74,7 @@
 ///////////////
 
 //Start of a breath chain, calls breathe()
-/mob/living/carbon/handle_breathing(times_fired)
+/mob/living/carbon/proc/handle_breathing(times_fired)
 	var/next_breath = 4
 	var/obj/item/organ/lungs/L = getorganslot(ORGAN_SLOT_LUNGS)
 	var/obj/item/organ/heart/H = getorganslot(ORGAN_SLOT_HEART)
@@ -344,7 +349,7 @@
 		if(BP.needs_processing)
 			. |= BP.on_life(force_heal + ((stam_regen * stam_heal * stam_heal_multiplier) / max(bodyparts_with_stam, 1)))
 
-/mob/living/carbon/handle_diseases()
+/mob/living/carbon/proc/handle_diseases()
 	for(var/thing in diseases)
 		var/datum/disease/D = thing
 		if(prob(D.infectivity))
@@ -353,7 +358,24 @@
 		if(stat != DEAD || D.process_dead)
 			D.stage_act()
 
-/mob/living/carbon/handle_mutations_and_radiation()
+/mob/living/carbon/proc/handle_traits()
+	//Eyes
+	if(eye_blind)			//blindness, heals slowly over time
+		if(!stat && !(HAS_TRAIT(src, TRAIT_BLIND)))
+			eye_blind = max(eye_blind-1,0)
+			if(client && !eye_blind)
+				clear_alert("blind")
+				clear_fullscreen("blind")
+			//Prevents healing blurryness while blind from normal means
+			return
+		else
+			eye_blind = max(eye_blind-1,1)
+	if(eye_blurry)			//blurry eyes heal slowly
+		eye_blurry = max(eye_blurry-1, 0)
+		if(client)
+			update_eye_blur()
+
+/mob/living/carbon/proc/handle_mutations_and_radiation()
 	if(dna && dna.temporary_mutations.len)
 		for(var/mut in dna.temporary_mutations)
 			if(dna.temporary_mutations[mut] < world.time)

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -1,5 +1,11 @@
 /mob/living/carbon/monkey
 
+
+/mob/living/carbon/monkey/Life(delta_time, times_fired)
+	. = ..()
+	if (DT_PROB(1, delta_time))
+		emote("scratch")
+
 /mob/living/carbon/monkey/handle_mutations_and_radiation()
 	if(radiation)
 		if(radiation > RAD_MOB_KNOCKDOWN && prob(RAD_MOB_KNOCKDOWN_PROB))
@@ -122,10 +128,6 @@
 		if (CH.clothing_flags & STOPSPRESSUREDAMAGE)
 			return ONE_ATMOSPHERE
 	return pressure
-
-/mob/living/carbon/monkey/handle_random_events()
-	if (prob(1) && prob(2))
-		emote("scratch")
 
 /mob/living/carbon/monkey/has_smoke_protection()
 	if(wear_mask)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -18,7 +18,7 @@
 	return
 
 /mob/living/proc/spawn_gibs()
-	new /obj/effect/gibspawner/generic(drop_location(), src, get_static_viruses())
+	new /obj/effect/gibspawner/generic(drop_location(), src)
 
 /mob/living/proc/spill_organs()
 	return

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -12,22 +12,8 @@
 
 	if(!has_status_effect(STATUS_EFFECT_STASIS))
 
-		if(stat != DEAD)
-			//Mutations and radiation
-			handle_mutations_and_radiation()
-
-		if(stat != DEAD)
-			//Breathing, if applicable
-			handle_breathing(times_fired)
-
-		handle_diseases()// DEAD check is in the proc itself; we want it to spread even if the mob is dead, but to handle its disease-y properties only if you're not.
-
-		if (QDELETED(src)) // diseases can qdel the mob via transformations
+		if (QDELETED(src))
 			return
-
-		if(stat != DEAD)
-			//Random events (vomiting etc)
-			handle_random_events()
 
 		//Handle temperature/pressure differences between body and environment
 		var/datum/gas_mixture/environment = loc.return_air()
@@ -38,14 +24,7 @@
 		var/gravity = has_gravity()
 		update_gravity(gravity)
 
-		if(gravity > STANDARD_GRAVITY)
-			if(!get_filter("gravity"))
-				add_filter("gravity",1,list("type"="motion_blur", "x"=0, "y"=0))
-			INVOKE_ASYNC(src, .proc/gravity_pulse_animation)
-			handle_high_gravity(gravity)
-
 		if(stat != DEAD)
-			handle_traits() // eye, ear, brain damages
 			handle_status_effects() //all special effects, stun, knockdown, jitteryness, hallucination, sleeping, etc
 
 	handle_fire()
@@ -54,20 +33,7 @@
 		machine.check_eye(src)
 
 	if(stat != DEAD)
-		return 1
-
-/mob/living/proc/handle_breathing(times_fired)
-	return
-
-/mob/living/proc/handle_mutations_and_radiation()
-	radiation = 0 //so radiation don't accumulate in simple animals
-	return
-
-/mob/living/proc/handle_diseases()
-	return
-
-/mob/living/proc/handle_random_events()
-	return
+		return TRUE
 
 /mob/living/proc/handle_environment(datum/gas_mixture/environment)
 	return
@@ -100,23 +66,6 @@
 /mob/living/proc/handle_status_effects()
 	if(confused)
 		confused = max(0, confused - 1)
-
-/mob/living/proc/handle_traits()
-	//Eyes
-	if(eye_blind)			//blindness, heals slowly over time
-		if(!stat && !(HAS_TRAIT(src, TRAIT_BLIND)))
-			eye_blind = max(eye_blind-1,0)
-			if(client && !eye_blind)
-				clear_alert("blind")
-				clear_fullscreen("blind")
-			//Prevents healing blurryness while blind from normal means
-			return
-		else
-			eye_blind = max(eye_blind-1,1)
-	if(eye_blurry)			//blurry eyes heal slowly
-		eye_blurry = max(eye_blurry-1, 0)
-		if(client)
-			update_eye_blur()
 
 /mob/living/proc/update_damage_hud()
 	return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -39,7 +39,6 @@
 
 	remove_from_all_data_huds()
 	GLOB.mob_living_list -= src
-	QDEL_LIST(diseases)
 	return ..()
 
 /mob/living/onZImpact(turf/T, levels)
@@ -115,16 +114,6 @@
 	if(isliving(M))
 		var/mob/living/L = M
 		they_can_move = L.mobility_flags & MOBILITY_MOVE
-		//Also spread diseases
-		for(var/thing in diseases)
-			var/datum/disease/D = thing
-			if(D.spread_flags & DISEASE_SPREAD_CONTACT_SKIN)
-				L.ContactContractDisease(D)
-
-		for(var/thing in L.diseases)
-			var/datum/disease/D = thing
-			if(D.spread_flags & DISEASE_SPREAD_CONTACT_SKIN)
-				ContactContractDisease(D)
 
 		//Should stop you pushing a restrained person out of the way
 		if(L.pulledby && L.pulledby != src && L.restrained())
@@ -323,16 +312,6 @@
 			M.LAssailant = WEAKREF(usr)
 		if(isliving(M))
 			var/mob/living/L = M
-			//Share diseases that are spread by touch
-			for(var/thing in diseases)
-				var/datum/disease/D = thing
-				if(D.spread_flags & DISEASE_SPREAD_CONTACT_SKIN)
-					L.ContactContractDisease(D)
-
-			for(var/thing in L.diseases)
-				var/datum/disease/D = thing
-				if(D.spread_flags & DISEASE_SPREAD_CONTACT_SKIN)
-					ContactContractDisease(D)
 
 			if(iscarbon(L))
 				var/mob/living/carbon/C = L
@@ -691,7 +670,7 @@
 				if((newdir in GLOB.cardinals) && (prob(50)))
 					newdir = turn(get_dir(target_turf, start), 180)
 				if(!blood_exists)
-					new /obj/effect/decal/cleanable/trail_holder(start, get_static_viruses())
+					new /obj/effect/decal/cleanable/trail_holder(start)
 
 				for(var/obj/effect/decal/cleanable/trail_holder/TH in start)
 					if((!(newdir in TH.existing_dirs) || trail_type == "trails_1" || trail_type == "trails_2") && TH.existing_dirs.len <= 16) //maximum amount of overlays is 16 (all light & heavy directions filled)
@@ -1313,7 +1292,7 @@
 	mob_pickup(user)
 	return TRUE
 
-/mob/living/proc/get_static_viruses() //used when creating blood and other infective objects
+/mob/living/carbon/proc/get_static_viruses() //used when creating blood and other infective objects
 	if(!LAZYLEN(diseases))
 		return
 	var/list/datum/disease/result = list()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -408,16 +408,6 @@
 	..()
 	setMovetype(movement_type & ~FLOATING) // If we were without gravity, the bouncing animation got stopped, so we make sure we restart the bouncing after the next movement.
 
-/mob/living/extrapolator_act(mob/user, var/obj/item/extrapolator/E, scan = TRUE)
-	if(istype(E) && diseases.len)
-		if(scan)
-			E.scan(src, diseases, user)
-		else
-			E.extrapolate(src, diseases, user)
-		return TRUE
-	else
-		return FALSE
-
 /mob/living/proc/sethellbound()
 	if(mind)
 		mind.hellbound = TRUE

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -124,10 +124,6 @@
 
 	var/mobchatspan = "unknown"	//The span to use when this mob talks in chat for the name tag
 
-	//List of active diseases
-	var/list/diseases = list() // list of all diseases in a mob
-	var/list/disease_resistances = list()
-
 	var/slowed_by_drag = TRUE //Whether the mob is slowed down when dragging another prone mob
 
 	var/is_busy = FALSE //Used for random actions that take time. ex: curbstomping. We need to make sure we can only do one of these at a time.

--- a/code/modules/mob/living/simple_animal/friendly/hamster.dm
+++ b/code/modules/mob/living/simple_animal/friendly/hamster.dm
@@ -66,7 +66,7 @@
 /mob/living/simple_animal/pet/hamster/vector/proc/on_entered(datum/source, M as mob)
 	SIGNAL_HANDLER
 
-	if(isliving(M) && !isnull(vector_disease) && prob(20))
-		var/mob/living/L = M
+	if(iscarbon(M) && !isnull(vector_disease) && prob(20))
+		var/mob/living/carbon/L = M
 		if(!L.HasDisease(vector_disease)) //I'm not actually sure if this check is needed, but better to be safe than sorry
 			L.ContactContractDisease(vector_disease)

--- a/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
@@ -71,10 +71,11 @@
 		if(prob(80))
 			var/atom/throw_target = get_edge_target_turf(L, dir)
 			L.throw_at(throw_target, rand(1,2), 7, src)
-			if(diseased)
+			if(diseased && iscarbon(target))
+				var/mob/living/carbon/infected = target
 				var/flesh_wound = ran_zone(CHEST, 40)
 				if(prob(100-L.getarmor(flesh_wound, "melee")))
-					L.ForceContractDisease(new /datum/disease/transformation/jungle_fever())
+					infected.ForceContractDisease(new /datum/disease/transformation/jungle_fever())
 		else
 			L.Unconscious(20)
 			visible_message("<span class='danger'>[src] knocks [L] out!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/macrophage.dm
+++ b/code/modules/mob/living/simple_animal/hostile/macrophage.dm
@@ -34,8 +34,8 @@
 	if(!.)
 		return FALSE
 	var/alreadyinfected = FALSE
-	if(isliving(the_target))
-		var/mob/living/M = the_target
+	if(iscarbon(the_target))
+		var/mob/living/carbon/M = the_target
 		for(var/datum/disease/D in M.diseases)
 			if(D.GetDiseaseID() == basedisease.GetDiseaseID())
 				if(aggressive)
@@ -58,8 +58,8 @@
 
 /mob/living/simple_animal/hostile/macrophage/AttackingTarget()
 	. = ..()
-	if(. && isliving(target))
-		var/mob/living/M = target
+	if(. && iscarbon(target))
+		var/mob/living/carbon/M = target
 		if(M.can_inject(src))
 			for(var/datum/disease/D in infections)
 				if(M.ForceContractDisease(D)) //we already check spread type in the macrophage creation proc

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -454,7 +454,7 @@
 		tod = null
 	update_stat()
 
-/mob/living/proc/fakedeath(source, silent = FALSE)
+/mob/living/carbon/proc/fakedeath(source, silent = FALSE)
 	if(stat == DEAD)
 		return
 	if(!silent)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -385,8 +385,8 @@
 				if(M.mind in SSticker.mode.apprentices)
 					return 2
 			if("monkey")
-				if(isliving(M))
-					var/mob/living/L = M
+				if(iscarbon(M))
+					var/mob/living/carbon/L = M
 					if(L.diseases && (locate(/datum/disease/transformation/jungle_fever) in L.diseases))
 						return 2
 		return TRUE

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -230,8 +230,9 @@ All effects don't start immediately, but rather get worse over time; the rate is
 		M.Jitter(350)
 
 	if(prob(1) && iscarbon(M))
+		var/mob/living/carbon/affected = M
 		var/datum/disease/D = new /datum/disease/heart_failure
-		M.ForceContractDisease(D)
+		affected.ForceContractDisease(D)
 		to_chat(M, "<span class='userdanger'>You're pretty sure you just felt your heart stop for a second there..</span>")
 		M.playsound_local(M, 'sound/effects/singlebeat.ogg', 100, 0)
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -640,8 +640,9 @@
 
 /datum/reagent/medicine/ephedrine/overdose_process(mob/living/M)
 	if(prob(2) && iscarbon(M))
+		var/mob/living/carbon/affected = M
 		var/datum/disease/D = new /datum/disease/heart_failure
-		M.ForceContractDisease(D)
+		affected.ForceContractDisease(D)
 		to_chat(M, "<span class='userdanger'>You're pretty sure you just felt your heart stop for a second there..</span>")
 		M.playsound_local(M, 'sound/effects/singlebeat.ogg', 100, 0)
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -16,14 +16,15 @@
 	if(data && data["viruses"])
 		for(var/thing in data["viruses"])
 			var/datum/disease/D = thing
+			if(iscarbon(L))
+				var/mob/living/carbon/affected = L
+				if((D.spread_flags & DISEASE_SPREAD_SPECIAL) || (D.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS))
+					continue
 
-			if((D.spread_flags & DISEASE_SPREAD_SPECIAL) || (D.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS))
-				continue
-
-			if((method == TOUCH || method == VAPOR) && (D.spread_flags & DISEASE_SPREAD_CONTACT_FLUIDS))
-				L.ContactContractDisease(D)
-			else //ingest, patch or inject
-				L.ForceContractDisease(D)
+				if((method == TOUCH || method == VAPOR) && (D.spread_flags & DISEASE_SPREAD_CONTACT_FLUIDS))
+					affected.ContactContractDisease(D)
+				else //ingest, patch or inject
+					affected.ForceContractDisease(D)
 
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
@@ -103,12 +104,15 @@
 	taste_description = "slime"
 
 /datum/reagent/vaccine/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
-	if(islist(data) && (method == INGEST || method == INJECT))
-		for(var/thing in L.diseases)
-			var/datum/disease/D = thing
-			if(D.GetDiseaseID() in data)
-				D.cure()
-		L.disease_resistances |= data
+
+	if(iscarbon(L))
+		var/mob/living/carbon/cured
+		if(islist(data) && (method == INGEST || method == INJECT))
+			for(var/thing in cured.diseases)
+				var/datum/disease/D = thing
+				if(D.GetDiseaseID() in data)
+					D.cure()
+			cured.disease_resistances |= data
 
 /datum/reagent/vaccine/on_merge(list/data)
 	if(istype(data))
@@ -724,7 +728,7 @@
 	taste_description = "slime"
 	can_synth = FALSE //idedplznerf
 
-/datum/reagent/aslimetoxin/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
+/datum/reagent/aslimetoxin/reaction_mob(mob/living/carbon/L, method=TOUCH, reac_volume)
 	if(method != TOUCH)
 		L.ForceContractDisease(new /datum/disease/transformation/slime(), FALSE, TRUE)
 
@@ -735,7 +739,7 @@
 	can_synth = FALSE
 	taste_description = "decay"
 
-/datum/reagent/gluttonytoxin/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
+/datum/reagent/gluttonytoxin/reaction_mob(mob/living/carbon/L, method=TOUCH, reac_volume)
 	L.ForceContractDisease(new /datum/disease/transformation/morph(), FALSE, TRUE)
 
 /datum/reagent/serotrotium
@@ -1186,7 +1190,7 @@
 	can_synth = FALSE
 	taste_description = "sludge"
 
-/datum/reagent/nanomachines/reaction_mob(mob/living/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
+/datum/reagent/nanomachines/reaction_mob(mob/living/carbon/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
 	if(method==PATCH || method==INGEST || method==INJECT || (method == VAPOR && prob(min(reac_volume,100)*(1 - touch_protection))))
 		L.ForceContractDisease(new /datum/disease/transformation/robot(), FALSE, TRUE)
 
@@ -1197,7 +1201,7 @@
 	can_synth = FALSE
 	taste_description = "sludge"
 
-/datum/reagent/xenomicrobes/reaction_mob(mob/living/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
+/datum/reagent/xenomicrobes/reaction_mob(mob/living/carbon/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
 	if(method==PATCH || method==INGEST || method==INJECT || (method == VAPOR && prob(min(reac_volume,100)*(1 - touch_protection))))
 		L.ForceContractDisease(new /datum/disease/transformation/xeno(), FALSE, TRUE)
 
@@ -1209,7 +1213,7 @@
 	taste_description = "slime"
 	random_unrestricted = FALSE
 
-/datum/reagent/fungalspores/reaction_mob(mob/living/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
+/datum/reagent/fungalspores/reaction_mob(mob/living/carbon/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
 	if(method==PATCH || method==INGEST || method==INJECT || (method == VAPOR && prob(min(reac_volume,100)*(1 - touch_protection))))
 		L.ForceContractDisease(new /datum/disease/tuberculosis(), FALSE, TRUE)
 
@@ -1220,7 +1224,7 @@
 	taste_description = "goo"
 	can_synth = FALSE //special orange man request
 
-/datum/reagent/snail/reaction_mob(mob/living/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
+/datum/reagent/snail/reaction_mob(mob/living/carbon/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
 	if(method==PATCH || method==INGEST || method==INJECT || (method == VAPOR && prob(min(reac_volume,100)*(1 - touch_protection))))
 		L.ForceContractDisease(new /datum/disease/gastrolosis(), FALSE, TRUE)
 
@@ -1975,7 +1979,7 @@
 	taste_description = "inner peace"
 	can_synth = FALSE
 
-/datum/reagent/tranquility/reaction_mob(mob/living/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
+/datum/reagent/tranquility/reaction_mob(mob/living/carbon/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
 	if(method==PATCH || method==INGEST || method==INJECT || (method == VAPOR && prob(min(reac_volume,100)*(1 - touch_protection))))
 		L.ForceContractDisease(new /datum/disease/transformation/gondola(), FALSE, TRUE)
 

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -65,14 +65,16 @@
 	return TRUE
 
 /obj/item/reagent_containers/syringe/proc/transfer_diseases(mob/living/L)
-	for(var/datum/disease/D in syringediseases)
-		if((D.spread_flags & DISEASE_SPREAD_SPECIAL) || (D.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS))
-			continue
-		L.ForceContractDisease(D)
-	for(var/datum/disease/D in L.diseases)
-		if((D.spread_flags & DISEASE_SPREAD_SPECIAL) || (D.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS))
-			continue
-		syringediseases += D
+	if(iscarbon(L))
+		var/mob/living/carbon/infected = L
+		for(var/datum/disease/D in syringediseases)
+			if((D.spread_flags & DISEASE_SPREAD_SPECIAL) || (D.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS))
+				continue
+			infected.ForceContractDisease(D)
+		for(var/datum/disease/D in infected.diseases)
+			if((D.spread_flags & DISEASE_SPREAD_SPECIAL) || (D.spread_flags & DISEASE_SPREAD_NON_CONTAGIOUS))
+				continue
+			syringediseases += D
 
 /obj/item/reagent_containers/syringe/afterattack(atom/target, mob/user , proximity)
 	. = ..()

--- a/code/modules/research/nanites/nanite_programs/suppression.dm
+++ b/code/modules/research/nanites/nanite_programs/suppression.dm
@@ -105,7 +105,9 @@
 /datum/nanite_program/fake_death/enable_passive_effect()
 	. = ..()
 	host_mob.emote("deathgasp")
-	host_mob.fakedeath("nanites")
+	if(iscarbon(host_mob))
+		var/mob/living/carbon/faker = host_mob
+		faker.fakedeath("nanites")
 
 /datum/nanite_program/fake_death/disable_passive_effect()
 	. = ..()

--- a/code/modules/wiremod/shell/drone.dm
+++ b/code/modules/wiremod/shell/drone.dm
@@ -22,7 +22,7 @@
 		gib(no_brain = TRUE, no_organs = TRUE, no_bodyparts = TRUE)
 
 /mob/living/circuit_drone/spawn_gibs()
-	new /obj/effect/gibspawner/robot(drop_location(), src, get_static_viruses())
+	new /obj/effect/gibspawner/robot(drop_location(), src)
 
 /obj/item/circuit_component/bot_circuit
 	display_name = "Drone"

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -556,34 +556,6 @@
 				<li class="bugfix">Clown's ability to slip while wearing their PDA</li>
 				<li class="bugfix">trash items weren't spawning</li>
 			</ul>
-
-			<h2 class="date">15 July 2022</h2>
-			<h3 class="author">DoctorSquishy updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Fixed Sleeper icons for clockwork and syndie</li>
-			</ul>
-			<h3 class="author">DoctorSquishy, Donkie, MadMedicineMan, Rohesie, Kylerace, nicbn, WarlockD updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="tweak">allows the air alarm to let vents suck are as well as pressurize.</li>
-				<li class="code_imp">Machine code should run smoother now which means less server lag!</li>
-			</ul>
-			<h3 class="author">NanoCats updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="imageadd">Added "Boxfort" "Terminal" "Girl" "Boy" "Hotdog" and "Yesman" skins for AI Enrichment purposes</li>
-			</ul>
-			<h3 class="author">Oricana-16 updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="tweak">Removed Sulphuric Acid from the Vent Clog Event's safe chem pool</li>
-			</ul>
-			<h3 class="author">dwasint updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="rscadd">search bar to supply console</li>
-			</ul>
-			<h3 class="author">wraith-54321 updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="rscadd">Added a new Syndie-kit special</li>
-				<li class="rscadd">Added a new unique spell</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>

--- a/monkestation/code/datums/diseases/advance/symptoms/fermentation.dm
+++ b/monkestation/code/datums/diseases/advance/symptoms/fermentation.dm
@@ -43,7 +43,7 @@
 /datum/symptom/fermentation/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	var/mob/living/carbon/C = M
 
 	if(A.stage >= 2)
@@ -91,7 +91,7 @@
 
 /datum/symptom/fermentation/End(datum/disease/advance/A) //Restore traits as needed.
 	. = ..()
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	QDEL_NULL(is_waddling)
 	if(has_light_drinker == TRUE)
 		REMOVE_TRAIT(M, TRAIT_DRUNK_HEALING, DISEASE_TRAIT)

--- a/monkestation/code/datums/diseases/advance/symptoms/gateway.dm
+++ b/monkestation/code/datums/diseases/advance/symptoms/gateway.dm
@@ -40,7 +40,7 @@
 /datum/symptom/gateway/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 
 	if(A.stage >= 2 && random_teleportation)
 		if(prob(15))
@@ -76,7 +76,7 @@
 
 /datum/symptom/gateway/End(datum/disease/advance/A)
 	. = ..()
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = A.affected_mob

--- a/monkestation/code/datums/diseases/advance/symptoms/goat.dm
+++ b/monkestation/code/datums/diseases/advance/symptoms/goat.dm
@@ -32,7 +32,7 @@
 /datum/symptom/goat/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 
 	if(A.stage >= 2)
 		if(prob(10)) //Works as both a virus 'warning' and hints at effects of the virus itself.
@@ -62,7 +62,7 @@
 
 /datum/symptom/goat/End(datum/disease/advance/A)
 	. = ..()
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 	M.remove_movespeed_modifier(type)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = A.affected_mob

--- a/monkestation/code/datums/diseases/advance/symptoms/rodman.dm
+++ b/monkestation/code/datums/diseases/advance/symptoms/rodman.dm
@@ -41,7 +41,7 @@
 /datum/symptom/rodman_syndrome/Activate(datum/disease/advance/A)
 	if(!..())
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/carbon/M = A.affected_mob
 
 	switch(A.stage)
 		if(2, 3)

--- a/monkestation/code/modules/wiremod/shell/scout_drone.dm
+++ b/monkestation/code/modules/wiremod/shell/scout_drone.dm
@@ -22,7 +22,7 @@
 		gib(no_brain = TRUE, no_organs = TRUE, no_bodyparts = TRUE)
 
 /mob/living/circuit_scout/spawn_gibs()
-	new /obj/effect/gibspawner/robot(drop_location(), src, get_static_viruses())
+	new /obj/effect/gibspawner/robot(drop_location(), src)
 
 /obj/item/circuit_component/scout_circuit
 	display_name = "Scout"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Move handle_mutations_and_radiation to living/carbon Move var/radiation to living/carbon

Move handle_breathing to living

Move handle_diseases to living/carbon
Move var/list/diseases,  var/list/disease_resistances to living/carbon

Move handle_random_events to living/carbon/human
(Monkeys no longer process random scratches)

Move handle_traits to mob/carbon

Moves changeling chemical gain from life to the antag datum

Fixes and removes an entirely unused changeling var that was meant to heal clone damage on the user

## Why It's Good For The Game

I saw a roughly 10% improvement locally on the mobs subsystem with 200 humans and 200 simple mobs active.
It's a slight improvement, but every bit counts.

## Changelog

:cl:
fix: Changeling clone damage heals passively as originally intended
refactor: Cleaned up some life loop code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
