### PR TITLE
Adds several new cargo crates

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -314,6 +314,42 @@
 	crate_name = "weed control crate"
 	crate_type = /obj/structure/closet/crate/secure/hydroponics
 
+/datum/supply_pack/emergency/weedcontrol_reverse
+	name = "Weed Out-of-Control Crate"
+	desc = "Dude, do you ever think that, like, we think that we order the crates, but what if the truth is, the crates order us?"
+	cost = 420
+	contraband = TRUE
+	contains = list(/obj/item/storage/fancy/rollingpapers,
+					/obj/item/storage/fancy/rollingpapers,
+					/obj/item/storage/box/matches,
+					/obj/item/clothing/mask/vape,
+					/obj/item/clothing/mask/bandana/green,
+					/obj/item/storage/belt/fannypack/green,
+					/obj/item/food/chips,
+					/obj/item/food/sosjerky)
+	crate_name = "weed crate"
+
+/datum/supply_pack/emergency/pest_control
+	name = "Pest Control Crate"
+	desc = "dUe To SpAcE-wInTeR, a NuMbEr Of RoDeNtS hAvE mIgRaTeD iNtO tHe MaInTeNaNcE tUnNeLs."
+	cost = 1500
+	contains = list(/obj/item/storage/box/mousetraps,
+					/obj/item/storage/box/mousetraps,
+					/obj/item/restraints/legcuffs/beartrap,
+					/obj/item/restraints/legcuffs/beartrap)
+	crate_name = "pest control crate"
+
+/datum/supply_pack/emergency/pest_control_reverse
+	name = "Pest Out-of-Control Crate"
+	desc = "Due to space-winter, a number of rodents have migrated into this crate."
+	cost = 800
+	contraband = TRUE
+	contains = list(/mob/living/simple_animal/mouse,
+					/mob/living/simple_animal/mouse,
+					/mob/living/simple_animal/mouse,
+					/mob/living/simple_animal/mouse)
+	crate_name = "pest crate"
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Security ////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
@@ -785,6 +821,16 @@
 					/obj/item/ammo_box/magazine/wt550m9,
 					/obj/item/ammo_box/magazine/wt550m9)
 
+/datum/supply_pack/security/armory/secway
+	name = "Secway Crate"
+	desc = "Sail through the halls like the badass mallcop of your dreams with the finest in overweight officer transportation technology!"
+	cost = 5000
+	contraband = TRUE
+	contains = list(/obj/vehicle/ridden/secway,
+					/obj/item/key/security)
+	crate_name = "secway crate"
+	crate_type = /obj/structure/closet/crate/large
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Engineering /////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
@@ -1077,6 +1123,41 @@
 	)
 	crate_name = "portable pump crate"
 	crate_type = /obj/structure/closet/crate/large
+
+/datum/supply_pack/engineering/cones
+	name = "Engineering Hat Crate"
+	desc = "Contains a complete set of headwear to fit the heads of an entire engineering crew."
+	cost = 600
+	contraband = TRUE
+	contains = list(
+		/obj/item/clothing/head/cone,
+		/obj/item/clothing/head/cone,
+		/obj/item/clothing/head/cone,
+		/obj/item/clothing/head/cone,
+		/obj/item/clothing/head/cone,
+		/obj/item/clothing/head/cone
+	)
+	crate_name = "engineering hat crate"
+
+/datum/supply_pack/engineering/radios
+	name = "Telecommunications Starter Pack Crate"
+	desc = "Contains everything you need to get a basic stationwide radio network established!"
+	cost = 500
+	contraband = TRUE
+	contains = list(
+		/obj/item/radio,
+		/obj/item/radio,
+		/obj/item/radio,
+		/obj/item/radio,
+		/obj/item/radio,
+		/obj/item/radio,
+		/obj/item/radio,
+		/obj/item/radio,
+		/obj/item/radio,
+		/obj/item/radio,
+	)
+	crate_name = "telecommunications starter pack crate"
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////// Engine Construction /////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
@@ -1346,27 +1427,6 @@
 	cost = 1700
 	contains = list(/obj/item/stack/sheet/mineral/wood/fifty)
 	crate_name = "wood planks crate"
-
-/datum/supply_pack/materials/bz
-	name = "BZ Canister Crate"
-	desc = "Contains a canister of BZ. Requires Atmospherics access to open."
-	cost = 8000
-	access = ACCESS_ATMOSPHERICS
-	access_budget = ACCESS_ATMOSPHERICS
-	contains = list(/obj/machinery/portable_atmospherics/canister/bz)
-	crate_name = "BZ canister crate"
-	crate_type = /obj/structure/closet/crate/secure
-
-/datum/supply_pack/materials/carbon_dio
-	name = "Carbon Dioxide Canister"
-	desc = "Contains a canister of Carbon Dioxide. Requires Atmospherics access to open."
-	cost = 1200
-	access = ACCESS_ATMOSPHERICS
-	access_budget = ACCESS_ATMOSPHERICS
-	contains = list(/obj/machinery/portable_atmospherics/canister/carbon_dioxide)
-	crate_name = "carbon dioxide canister crate"
-	crate_type = /obj/structure/closet/crate/secure
-
 /datum/supply_pack/materials/foamtank
 	name = "Firefighting Foam Tank Crate"
 	desc = "Contains a tank of firefighting foam. Also known as \"plasmaman's bane\"."
@@ -1384,24 +1444,52 @@
 	crate_name = "fuel tank crate"
 	crate_type = /obj/structure/closet/crate/large
 
+/datum/supply_pack/materials/watertank
+	name = "Water Tank Crate"
+	desc = "Contains a tank of dihydrogen monoxide... sounds dangerous."
+	cost = 750
+	contains = list(/obj/structure/reagent_dispensers/watertank)
+	crate_name = "water tank crate"
+	crate_type = /obj/structure/closet/crate/large
+
 /datum/supply_pack/materials/hightank
-	name = "Large Water Tank Crate"
+	name = " Water Tank Crate, Large"
 	desc = "Contains a high-capacity water tank. Useful for botany or other service jobs."
 	cost = 1200
 	contains = list(/obj/structure/reagent_dispensers/watertank/high)
 	crate_name = "high-capacity water tank crate"
 	crate_type = /obj/structure/closet/crate/large
 
+/datum/supply_pack/materials/bz
+	name = "BZ Canister Crate"
+	desc = "Contains a canister of BZ. Requires Atmospherics access to open."
+	cost = 8000
+	access = ACCESS_ATMOSPHERICS
+	access_budget = ACCESS_ATMOSPHERICS
+	contains = list(/obj/machinery/portable_atmospherics/canister/bz)
+	crate_name = "BZ canister crate"
+	crate_type = /obj/structure/closet/crate/secure
+
+/datum/supply_pack/materials/carbon_dio
+	name = "Carbon Dioxide Canister Crate"
+	desc = "Contains a canister of Carbon Dioxide. Requires Atmospherics access to open."
+	cost = 1200
+	access = ACCESS_ATMOSPHERICS
+	access_budget = ACCESS_ATMOSPHERICS
+	contains = list(/obj/machinery/portable_atmospherics/canister/carbon_dioxide)
+	crate_name = "carbon dioxide canister crate"
+	crate_type = /obj/structure/closet/crate/secure
+
 /datum/supply_pack/materials/nitrogen
 	name = "Nitrogen Canister"
-	desc = "Contains a canister of Nitrogen."
+	desc = "A canister of Nitrogen."
 	cost = 800
 	contains = list(/obj/machinery/portable_atmospherics/canister/nitrogen)
 	crate_name = "nitrogen canister crate"
 	crate_type = /obj/structure/closet/crate/large
 
 /datum/supply_pack/materials/nitrous_oxide_canister
-	name = "Nitrous Oxide Canister"
+	name = "Nitrous Oxide Canister Crate"
 	desc = "Contains a canister of Nitrous Oxide. Requires Atmospherics access to open."
 	cost = 2400
 	access = ACCESS_ATMOSPHERICS
@@ -1410,20 +1498,14 @@
 	crate_name = "nitrous oxide canister crate"
 	crate_type = /obj/structure/closet/crate/secure
 
-/datum/supply_pack/materials/oxygen
-	name = "Oxygen Canister"
-	desc = "Contains a canister of Oxygen. Canned in Druidia."
-	cost = 800
-	contains = list(/obj/machinery/portable_atmospherics/canister/oxygen)
-	crate_name = "oxygen canister crate"
-	crate_type = /obj/structure/closet/crate/large
-
-/datum/supply_pack/materials/watertank
-	name = "Water Tank Crate"
-	desc = "Contains a tank of dihydrogen monoxide... sounds dangerous."
-	cost = 750
-	contains = list(/obj/structure/reagent_dispensers/watertank)
-	crate_name = "water tank crate"
+/datum/supply_pack/materials/plasma_canister
+	name = "Plasma Canister"
+	desc = "Contains a canister of Plasma. Hey wait aren't YOU supposed to be producing this stuff for US?"
+	cost = 4000
+	access = ACCESS_ATMOSPHERICS
+	access_budget = ACCESS_ATMOSPHERICS
+	contains = list(/obj/machinery/portable_atmospherics/canister/toxins)
+	crate_name = "plasma canister crate"
 	crate_type = /obj/structure/closet/crate/large
 
 /datum/supply_pack/materials/water_vapor
@@ -1682,6 +1764,19 @@
 	contains = list(/obj/machinery/computer/pandemic)
 	crate_name = "P.A.N.D.E.M.I.C. Replacement Crate"
 	dangerous = TRUE
+
+/datum/supply_pack/medical/maintpills
+	name = "Questionable Medicine Crate"
+	desc = "A shipment of unlabelled surplus pills.  It's... probably ok... probably."
+	cost = 10000
+	contraband = TRUE
+	contains = list(/obj/item/reagent_containers/pill/floorpill,
+					/obj/item/reagent_containers/pill/floorpill,
+					/obj/item/reagent_containers/pill/floorpill,
+					/obj/item/reagent_containers/pill/floorpill,
+					/obj/item/reagent_containers/pill/floorpill)
+	crate_name = "questionable medicine crate"
+
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Science /////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
@@ -1863,7 +1958,7 @@
 					/obj/item/grenade/chem_grenade/cleaner)
 	crate_name = "janitorial supplies crate"
 
-/datum/supply_pack/service/janitor/janicart
+/datum/supply_pack/service/janitor/janitorialcart
 	name = "Janitorial Cart and Galoshes Crate"
 	desc = "The keystone to any successful janitor. As long as you have feet, this pair of galoshes will keep them firmly planted on the ground. Also contains a janitorial cart."
 	cost = 1000
@@ -1871,6 +1966,16 @@
 	contains = list(/obj/structure/janitorialcart,
 					/obj/item/clothing/shoes/galoshes)
 	crate_name = "janitorial cart crate"
+	crate_type = /obj/structure/closet/crate/large
+
+/datum/supply_pack/service/janitor/janicart
+	name = "Janicart Crate"
+	desc = "You'd better not have wrecked the last one joyriding."
+	cost = 20000
+	access_budget = ACCESS_JANITOR
+	contains = list(/obj/vehicle/ridden/janicart,
+					/obj/item/key/janitor)
+	crate_name = "janicart crate"
 	crate_type = /obj/structure/closet/crate/large
 
 /datum/supply_pack/service/janitor/janitank
@@ -1890,6 +1995,18 @@
 	contains = list(/mob/living/simple_animal/bot/mulebot)
 	crate_name = "\improper MULEbot Crate"
 	crate_type = /obj/structure/closet/crate/large
+
+/datum/supply_pack/service/glassware
+	name = "Glassware Crate"
+	desc = "Printing too much trouble? Buy our bulk glassware package today!"
+	cost = 1000
+	contains = list(/obj/item/storage/box/beakers,
+					/obj/item/storage/box/drinkingglasses,
+					/obj/item/storage/box/drinkingglasses,
+					/obj/item/reagent_containers/food/drinks/flask,
+					/obj/item/reagent_containers/food/drinks/flask,
+					/obj/item/reagent_containers/food/drinks/shaker)
+	crate_name = "glassware crate"
 
 /datum/supply_pack/service/party
 	name = "Party Equipment"
@@ -2437,6 +2554,16 @@
 	contains = list(/mob/living/simple_animal/cow)
 	crate_name = "cow crate"
 
+/datum/supply_pack/critter/friendly_bee
+	name = "Friendly Bee Crate"
+	desc = "Buzz buzz!"
+	cost = 2000
+	contains = list(/mob/living/simple_animal/hostile/poison/bees/friendly,
+					/mob/living/simple_animal/hostile/poison/bees/friendly,
+					/mob/living/simple_animal/hostile/poison/bees/friendly,
+					/mob/living/simple_animal/hostile/poison/bees/friendly)
+	crate_name = "happily buzzing crate"
+
 /datum/supply_pack/critter/crab
 	name = "Crab Rocket"
 	desc = "CRAAAAAAB ROCKET. CRAB ROCKET. CRAB ROCKET. CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB ROCKET. CRAFT. ROCKET. BUY. CRAFT ROCKET. CRAB ROOOCKET. CRAB ROOOOCKET. CRAB CRAB CRAB CRAB CRAB CRAB CRAB CRAB ROOOOOOOOOOOOOOOOOOOOOOCK EEEEEEEEEEEEEEEEEEEEEEEEE EEEETTTTTTTTTTTTAAAAAAAAA AAAHHHHHHHHHHHHH. CRAB ROCKET. CRAAAB ROCKEEEEEEEEEGGGGHHHHTT CRAB CRAB CRAABROCKET CRAB ROCKEEEET."//fun fact: i actually spent like 10 minutes and transcribed the entire video.
@@ -2602,6 +2729,19 @@
 					/obj/item/ammo_box/magazine/toy/pistol,
 					/obj/item/ammo_box/magazine/toy/pistol)
 	crate_name = "foam force crate"
+
+/datum/supply_pack/costumes_toys/recreation
+	name = "Recreational Crate"
+	desc = "Equipment for getting those scientists to actually get out of their chairs and stretch their legs a bit!"
+	cost = 1500
+	crate_name = "recreational crate"
+	contains = list(/obj/item/toy/beach_ball/holoball,
+					/obj/item/toy/beach_ball/holoball,
+					/obj/item/melee/skateboard/pro,
+					/obj/item/melee/skateboard/pro,
+					/obj/item/clothing/shoes/sneakers/red,
+					/obj/item/clothing/shoes/sneakers/red)
+	crate_type = /obj/structure/closet/crate/large
 
 /datum/supply_pack/costumes_toys/formalwear
 	name = "Formalwear Crate"
@@ -3083,3 +3223,12 @@
 					/obj/item/toner/large,
 					/obj/item/toner/large)
 	crate_name = "large toner crate"
+
+/datum/supply_pack/misc/strange_objects
+	name = "Strange Object Crate"
+	desc = "We aren't quite sure what these are, but we'll sell them to you at a discount!"
+	cost = 2000
+	contains = list(/obj/item/relic,
+					/obj/item/relic,
+					/obj/item/relic)
+	crate_name = "strange object crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -331,7 +331,7 @@
 
 /datum/supply_pack/emergency/pest_control
 	name = "Pest Control Crate"
-	desc = "dUe To SpAcE-wInTeR, a NuMbEr Of RoDeNtS hAvE mIgRaTeD iNtO tHe MaInTeNaNcE tUnNeLs."
+	desc = "Additional supplies for handling rodents of both ordinary and unusual size."
 	cost = 1500
 	contains = list(/obj/item/storage/box/mousetraps,
 					/obj/item/storage/box/mousetraps,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -331,7 +331,7 @@
 
 /datum/supply_pack/emergency/pest_control
 	name = "Pest Control Crate"
-	desc = "Additional supplies for handling rodents of both ordinary and unusual size."
+	desc = "Additional traps for handling rodents of both ordinary and unusual size."
 	cost = 1500
 	contains = list(/obj/item/storage/box/mousetraps,
 					/obj/item/storage/box/mousetraps,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -316,7 +316,7 @@
 
 /datum/supply_pack/emergency/weedcontrol_reverse
 	name = "Weed Out-of-Control Crate"
-	desc = "Dude, do you ever think that, like, we think that we order the crates, but what if the truth is, the crates order us?"
+	desc = "Supplies for when the botanists have smoked all the blunts and eaten all the food, contains rolling papers, snacks, and paraphernalia."
 	cost = 420
 	contraband = TRUE
 	contains = list(/obj/item/storage/fancy/rollingpapers,
@@ -342,7 +342,7 @@
 /datum/supply_pack/emergency/pest_control_reverse
 	name = "Pest Out-of-Control Crate"
 	desc = "Due to space-winter, a number of rodents have migrated into this crate."
-	cost = 800
+	cost = 1800
 	contraband = TRUE
 	contains = list(/mob/living/simple_animal/mouse,
 					/mob/living/simple_animal/mouse,
@@ -1126,9 +1126,8 @@
 
 /datum/supply_pack/engineering/cones
 	name = "Engineering Hat Crate"
-	desc = "Contains a complete set of headwear to fit the heads of an entire engineering crew."
+	desc = "A complete set of headwear to fit the heads of an entire engineering crew.  Includes 6 cones."
 	cost = 600
-	contraband = TRUE
 	contains = list(
 		/obj/item/clothing/head/cone,
 		/obj/item/clothing/head/cone,
@@ -1470,7 +1469,7 @@
 	crate_name = "BZ canister crate"
 	crate_type = /obj/structure/closet/crate/secure
 
-/datum/supply_pack/materials/carbon_dio
+/datum/supply_pack/materials/carbon_dioxide
 	name = "Carbon Dioxide Canister Crate"
 	desc = "Contains a canister of Carbon Dioxide. Requires Atmospherics access to open."
 	cost = 1200
@@ -1766,8 +1765,8 @@
 	dangerous = TRUE
 
 /datum/supply_pack/medical/maintpills
-	name = "Questionable Medicine Crate"
-	desc = "A shipment of unlabelled surplus pills.  It's... probably ok... probably."
+	name = "Experimental Medicine Crate"
+	desc = "A shipment of unlabelled, untested surplus pills.  It's... probably ok... probably."
 	cost = 10000
 	contraband = TRUE
 	contains = list(/obj/item/reagent_containers/pill/floorpill,
@@ -1775,7 +1774,7 @@
 					/obj/item/reagent_containers/pill/floorpill,
 					/obj/item/reagent_containers/pill/floorpill,
 					/obj/item/reagent_containers/pill/floorpill)
-	crate_name = "questionable medicine crate"
+	crate_name = "experimental medicine crate"
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Science /////////////////////////////////////////
@@ -1958,7 +1957,7 @@
 					/obj/item/grenade/chem_grenade/cleaner)
 	crate_name = "janitorial supplies crate"
 
-/datum/supply_pack/service/janitor/janitorialcart
+/datum/supply_pack/service/janitor/janitorial_cart
 	name = "Janitorial Cart and Galoshes Crate"
 	desc = "The keystone to any successful janitor. As long as you have feet, this pair of galoshes will keep them firmly planted on the ground. Also contains a janitorial cart."
 	cost = 1000
@@ -1971,7 +1970,7 @@
 /datum/supply_pack/service/janitor/janicart
 	name = "Janicart Crate"
 	desc = "You'd better not have wrecked the last one joyriding."
-	cost = 20000
+	cost = 2000
 	access_budget = ACCESS_JANITOR
 	contains = list(/obj/vehicle/ridden/janicart,
 					/obj/item/key/janitor)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This adds several new crates to cargo's list for purchase.

- Weed Out-of-control crate (contraband) - Weed parapheralia
- Pest control crate - mousetraps and bear traps
- Pest Out-of-control crate (contraband) - several mice
- Secway crate - more secways
- Engineering Hat Crate - warning cones
- Telecommunications starter pack crate (contraband) - a bunch of station bounced radios
- Plasma Canister - (because we can get one from the shuttle kit now)
- Questionable Medicine Crate (contraband) - 5 maint pills
- Janicart Crate - a (very expensive) replacement janicart
- Glassware crate - some assorted glasses and containers for barkeeps
- Friendly bee crate - Several friendly maintenance bees
- Recreational crate - skateboards and basketballs
- Strange Object crate - some extra strange objects

Prices are fairly loose since the economy is kind of nonexistent for now.  I stuck mostly to easier crates for this one just to get the ball rolling.

I also rearranged the materials category slightly so all the cans were together because that always bugged me.

## Why It's Good For The Game

More stuff for cargo to order and play with!  More potential uses for cargo.  Also allows you to replace a handful of irreplaceable items, and use basketballs outside the holodeck.

## Changelog

:cl:
add: Cargo now has several new crates, check them out for yourself!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
