### PR TITLE
Adds waddles to animated objects and various creatures

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -196,7 +196,8 @@ GLOBAL_LIST_INIT(barefootmob, typecacheof(list(
 
 GLOBAL_LIST_INIT(heavyfootmob, typecacheof(list(
 	/mob/living/simple_animal/hostile/megafauna,
-	/mob/living/simple_animal/hostile/jungle/leaper
+	/mob/living/simple_animal/hostile/jungle/leaper,
+	/mob/living/simple_animal/hostile/mimic
 	)))
 
 //Misc mobs

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -40,6 +40,7 @@
 /mob/living/simple_animal/pet/cat/Initialize(mapload)
 	. = ..()
 	add_verb(/mob/living/proc/lay_down)
+	src.AddComponent(/datum/component/waddling)
 
 /mob/living/simple_animal/pet/cat/space
 	name = "space cat"

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -17,8 +17,12 @@
 	can_be_held = TRUE
 	chat_color = "#ECDA88"
 	mobchatspan = "corgi"
-
+	var/datum/component/waddle
 	do_footstep = TRUE
+
+/mob/living/simple_animal/pet/dog/Initialize(mapload)
+	. = ..()
+	waddle = src.AddComponent(/datum/component/waddling)
 
 //Corgis and pugs are now under one dog subtype
 
@@ -393,6 +397,7 @@ GLOBAL_LIST_INIT(strippable_corgi_items, create_strippable_list(list(
 		desc = "At a ripe old age of [record_age], Ian's not as spry as he used to be, but he'll always be the HoP's beloved corgi." //RIP
 		turns_per_move = 20
 		held_state = "old_corgi"
+		QDEL_NULL(waddle)//Poor fella's too old to waddle
 
 /mob/living/simple_animal/pet/dog/corgi/Ian/Life()
 	if(!stat && SSticker.current_state == GAME_STATE_FINISHED && !memory_saved)

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -36,6 +36,7 @@
 /mob/living/simple_animal/hostile/retaliate/goat/Initialize(mapload)
 	udder = new()
 	. = ..()
+	src.AddComponent(/datum/component/waddling)
 
 /mob/living/simple_animal/hostile/retaliate/goat/Destroy()
 	qdel(udder)
@@ -225,6 +226,7 @@
 	. = ..()
 	pixel_x = rand(-6, 6)
 	pixel_y = rand(0, 10)
+	src.AddComponent(/datum/component/waddling)
 	GLOB.total_chickens++
 
 /mob/living/simple_animal/chick/Life()
@@ -304,6 +306,7 @@
 	head_icon = 'icons/mob/pets_held_large.dmi'
 	pixel_x = rand(-6, 6)
 	pixel_y = rand(0, 10)
+	src.AddComponent(/datum/component/waddling)
 	GLOB.total_chickens++
 
 /mob/living/simple_animal/chicken/death(gibbed)
@@ -382,6 +385,7 @@
 /obj/item/udder/Initialize(mapload)
 	create_reagents(50)
 	reagents.add_reagent(/datum/reagent/consumable/milk, 20)
+	src.AddComponent(/datum/component/waddling)
 	. = ..()
 
 /obj/item/udder/proc/generateMilk()

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -381,7 +381,6 @@
 
 /mob/living/simple_animal/chicken/turkey/Initialize(mapload)
 	. = ..()
-	src.AddComponent(/datum/component/waddling)
 
 /obj/item/udder
 	name = "udder"

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -379,13 +379,16 @@
 	gold_core_spawnable = FRIENDLY_SPAWN
 	chat_color = "#FFDC9B"
 
+/mob/living/simple_animal/chicken/turkey/Initialize(mapload)
+	. = ..()
+	src.AddComponent(/datum/component/waddling)
+
 /obj/item/udder
 	name = "udder"
 
 /obj/item/udder/Initialize(mapload)
 	create_reagents(50)
 	reagents.add_reagent(/datum/reagent/consumable/milk, 20)
-	src.AddComponent(/datum/component/waddling)
 	. = ..()
 
 /obj/item/udder/proc/generateMilk()

--- a/code/modules/mob/living/simple_animal/friendly/fox.dm
+++ b/code/modules/mob/living/simple_animal/friendly/fox.dm
@@ -25,6 +25,10 @@
 	do_footstep = TRUE
 	worn_slot_flags = ITEM_SLOT_HEAD
 
+/mob/living/simple_animal/pet/fox/Initialize(mapload)
+	. = ..()
+	src.AddComponent(/datum/component/waddling)
+
 //Captain fox
 /mob/living/simple_animal/pet/fox/Renault
 	name = "Renault"

--- a/code/modules/mob/living/simple_animal/hostile/bread.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bread.dm
@@ -30,6 +30,10 @@
 	chat_color = "#CAA25B"
 	mobchatspan = "blob"
 
+/mob/living/simple_animal/hostile/breadloaf/Initialize()
+	. = ..()
+	src.AddComponent(/datum/component/waddling)
+
 /mob/living/simple_animal/hostile/breadloaf/teleport_act()
 	if(mutations == 0)
 		mutationcap = rand(1,mutability)

--- a/code/modules/mob/living/simple_animal/hostile/goose.dm
+++ b/code/modules/mob/living/simple_animal/hostile/goose.dm
@@ -30,6 +30,10 @@
 	var/icon_vomit = "vomit"
 	var/icon_vomit_end = "vomit_end"
 
+/mob/living/simple_animal/hostile/retaliate/goose/Initialize(mapload)
+	. = ..()
+	src.AddComponent(/datum/component/waddling)
+
 /mob/living/simple_animal/hostile/retaliate/goose/handle_automated_movement()
 	. = ..()
 	if (stat == DEAD)

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -29,6 +29,7 @@
 	gold_core_spawnable = NO_SPAWN
 	del_on_death = TRUE
 	hardattacks = TRUE
+	do_footstep = TRUE
 
 	discovery_points = 4000
 
@@ -48,6 +49,7 @@
 		for(var/obj/item/I in loc)
 			I.forceMove(src)
 	add_overlay("[icon_state]_door")
+	src.AddComponent(/datum/component/waddling)
 
 /mob/living/simple_animal/hostile/mimic/crate/DestroyPathToTarget()
 	..()
@@ -99,6 +101,7 @@ GLOBAL_LIST_INIT(protected_objects, list(/obj/structure/table, /obj/structure/ca
 /mob/living/simple_animal/hostile/mimic/copy
 	health = 100
 	maxHealth = 100
+	do_footstep = TRUE
 	var/mob/living/creator = null // the creator
 	var/destroy_objects = 0
 	var/knockdown_people = 0
@@ -112,6 +115,7 @@ GLOBAL_LIST_INIT(protected_objects, list(/obj/structure/table, /obj/structure/ca
 	if (no_googlies)
 		overlay_googly_eyes = FALSE
 	CopyObject(copy, creator, destroy_original)
+	src.AddComponent(/datum/component/waddling)
 
 /mob/living/simple_animal/hostile/mimic/copy/Life()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This adds a waddle animation to the animated items created by the staff of animation and the brand intelligence event.  It also gives them a heavy footstep sound.

It also adds a waddle to various animals that aren't too small and scuttley (lizards and roaches) or too large (cows and bears)

It purposefully DOESN'T add a waddle to old Ian since he's got mobility wheels.

## Why It's Good For The Game

I think they look a LOT nicer.  It gives a clear indication that the creature is moving around, and adds a little life to them.  In the future I hope to find something similar that will look good for the scuttling and large mobs.


https://user-images.githubusercontent.com/31165061/196010793-633a9d1b-0791-45b7-a6d4-fd678386d5b7.mp4



## Changelog

:cl:
add: Animated objects and several types of animals now look a bit more lively when moving around!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
