### PR TITLE
Adds chemical bags to the chemmaster [port]

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3176,6 +3176,7 @@
 #include "code\modules\reagents\reagent_containers\blood_pack.dm"
 #include "code\modules\reagents\reagent_containers\borghydro.dm"
 #include "code\modules\reagents\reagent_containers\bottle.dm"
+#include "code\modules\reagents\reagent_containers\chem_bag.dm"
 #include "code\modules\reagents\reagent_containers\dropper.dm"
 #include "code\modules\reagents\reagent_containers\glass.dm"
 #include "code\modules\reagents\reagent_containers\hypospray.dm"

--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -13,6 +13,8 @@
 #define AMOUNT_VISIBLE	(1<<6)	//! For non-transparent containers that still have the general amount of reagents in them visible.
 #define NO_REACT        (1<<7)  //! Applied to a reagent holder, the contents will not react with each other.
 
+#define ABSOLUTELY_GRINDABLE (1<<7) //! used in 'All-In-One Grinder' that it can grind anything if it has this bitflag
+
 /// Is an open container for all intents and purposes.
 #define OPENCONTAINER 	(REFILLABLE | DRAINABLE | TRANSPARENT)
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -496,6 +496,10 @@
 /atom/proc/is_drainable()
 	return reagents && (reagents.flags & DRAINABLE)
 
+/// Is this atom grindable to get reagents
+/atom/proc/is_grindable()
+	return reagents && (reagents.flags & ABSOLUTELY_GRINDABLE)
+
 /// Are you allowed to drop this atom
 /atom/proc/AllowDrop()
 	return FALSE

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -27,6 +27,11 @@
 	QDEL_NULL(beaker)
 	return ..()
 
+/obj/machinery/iv_drip/Moved()
+	. = ..()
+	if(has_gravity())
+		playsound(src, 'sound/effects/roll.ogg', 100, 1)
+
 /obj/machinery/iv_drip/update_icon()
 	if(attached)
 		if(mode)

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -133,7 +133,7 @@
 	if(beaker)
 		// Give blood
 		if(mode)
-			if(beaker.reagents && beaker.reagents.total_volume)
+			if(beaker.reagents?.total_volume)
 				var/transfer_amount = 5
 				if(istype(beaker, /obj/item/reagent_containers/blood))
 					// speed up transfer on blood packs

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -15,7 +15,7 @@
 									/obj/item/reagent_containers/food,
 									/obj/item/food, //I will inject a slice of pizza into my arm and you cannot stop me
 									/obj/item/reagent_containers/glass,
-									/obj/item/reagent_containers/chem_bag,))
+									/obj/item/reagent_containers/chem_bag))
 	var/can_convert = TRUE // If it can be made into an anesthetic machine or not
 
 /obj/machinery/iv_drip/Initialize(mapload)
@@ -46,6 +46,8 @@
 			add_overlay("beakeractive")
 		else
 			add_overlay("beakeridle")
+		if(istype(beaker, /obj/item/food))
+			return
 		if(beaker.reagents.total_volume)
 			var/mutable_appearance/filling_overlay = mutable_appearance('icons/obj/iv_drip.dmi', "reagent")
 
@@ -131,7 +133,7 @@
 	if(beaker)
 		// Give blood
 		if(mode)
-			if(beaker.reagents.total_volume)
+			if(beaker.reagents && beaker.reagents.total_volume)
 				var/transfer_amount = 5
 				if(istype(beaker, /obj/item/reagent_containers/blood))
 					// speed up transfer on blood packs
@@ -139,6 +141,8 @@
 				var/fraction = min(transfer_amount*delta_time/beaker.reagents.total_volume, 1) //the fraction that is transfered of the total volume
 				beaker.reagents.reaction(attached, INJECT, fraction, FALSE) //make reagents reacts, but don't spam messages
 				beaker.reagents.trans_to(attached, transfer_amount)
+				if(istype(beaker, /obj/item/food) && !beaker.reagents.total_volume) //empty food item disappears
+					qdel(beaker)
 				update_icon()
 
 		// Take blood

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -13,7 +13,9 @@
 	var/obj/item/reagent_containers/beaker
 	var/static/list/drip_containers = typecacheof(list(/obj/item/reagent_containers/blood,
 									/obj/item/reagent_containers/food,
-									/obj/item/reagent_containers/glass))
+									/obj/item/food, //I will inject a slice of pizza into my arm and you cannot stop me
+									/obj/item/reagent_containers/glass,
+									/obj/item/reagent_containers/chem_bag,))
 	var/can_convert = TRUE // If it can be made into an anesthetic machine or not
 
 /obj/machinery/iv_drip/Initialize(mapload)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1642,6 +1642,25 @@
 					/obj/machinery/iv_drip)
 	crate_name = "iv drip crate"
 
+/datum/supply_pack/medical/chem_bags
+	name = "IV bag crate"
+	desc = "Contains basic medicines prepped for delivery via IV"
+	cost = 1300
+	contains = list(/obj/item/reagent_containers/chem_bag/epinephrine,
+					/obj/item/reagent_containers/chem_bag/bicaridine,
+					/obj/item/reagent_containers/chem_bag/kelotane,
+					/obj/item/reagent_containers/chem_bag/antitoxin,
+					/obj/item/reagent_containers/chem_bag/morphine,
+					/obj/item/reagent_containers/chem_bag/perfluorodecalin)
+	crate_name = "IV bag crate"
+
+/datum/supply_pack/medical/salglucanister
+	name = "Heavy-Duty Saline Canister"
+	desc = "Contains a bulk supply of saline-glucose condensed into a single canister that should last several days, with a large pump to fill containers with. Direct injection of saline should be left to medical professionals as the pump is capable of overdosing patients. Requires medbay access to open."
+	cost = 1200
+	access = ACCESS_MEDICAL
+	contains = list(/obj/machinery/iv_drip/saline)
+
 /datum/supply_pack/medical/supplies
 	name = "Medical Supplies Crate"
 	desc = "Contains a little bit of everything needed to stock a medbay or to form your own."
@@ -1673,7 +1692,6 @@
 	for(var/i in 1 to 10)
 		var/item = pick(contains)
 		new item(C)
-
 /datum/supply_pack/medical/surgery
 	name = "Surgical Supplies Crate"
 	desc = "Do you want to perform surgery, but don't have one of those fancy shmancy degrees? Just get started with this crate containing a medical duffelbag, Sterilizine spray and collapsible roller bed."
@@ -1682,13 +1700,6 @@
 					/obj/item/reagent_containers/medspray/sterilizine,
 					/obj/item/roller)
 	crate_name = "surgical supplies crate"
-
-/datum/supply_pack/medical/salglucanister
-	name = "Heavy-Duty Saline Canister"
-	desc = "Contains a bulk supply of saline-glucose condensed into a single canister that should last several days, with a large pump to fill containers with. Direct injection of saline should be left to medical professionals as the pump is capable of overdosing patients. Requires medbay access to open."
-	cost = 1200
-	access = ACCESS_MEDICAL
-	contains = list(/obj/machinery/iv_drip/saline)
 
 /datum/supply_pack/medical/randomvirus
 	name = "Virus Sample Crate"

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -304,7 +304,7 @@
 			// Start filling
 			switch(item_type)
 				if("pill")
-					var/obj/item/reagent_containers/pill/P
+					var/obj/item/reagent_containers/pill/pill
 					var/target_loc = drop_location()
 					var/drop_threshold = INFINITY
 					if(bottle)
@@ -315,60 +315,60 @@
 							target_loc = bottle
 					for(var/i = 0; i < amount; i++)
 						if(i < drop_threshold)
-							P = new/obj/item/reagent_containers/pill(target_loc)
+							pill = new/obj/item/reagent_containers/pill(target_loc)
 						else
-							P = new/obj/item/reagent_containers/pill(drop_location())
-						P.name = trim("[name] pill")
+							pill = new/obj/item/reagent_containers/pill(drop_location())
+						pill.name = trim("[name] pill")
 						if(chosenPillStyle == RANDOM_PILL_STYLE)
-							P.icon_state ="pill[rand(1,21)]"
+							pill.icon_state ="pill[rand(1,21)]"
 						else
-							P.icon_state = "pill[chosenPillStyle]"
-						if(P.icon_state == "pill4")
-							P.desc = "A tablet or capsule, but not just any, a red one, one taken by the ones not scared of knowledge, freedom, uncertainty and the brutal truths of reality."
-						adjust_item_drop_location(P)
-						reagents.trans_to(P, vol_each, transfered_by = usr)
+							pill.icon_state = "pill[chosenPillStyle]"
+						if(pill.icon_state == "pill4")
+							pill.desc = "A tablet or capsule, but not just any, a red one, one taken by the ones not scared of knowledge, freedom, uncertainty and the brutal truths of reality."
+						adjust_item_drop_location(pill)
+						reagents.trans_to(pill, vol_each, transfered_by = usr)
 					. = TRUE
 				if("patch")
-					var/obj/item/reagent_containers/pill/patch/P
+					var/obj/item/reagent_containers/pill/patch/patch
 					for(var/i = 0; i < amount; i++)
-						P = new/obj/item/reagent_containers/pill/patch(drop_location())
-						P.name = trim("[name] patch")
-						adjust_item_drop_location(P)
-						reagents.trans_to(P, vol_each, transfered_by = usr)
+						patch = new/obj/item/reagent_containers/pill/patch(drop_location())
+						patch.name = trim("[name] patch")
+						adjust_item_drop_location(patch)
+						reagents.trans_to(patch, vol_each, transfered_by = usr)
 					. = TRUE
 				if("bottle")
-					var/obj/item/reagent_containers/glass/bottle/P
+					var/obj/item/reagent_containers/glass/bottle/bottle
 					for(var/i = 0; i < amount; i++)
-						P = new/obj/item/reagent_containers/glass/bottle(drop_location())
-						P.name = trim("[name] bottle")
-						adjust_item_drop_location(P)
-						reagents.trans_to(P, vol_each, transfered_by = usr)
+						bottle = new/obj/item/reagent_containers/glass/bottle(drop_location())
+						bottle.name = trim("[name] bottle")
+						adjust_item_drop_location(bottle)
+						reagents.trans_to(bottle, vol_each, transfered_by = usr)
 					. = TRUE
 				if("bag")
-					var/obj/item/reagent_containers/chem_bag/P
+					var/obj/item/reagent_containers/chem_bag/bag
 					for(var/i = 0; i < amount; i++)
-						P = new/obj/item/reagent_containers/chem_bag/(drop_location())
-						P.name = trim("[name] chemical bag")
-						P.label_name = trim(name) // supporting a custom name in certain situations
-						adjust_item_drop_location(P)
-						reagents.trans_to(P, vol_each, transfered_by = usr)
+						bag = new/obj/item/reagent_containers/chem_bag/(drop_location())
+						bag.name = trim("[name] chemical bag")
+						bag.label_name = trim(name) // supporting a custom name in certain situations
+						adjust_item_drop_location(bag)
+						reagents.trans_to(bag, vol_each, transfered_by = usr)
 					. = TRUE
 				if("condimentPack")
-					var/obj/item/reagent_containers/food/condiment/pack/P
+					var/obj/item/reagent_containers/food/condiment/pack/pack
 					for(var/i = 0; i < amount; i++)
-						P = new/obj/item/reagent_containers/food/condiment/pack(drop_location())
-						P.originalname = name
-						P.name = trim("[name] pack")
-						P.desc = "A small condiment pack. The label says it contains [name]."
-						reagents.trans_to(P, vol_each, transfered_by = usr)
+						pack = new/obj/item/reagent_containers/food/condiment/pack(drop_location())
+						pack.originalname = name
+						pack.name = trim("[name] pack")
+						pack.desc = "A small condiment pack. The label says it contains [name]."
+						reagents.trans_to(pack, vol_each, transfered_by = usr)
 					. = TRUE
 				if("condimentBottle")
-					var/obj/item/reagent_containers/food/condiment/P
+					var/obj/item/reagent_containers/food/condiment/bottle
 					for(var/i = 0; i < amount; i++)
-						P = new/obj/item/reagent_containers/food/condiment(drop_location())
-						P.originalname = name
-						P.name = trim("[name] bottle")
-						reagents.trans_to(P, vol_each, transfered_by = usr)
+						bottle = new/obj/item/reagent_containers/food/condiment(drop_location())
+						bottle.originalname = name
+						bottle.name = trim("[name] bottle")
+						reagents.trans_to(bottle, vol_each, transfered_by = usr)
 					. = TRUE
 		if("analyze")
 			var/datum/reagent/R = GLOB.name2reagent[params["id"]]

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -269,6 +269,8 @@
 				vol_each_max = min(40, vol_each_max)
 			else if (item_type == "bottle" && !condi)
 				vol_each_max = min(30, vol_each_max)
+			else if (item_type == "bag" && !condi)
+				vol_each_max = min(200, vol_each_max)
 			else if (item_type == "condimentPack" && condi)
 				vol_each_max = min(10, vol_each_max)
 			else if (item_type == "condimentBottle" && condi)
@@ -339,6 +341,15 @@
 					for(var/i = 0; i < amount; i++)
 						P = new/obj/item/reagent_containers/glass/bottle(drop_location())
 						P.name = trim("[name] bottle")
+						adjust_item_drop_location(P)
+						reagents.trans_to(P, vol_each, transfered_by = usr)
+					. = TRUE
+				if("bag")
+					var/obj/item/reagent_containers/chem_bag/P
+					for(var/i = 0; i < amount; i++)
+						P = new/obj/item/reagent_containers/chem_bag/(drop_location())
+						P.name = trim("[name] chemical bag")
+						P.label_name = trim(name) // supporting a custom name in certain situations
 						adjust_item_drop_location(P)
 						reagents.trans_to(P, vol_each, transfered_by = usr)
 					. = TRUE

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -159,7 +159,7 @@
 				to_chat(user, "<span class='notice'>You fill [src] to the brim.</span>")
 		return TRUE
 
-	if(!I.grind_results && !I.juice_results)
+	if(!I.grind_results && !I.juice_results && !I.is_grindable())
 		if(user.a_intent == INTENT_HARM)
 			return ..()
 		else
@@ -286,7 +286,7 @@
 		if(beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
 			break
 		var/obj/item/I = i
-		if(I.grind_results)
+		if(I.grind_results || I.is_grindable())
 			if(istype(I, /obj/item/reagent_containers))
 				var/obj/item/reagent_containers/p = I
 				if(!p.prevent_grinding)

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -7,6 +7,7 @@
 	var/blood_type = null
 	var/unique_blood = null
 	var/labelled = 0
+	reagent_flags = TRANSPARENT | ABSOLUTELY_GRINDABLE
 	fill_icon_thresholds = list(10, 20, 30, 40, 50, 60, 70, 80, 90, 100)
 
 /obj/item/reagent_containers/blood/Initialize(mapload)
@@ -14,6 +15,16 @@
 	if(blood_type != null)
 		reagents.add_reagent(unique_blood ? unique_blood : /datum/reagent/blood, 200, list("viruses"=null,"blood_DNA"=null,"blood_type"=blood_type,"resistances"=null,"trace_chem"=null))
 		update_icon()
+
+/obj/item/reagent_containers/blood/examine(mob/user)
+	. = ..()
+	if(reagents)
+		if(volume == reagents.total_volume)
+			. += "<span class='notice'>It is fully filled.</span>"
+		else if(!reagents.total_volume)
+			. += "<span class='notice'>It's empty.</span>"
+		else
+			. += "<span class='notice'>It seems [round(reagents.total_volume/volume*100)]% filled.</span>"
 
 /obj/item/reagent_containers/blood/on_reagent_change(changetype)
 	if(reagents)

--- a/code/modules/reagents/reagent_containers/chem_bag.dm
+++ b/code/modules/reagents/reagent_containers/chem_bag.dm
@@ -1,0 +1,70 @@
+/obj/item/reagent_containers/chem_bag
+	name = "chemical bag"
+	desc = "Contains chemicals used for transfusion. Must be attached to an IV drip."
+	icon = 'icons/obj/bloodpack.dmi'
+	icon_state = "bloodpack"
+	volume = 200
+	fill_icon_thresholds = list(10, 20, 30, 40, 50, 60, 70, 80, 90, 100)
+	reagent_flags = TRANSPARENT | ABSOLUTELY_GRINDABLE
+	var/label_name // this is to support when you don't want to display "chemical bag" part with a custom name
+
+/obj/item/reagent_containers/chem_bag/Initialize(mapload)
+	. = ..()
+	if(!icon_state)
+		icon_state = "bloodpack"
+		update_icon()
+	if(label_name)
+		name = "[label_name] chemical bag"
+
+/obj/item/reagent_containers/chem_bag/examine(mob/user)
+	. = ..()
+	if(reagents)
+		if(volume == reagents.total_volume)
+			. += "<span class='notice'>It is fully filled.</span>"
+		else if(!reagents.total_volume)
+			. += "<span class='notice'>It's empty.</span>"
+		else
+			. += "<span class='notice'>It seems [round(reagents.total_volume/volume*100)]% filled.</span>"
+
+/obj/item/reagent_containers/chem_bag/epinephrine
+	label_name = "epinephrine"
+	list_reagents = list(/datum/reagent/medicine/epinephrine = 200)
+
+/obj/item/reagent_containers/chem_bag/bicaridine
+	label_name = "bicaridine"
+	list_reagents = list(/datum/reagent/medicine/bicaridine = 200)
+
+/obj/item/reagent_containers/chem_bag/kelotane
+	label_name = "kelotane"
+	list_reagents = list(/datum/reagent/medicine/kelotane = 200)
+
+/obj/item/reagent_containers/chem_bag/antitoxin
+	label_name = "antitoxin"
+	list_reagents = list(/datum/reagent/medicine/antitoxin = 200)
+
+/obj/item/reagent_containers/chem_bag/morphine
+	label_name = "morphine"
+	list_reagents = list(/datum/reagent/medicine/morphine = 200)
+
+/obj/item/reagent_containers/chem_bag/perfluorodecalin
+	label_name = "perfluorodecalin"
+	list_reagents = list(/datum/reagent/medicine/perfluorodecalin = 200)
+
+// 80u is enough to treat 10 people with the new sleeper rework
+/obj/item/reagent_containers/chem_bag/epinephrine/sleeper_roundstart
+	list_reagents = list(/datum/reagent/medicine/epinephrine = 80)
+
+/obj/item/reagent_containers/chem_bag/bicaridine/sleeper_roundstart
+	list_reagents = list(/datum/reagent/medicine/bicaridine = 80)
+
+/obj/item/reagent_containers/chem_bag/kelotane/sleeper_roundstart
+	list_reagents = list(/datum/reagent/medicine/kelotane = 80)
+
+/obj/item/reagent_containers/chem_bag/antitoxin/sleeper_roundstart
+	list_reagents = list(/datum/reagent/medicine/antitoxin = 80)
+
+/obj/item/reagent_containers/chem_bag/morphine/sleeper_roundstart
+	list_reagents = list(/datum/reagent/medicine/morphine = 80)
+
+/obj/item/reagent_containers/chem_bag/perfluorodecalin/sleeper_roundstart
+	list_reagents = list(/datum/reagent/medicine/perfluorodecalin = 80)

--- a/tgui/packages/tgui/interfaces/ChemMaster.js
+++ b/tgui/packages/tgui/interfaces/ChemMaster.js
@@ -231,6 +231,10 @@ const PackagingControls = (props, context) => {
     setBottleAmount,
   ] = useSharedState(context, 'bottleAmount', 1);
   const [
+    bagAmount,
+    setBagAmount,
+  ] = useSharedState(context, 'bagAmount', 1);
+  const [
     packAmount,
     setPackAmount,
   ] = useSharedState(context, 'packAmount', 1);
@@ -292,6 +296,19 @@ const PackagingControls = (props, context) => {
           onCreate={() => act('create', {
             type: 'bottle',
             amount: bottleAmount,
+            volume: 'auto',
+          })} />
+      )}
+      {!condi && (
+        <PackagingControlsItem
+          label="Bags"
+          amount={bagAmount}
+          amountUnit="bags"
+          sideNote="max 200u"
+          onChangeAmount={(e, value) => setBagAmount(value)}
+          onCreate={() => act('create', {
+            type: 'bag',
+            amount: bagAmount,
             volume: 'auto',
           })} />
       )}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This is a pre-port of https://github.com/BeeStation/BeeStation-Hornet/pull/7862

It's not merged yet but it looks solid to me, and could potentially add some fun options!

I also fixed a "bug" where IVs used to let you hook up food and now you can't.  Because Borbop's food update left it in a half-functional state and I think it's way funnier to be able to hook up an IV drip pizza than not being able to at all.

## Why It's Good For The Game

More opportunities to use the IV system, and more freedom to utilize reagents, plus just more things to play with. 

This also helps pave the way to a sleeper rework Bee also has open, which is something we'd already talked about doing independently.

## Changelog

:cl: EvilDragonfiend and KoboldCommando
add: Adds IV bags to the chemmaster as an option
add: You can now grind up IV bags
add: Bags of basic medicines can be ordered by Cargo.
add: Food can be used in an IV. Inject that apple right into your arm.
add: IV drips can now be heard being wheeled down the hall
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
