### PR TITLE
fixes a poster

### DIFF
--- a/code/game/objects/effects/contraband.dm
+++ b/code/game/objects/effects/contraband.dm
@@ -668,6 +668,6 @@
 /obj/structure/sign/poster/official/ahelp
 	name = "Ahelp - It helps!"
 	desc = "A poster with a slogan reminding people about the Automatic Hazardous Environment Limitation Program, which processes reports of safety hazards before delivering them directly to Mr. Nanotrasen's fireplace to keep him warm."
-	icon_state = "poster50"
+	icon_state = "poster45_legit"
 
 #undef PLACE_SPEED


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

OK FOR REAL THIS TIME

A poster added recently has the wrong icon state and was showing up as purple and black.  Which is pretty funny, but I like the actual version I think.

## Changelog

:cl:
fix: the ahelp poster should now show up correctly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
