### PR TITLE
Adds whetstone to the traitor uplink

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1783,6 +1783,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/clothing/glasses/thermal/syndi
 	cost = 3
 
+/datum/uplink_item/device_tools/whetstone
+	name = "Whetstone"
+	desc = "Salvaged a good sharp weapon?  Wish it were a bit sharper? \
+			Our deep-kitchen chefs have smuggled out some quality whetstones. \
+			Good for making a bad blade good, or a good blade better!"
+	item = /obj/item/sharpener
+	cost = 2
+
 // Implants
 /datum/uplink_item/implants
 	category = "Implants"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This adds the chef whetstone as a purchasable traitor item for 2 tc

## Why It's Good For The Game

I think this will facilitate shenanigans, since the whetstone is better at making bad knifes decent than it is at making good knives better than anything else.  Even a wielded sharpened fireaxe still doesn't overcome an esword, and you've put in the effort of obtaining the axe and have to wield it.

Though if you want to be silly and stab people to death with a sharpened mop, now that's a lot more viable.

Currently the only way I know of to obtain this is as a roundstart chef, but it can potentially be used on a lot of things!

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
add: Whetstones can now be purchased through traitor uplinks!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
