### PR TITLE
Lets Science and Medbay build simian translators

### DIFF
--- a/code/modules/research/designs/electronics_designs.dm
+++ b/code/modules/research/designs/electronics_designs.dm
@@ -32,6 +32,16 @@
 	build_path = /obj/item/surveillance_upgrade
 	category = list("Electronics")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
+/datum/design/monkeytranslator
+	name = "MonkeTech AutoTranslator"
+	desc = "A small device that will translate speech."
+	id = "monkeytranslator"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 1000, /datum/material/glass = 500)
+	construction_time = 75
+	build_path = /obj/item/clothing/mask/translator
+	category = list("Electronics")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
 
 ///////////////////////////////////
 //////////Nanite Devices///////////

--- a/code/modules/research/designs/electronics_designs.dm
+++ b/code/modules/research/designs/electronics_designs.dm
@@ -32,10 +32,10 @@
 	build_path = /obj/item/surveillance_upgrade
 	category = list("Electronics")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
-/datum/design/monkeytranslator
+/datum/design/monkey_translator
 	name = "MonkeTech AutoTranslator"
 	desc = "A small device that will translate speech."
-	id = "monkeytranslator"
+	id = "monkey_translator"
 	build_type = PROTOLATHE
 	materials = list(/datum/material/iron = 1000, /datum/material/glass = 500)
 	construction_time = 75

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -148,7 +148,7 @@
 	display_name = "Data Theory"
 	description = "Big Data, in space!"
 	prereq_ids = list("base")
-	design_ids = list("bounty_pad", "bounty_pad_control") //Monkestation edit
+	design_ids = list("bounty_pad", "bounty_pad_control", "monkeytranslator") //Monkestation edit
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -148,7 +148,7 @@
 	display_name = "Data Theory"
 	description = "Big Data, in space!"
 	prereq_ids = list("base")
-	design_ids = list("bounty_pad", "bounty_pad_control", "monkeytranslator") //Monkestation edit
+	design_ids = list("bounty_pad", "bounty_pad_control", "monkey_translator") //Monkestation edit
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This adds the MonkeTech AutoTranslator to the lathes in both science and medbay, available after the data theory research is done (it's a precursor to neural tech which I'd consider "after" translators, and also severely lacking in actual unlocks).

## Why It's Good For The Game

Simians who lose their translator are now less screwed, and we have a slightly less awkward solution to people who can't speak common.

Consideration could be given to whether this lessens the impact of foreigner, simian, ashwalkers and so on, but I think the required tech and build resources can be tweaked to handle that later if a more coherent design is undertaken.

## Changelog

:cl:
add: MonkeTech AutoTranslators can now be built in science and medbay after some basic research!  Rejoice, death-prone simians!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
