### PR TITLE
Fixes mimics messing with Rezadone/Synthflesh unhusking.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -400,7 +400,6 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 // Monkestation Changes Start
 #define TRAIT_TRASH_EATER "trash_eater" //goat.dm symptom requirement
 #define TRAIT_VAULTING "vaulting" //simian trait
-#define MIMIC_ABSORB "absorb" //alien_mimic absorbing
 ///Turf trait for when a turf is transparent
 #define TURF_Z_TRANSPARENT_TRAIT "turf_z_transparent"
 // Monkestation Changes End

--- a/monkestation/code/modules/antagonists/mimic/mimic.dm
+++ b/monkestation/code/modules/antagonists/mimic/mimic.dm
@@ -392,7 +392,7 @@
 				playsound(get_turf(src), absorb_sound,100)
 				visible_message("<span class='warning'>[src] absorbs [carbon_victim]!</span>", \
 							"<span class='userdanger'>[carbon_victim]'s corpse decays as you absorb the nutrients from their body.</span>")
-				carbon_victim.become_husk(MIMIC_ABSORB)
+				carbon_victim.become_husk("burn") //Needs to be "burn" so rezadone and such an fix it, don't want it being an RR due to too many bodies for medbay.
 				people_absorbed++
 				adjustHealth(-40)
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Mimics would husk with their own thing ("absorb"), but rezadone and synthflesh only heal specific types of husk ("burn"). 

## Why It's Good For The Game

Mimics shouldn't be an RR by any means. The husking should just be another step in the healing process to make it a bit harder for medbay, not 10x harder and longer to fix, and impossible to keep up with if more bodies come in.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Rezadone after mimic husk
![image](https://user-images.githubusercontent.com/99915170/191446966-3d3508db-9047-4b7f-8512-44c4b6dd36d9.png)

</details>

## Changelog

:cl:
fix: Rezadone and Synthflesh now work on mimic husking.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
