### PR TITLE
Added a bluespace beacon to the default exploration outfit

### DIFF
--- a/code/modules/jobs/job_types/exploration_team.dm
+++ b/code/modules/jobs/job_types/exploration_team.dm
@@ -63,8 +63,9 @@
 	gloves = /obj/item/clothing/gloves/color/black
 	uniform = /obj/item/clothing/under/rank/cargo/exploration
 	backpack_contents = list(
-		/obj/item/kitchen/knife/combat/survival=1,\
-		/obj/item/stack/marker_beacon/thirty=1)
+		/obj/item/kitchen/knife/combat/survival=1,
+		/obj/item/stack/marker_beacon/thirty=1,
+		/obj/item/sbeacondrop/exploration=1)			//MonkeStation edit: adds a bluespace beacon for latejoiners
 	l_pocket = /obj/item/gps/mining/exploration
 	r_pocket = /obj/item/gun/energy/e_gun/mini/exploration
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
As it says on the tin- adds a single bluespace beacon to the default outfit for latejoin exploration crew players.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
Unlike medical or engineering equipment that can be obtained through other departments/exploration vendor, bluespace beacons are only available to exploration scientists at roundstart. This change will allow latejoiners to also have an opportunity to mark an interesting location found on their outings for return trips.

## Changelog

:cl:
add: Added a single bluespace beacon to default exploration crew outfit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
