### PR TITLE
Holodeck Logging

### DIFF
--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -167,6 +167,7 @@ and clear when youre done! if you dont i will use :newspaper2: on you
 			if(!valid)
 				return
 			//load the map_template that program_to_load represents
+			log_game("[key_name(usr)] switched the holodeck to [program_to_load]")
 			load_program(program_to_load)
 			. = TRUE
 		if("safety")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Adds a log_game that states who changed the holodeck to which mode.

## Why It's Good For The Game

Gives easier administrative tracking to know who just set the entire holodeck to burn test.

## Changelog

:cl:
admin: Holodeck changes are now tracked
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
