### PR TITLE
ports brain tumor changes

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -296,6 +296,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_EMPATH			"empath"
 #define TRAIT_FRIENDLY			"friendly"
 #define TRAIT_GRABWEAKNESS		"grab_weakness"
+#define TRAIT_BRAIN_TUMOR		"brain_tumor"
 //MonkeStation Edit Start
 #define TRAIT_JAILBIRD			"jailbird"
 #define TRAIT_STOWAWAY			"stowaway"

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -223,3 +223,12 @@
 	description = "<span class='nicegreen'>This taste seems oddly nostalgic...</span>\n"
 	mood_change = 3
 	timeout = 5 MINUTES
+
+/datum/mood_event/brain_tumor_mannitol
+	description = "<span class='nicegreen'>Mannitol makes my brain calm down.</span>\n"
+	mood_change = 0
+	timeout = 30 SECONDS
+
+/datum/mood_event/brain_tumor_mannitol/New(mob/M, param)
+	timeout = rand(30,60) SECONDS // makes the timing unreliable on your mood
+	..()

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -53,15 +53,27 @@
 /datum/quirk/brainproblems
 	name = "Brain Tumor"
 	desc = "You have a little friend in your brain that is slowly destroying it. Thankfully, you start with a bottle of mannitol pills."
+	mob_trait = TRAIT_BRAIN_TUMOR
 	value = -3
 	gain_text = "<span class='danger'>You feel smooth.</span>"
 	lose_text = "<span class='notice'>You feel wrinkled again.</span>"
 	medical_record_text = "Patient has a tumor in their brain that is slowly driving them to brain death."
 	process = TRUE
 	var/where = "at your feet"
+	var/notified = FALSE
 
 /datum/quirk/brainproblems/on_process(delta_time)
-	quirk_holder.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.2 * delta_time)
+	if(!quirk_holder.reagents.has_reagent(/datum/reagent/medicine/mannitol))
+		if(prob(80))
+			quirk_holder.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.1 * delta_time)
+	var/obj/item/organ/brain/B = quirk_holder.getorgan(/obj/item/organ/brain)
+	if(B)
+		if(B.damage>BRAIN_DAMAGE_MILD-1 && !notified)
+			to_chat(quirk_holder, "<span class='danger'>You sense your brain is getting beyond your control...</span>")
+			notified = TRUE
+		if(B.damage<1 && notified)
+			to_chat(quirk_holder, "<span class='notice'>You feel your brain is quite well.</span>")
+			notified = FALSE
 
 /datum/quirk/brainproblems/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -78,7 +78,7 @@
 /datum/quirk/brainproblems/on_spawn()
 	var/mob/living/carbon/human/holder = quirk_holder
 	var/obj/item/storage/pill_bottle/mannitol/braintumor/pill_bottle = new(get_turf(holder))
-	SEND_SIGNAL(holder.back, COMSIG_TRY_STORAGE_INSERT, pill_bottle, H, TRUE, TRUE) //insert the item, even if the backpack's full
+	SEND_SIGNAL(holder.back, COMSIG_TRY_STORAGE_INSERT, pill_bottle, holder, TRUE, TRUE) //insert the item, even if the backpack's full
 
 /datum/quirk/brainproblems/post_add()
 	to_chat(quirk_holder, "<span class='boldnotice'>There is a bottle of mannitol in your backpack. You're going to need it.</span>")

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -66,19 +66,19 @@
 	if(!quirk_holder.reagents.has_reagent(/datum/reagent/medicine/mannitol))
 		if(prob(80))
 			quirk_holder.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.1 * delta_time)
-	var/obj/item/organ/brain/B = quirk_holder.getorgan(/obj/item/organ/brain)
-	if(B)
-		if(B.damage>BRAIN_DAMAGE_MILD-1 && !notified)
+	var/obj/item/organ/brain/affected_brain = quirk_holder.getorgan(/obj/item/organ/brain)
+	if(affected_brain)
+		if(affected_brain.damage>BRAIN_DAMAGE_MILD-1 && !notified)
 			to_chat(quirk_holder, "<span class='danger'>You sense your brain is getting beyond your control...</span>")
 			notified = TRUE
-		if(B.damage<1 && notified)
+		if(affected_brain.damage<1 && notified)
 			to_chat(quirk_holder, "<span class='notice'>You feel your brain is quite well.</span>")
 			notified = FALSE
 
 /datum/quirk/brainproblems/on_spawn()
-	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/storage/pill_bottle/mannitol/braintumor/P = new(get_turf(H))
-	SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_INSERT, P, H, TRUE, TRUE) //insert the item, even if the backpack's full
+	var/mob/living/carbon/human/holder = quirk_holder
+	var/obj/item/storage/pill_bottle/mannitol/braintumor/pill_bottle = new(get_turf(holder))
+	SEND_SIGNAL(holder.back, COMSIG_TRY_STORAGE_INSERT, pill_bottle, H, TRUE, TRUE) //insert the item, even if the backpack's full
 
 /datum/quirk/brainproblems/post_add()
 	to_chat(quirk_holder, "<span class='boldnotice'>There is a bottle of mannitol in your backpack. You're going to need it.</span>")

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -407,7 +407,7 @@
 	desc = "Generously supplied by your Nanotrasen health insurance to treat that pesky tumor in your brain."
 
 /obj/item/storage/pill_bottle/mannitol/braintumor/PopulateContents()
-	for(var/i in 1 to 3)
+	for(var/i in 1 to 5)
 		new /obj/item/reagent_containers/pill/mannitol/braintumor(src)
 
 /obj/item/storage/pill_bottle/stimulant

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -843,8 +843,25 @@
 	description = "Efficiently restores brain damage."
 	color = "#A0A0A0" //mannitol is light grey, neurine is lighter grey"
 
+/datum/reagent/medicine/mannitol/on_mob_add(mob/living/carbon/C)
+	if(HAS_TRAIT(C, TRAIT_BRAIN_TUMOR))
+		overdose_threshold = 35 // special overdose to brain tumor quirker
+	..()
+
 /datum/reagent/medicine/mannitol/on_mob_life(mob/living/carbon/C)
-	C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -2*REM)
+	if(HAS_TRAIT(C, TRAIT_BRAIN_TUMOR)) // to brain tumor quirker
+		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "brain_tumor", /datum/mood_event/brain_tumor_mannitol)
+		if(!overdosed)
+			C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.5*REM)
+	else // to ordinary people
+		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -2*REM)
+	..()
+
+/datum/reagent/medicine/mannitol/overdose_process(mob/living/carbon/C)
+	if(HAS_TRAIT(C, TRAIT_BRAIN_TUMOR))
+		if(prob(10))
+			C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.1*REM)
+	..()
 	..()
 
 /datum/reagent/medicine/neurine

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -857,11 +857,9 @@
 		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -2*REM)
 	..()
 
-/datum/reagent/medicine/mannitol/overdose_process(mob/living/carbon/C)
-	if(HAS_TRAIT(C, TRAIT_BRAIN_TUMOR))
-		if(prob(10))
-			C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.1*REM)
-	..()
+/datum/reagent/medicine/mannitol/overdose_process(mob/living/carbon/C) //should only apply to those with the brain tumor quirk
+	if(prob(10))
+		C.adjustOrganLoss(ORGAN_SLOT_BRAIN, -0.1*REM)
 	..()
 
 /datum/reagent/medicine/neurine

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -139,7 +139,7 @@
 	rename_with_volume = TRUE
 
 /obj/item/reagent_containers/pill/mannitol/braintumor //For the brain tumor quirk
-	list_reagents = list(/datum/reagent/medicine/mannitol = 20)
+	list_reagents = list(/datum/reagent/medicine/mannitol = 30)
 
 /obj/item/reagent_containers/pill/mutadone
 	name = "mutadone pill"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This is a port of https://github.com/BeeStation/BeeStation-Hornet/pull/7172/

Makes Brain Tumor quirk less harsh, so that people would want to pick the quirk.

## Why It's Good For The Game

a quirk that nobody actually can help you is stupid. It's even worse than Blind trait in many situations.
This PR makes Brain Tumor penalty less harsh, so that you can earn your time more to find a help to treat your tumor.
Because it's less harsh, I added more downside in return.

## Changelog

:cl: EvilDragonfiend (ported by KoboldCommando)
balance: Brain Tumor will deal 0.1 brain damage at 80% chance. (equals 0.08 damage) previously it was 0.2 damage.
balance: Brain Tumor will not deal brain damage when the quirker has mannitol in their bloodstream.
balance: Mannitol is less effective for Brain Tumor quirker. It only heals 0.5 brain damage and special overdose thresholds(35u). on overdose, it will heal only 0.1 brain damage at 10% chance. (equals 0.01 damage) Don't overdose them.
balance: Brain Tumor quirker now starts with 5 pills of 30u mannitol. Each pill keeps you for 150 seconds, in total 750 seconds.
add: Brain Tumor will warn you when you're about to be at a mild trauma threshold. It will notice you when your brain damage is at near zero.
add: Brain Tumor quirker will have a +0 mood event when they eat mannitol. the message will persist for 30~60 seconds longer even if mannitol doesn't exist in your bloodstream.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
