### PR TITLE
Lets Roboticists Access Securitrons

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -457,4 +457,4 @@ Auto Patrol: []"},
 		return
 
 /obj/machinery/bot_core/secbot
-	req_access = list(ACCESS_SECURITY)
+	req_one_access = list(ACCESS_SECURITY, ACCESS_ROBOTICS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Currently roboticists can't open up securitron controls, only security.  This lets them do so.

## Why It's Good For The Game

Building additional securitrons seems very rare on monkestation, which is likely because of the many barriers that stand in the way.  This removes one of those.  Roboticists will still need to acquire the equipment from security or cargo (via crime).  But you won't have to get expanded access or have a security officer hang out in robotics constantly.

The primary risks I can think of are minimal and would mostly simply be carried out by other means and wind up negated quickly.  In particular, killing beepsky when you intend to is quite easy, and sending him on a rampage will not likely be as effective as you taking out the baton yourself and will get you arrested just as hard.

## Changelog

:cl:
balance: Roboticists now have access to configure securitrons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
