### PR TITLE
Fixes civilian bounty job assignments, and lowers cooldown

### DIFF
--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -74,52 +74,52 @@ GLOBAL_LIST_EMPTY(bounties_list)
 	return TRUE
 
 // Returns a new bounty of random type, but does not add it to GLOB.bounties_list.
-/proc/random_bounty(guided = 0)
+/proc/random_bounty(guided)
 	var/bounty_num
 	if(guided && (guided != CIV_JOB_RANDOM))
 		bounty_num = guided
 	else
-		bounty_num = rand(1,12)
+		bounty_num = rand(1,12) //roll one of the 12 defined job types
 	switch(bounty_num)
-		if(1)
+		if(CIV_JOB_BASIC)
 			var/subtype = pick(subtypesof(/datum/bounty/item/assistant))
 			return new subtype
-		if(2)
+		if(CIV_JOB_ROBO)
 			var/subtype = pick(subtypesof(/datum/bounty/item/mech))
 			return new subtype
-		if(3)
+		if(CIV_JOB_CHEF)
 			var/subtype = pick(subtypesof(/datum/bounty/item/chef))
 			return new subtype
-		if(4)
+		if(CIV_JOB_SEC)
 			var/subtype = pick(subtypesof(/datum/bounty/item/security))
 			return new subtype
-		if(5)
-			if(rand(2) == 1)
+		if(CIV_JOB_BAR)
+			if(prob(50))
 				return new /datum/bounty/reagent/simple_drink
 			return new /datum/bounty/reagent/complex_drink
-		if(6)
-			if(rand(2) == 1)
+		if(CIV_JOB_CHEM)
+			if(prob(50))
 				return new /datum/bounty/reagent/chemical_simple
 			return new /datum/bounty/reagent/chemical_complex
-		if(7)
+		if(CIV_JOB_VIRO)
 			var/subtype = pick(subtypesof(/datum/bounty/virus))
 			return new subtype
-		if(8)
-			if(rand(2) == 1)
+		if(CIV_JOB_SCI)
+			if(prob(50))
 				var/subtype = pick(subtypesof(/datum/bounty/item/science))
 				return new subtype
 			var/subtype = pick(subtypesof(/datum/bounty/item/slime))
 			return new subtype
-		if(9)
+		if(CIV_JOB_ENG)
 			var/subtype = pick(subtypesof(/datum/bounty/item/engineering))
 			return new subtype
-		if(10)
+		if(CIV_JOB_MINE)
 			var/subtype = pick(subtypesof(/datum/bounty/item/mining))
 			return new subtype
-		if(11)
+		if(CIV_JOB_MED)
 			var/subtype = pick(subtypesof(/datum/bounty/item/medical))
 			return new subtype
-		if(12)
+		if(CIV_JOB_GROW)
 			var/subtype = pick(subtypesof(/datum/bounty/item/botany))
 			return new subtype
 

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -74,8 +74,13 @@ GLOBAL_LIST_EMPTY(bounties_list)
 	return TRUE
 
 // Returns a new bounty of random type, but does not add it to GLOB.bounties_list.
-/proc/random_bounty()
-	switch(rand(1, 13))
+/proc/random_bounty(guided = 0)
+	var/bounty_num
+	if(guided && (guided != CIV_JOB_RANDOM))
+		bounty_num = guided
+	else
+		bounty_num = rand(1,12)
+	switch(bounty_num)
 		if(1)
 			var/subtype = pick(subtypesof(/datum/bounty/item/assistant))
 			return new subtype
@@ -100,21 +105,21 @@ GLOBAL_LIST_EMPTY(bounties_list)
 			var/subtype = pick(subtypesof(/datum/bounty/virus))
 			return new subtype
 		if(8)
-			var/subtype = pick(subtypesof(/datum/bounty/item/science))
-			return new subtype
-		if(9)
+			if(rand(2) == 1)
+				var/subtype = pick(subtypesof(/datum/bounty/item/science))
+				return new subtype
 			var/subtype = pick(subtypesof(/datum/bounty/item/slime))
 			return new subtype
-		if(10)
+		if(9)
 			var/subtype = pick(subtypesof(/datum/bounty/item/engineering))
 			return new subtype
-		if(11)
+		if(10)
 			var/subtype = pick(subtypesof(/datum/bounty/item/mining))
 			return new subtype
-		if(12)
+		if(11)
 			var/subtype = pick(subtypesof(/datum/bounty/item/medical))
 			return new subtype
-		if(13)
+		if(12)
 			var/subtype = pick(subtypesof(/datum/bounty/item/botany))
 			return new subtype
 

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -18,6 +18,7 @@ Assistant
 	paycheck = PAYCHECK_ASSISTANT // Get a job. Job reassignment changes your paycheck now. Get over it.
 	paycheck_department = ACCOUNT_CIV
 	display_order = JOB_DISPLAY_ORDER_ASSISTANT
+	bounty_types = CIV_JOB_BASIC
 	departments = DEPARTMENT_SERVICE
 	rpg_title = "Lout"
 

--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -20,6 +20,7 @@
 	paycheck = PAYCHECK_MEDIUM
 	paycheck_department = ACCOUNT_ENG
 	display_order = JOB_DISPLAY_ORDER_ATMOSPHERIC_TECHNICIAN
+	bounty_types = CIV_JOB_ENG
 	departments = DEPARTMENT_ENGINEERING
 	rpg_title = "Aeromancer"
 

--- a/code/modules/jobs/job_types/bartender.dm
+++ b/code/modules/jobs/job_types/bartender.dm
@@ -18,6 +18,7 @@
 	paycheck = PAYCHECK_EASY
 	paycheck_department = ACCOUNT_SRV
 	display_order = JOB_DISPLAY_ORDER_BARTENDER
+	bounty_types = CIV_JOB_BAR
 	departments = DEPARTMENT_SERVICE
 	rpg_title = "Tavernkeeper"
 

--- a/code/modules/jobs/job_types/botanist.dm
+++ b/code/modules/jobs/job_types/botanist.dm
@@ -17,6 +17,7 @@
 	paycheck = PAYCHECK_EASY
 	paycheck_department = ACCOUNT_SRV
 	display_order = JOB_DISPLAY_ORDER_BOTANIST
+	bounty_types = CIV_JOB_GROW
 	departments = DEPARTMENT_SERVICE
 	rpg_title = "Gardener"
 

--- a/code/modules/jobs/job_types/brigphys.dm
+++ b/code/modules/jobs/job_types/brigphys.dm
@@ -21,6 +21,7 @@
 	paycheck_department = ACCOUNT_MED
 
 	display_order = JOB_DISPLAY_ORDER_BRIG_PHYS
+	bounty_types = CIV_JOB_MED
 	departments = DEPARTMENT_MEDICAL | DEPARTMENT_SECURITY
 	rpg_title = "Battle Cleric"
 

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -26,6 +26,7 @@
 	mind_traits = list(TRAIT_DISK_VERIFIER)
 
 	display_order = JOB_DISPLAY_ORDER_CAPTAIN
+	bounty_types = CIV_JOB_RANDOM
 	departments = DEPARTMENT_COMMAND
 	rpg_title = "Star Duke"
 

--- a/code/modules/jobs/job_types/cargo_technician.dm
+++ b/code/modules/jobs/job_types/cargo_technician.dm
@@ -18,6 +18,7 @@
 	paycheck_department = ACCOUNT_CAR
 
 	display_order = JOB_DISPLAY_ORDER_CARGO_TECHNICIAN
+	bounty_types = CIV_JOB_RANDOM
 	departments = DEPARTMENT_CARGO
 	rpg_title = "Merchantman"
 

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -20,6 +20,7 @@
 	paycheck_department = ACCOUNT_MED
 
 	display_order = JOB_DISPLAY_ORDER_CHEMIST
+	bounty_types = CIV_JOB_CHEM
 	departments = DEPARTMENT_MEDICAL
 	rpg_title = "Alchemist"
 

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -31,6 +31,7 @@
 	paycheck_department = ACCOUNT_ENG
 
 	display_order = JOB_DISPLAY_ORDER_CHIEF_ENGINEER
+	bounty_types = CIV_JOB_ENG
 	departments = DEPARTMENT_ENGINEERING | DEPARTMENT_COMMAND
 	rpg_title = "High Crystallomancer"
 

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -30,6 +30,7 @@
 	paycheck_department = ACCOUNT_MED
 
 	display_order = JOB_DISPLAY_ORDER_CHIEF_MEDICAL_OFFICER
+	bounty_types = CIV_JOB_MED
 	departments = DEPARTMENT_MEDICAL | DEPARTMENT_COMMAND
 	rpg_title = "High Cleric"
 

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -18,6 +18,7 @@
 	paycheck_department = ACCOUNT_SRV
 
 	display_order = JOB_DISPLAY_ORDER_CLOWN
+	bounty_types = CIV_JOB_RANDOM
 	departments = DEPARTMENT_SERVICE
 	rpg_title = "Jester"
 

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -19,6 +19,7 @@
 	paycheck_department = ACCOUNT_SRV
 
 	display_order = JOB_DISPLAY_ORDER_COOK
+	bounty_types = CIV_JOB_CHEF
 	departments = DEPARTMENT_SERVICE
 	rpg_title = "Tavern Chef"
 

--- a/code/modules/jobs/job_types/deputy.dm
+++ b/code/modules/jobs/job_types/deputy.dm
@@ -22,6 +22,7 @@
 	mind_traits = list(TRAIT_LAW_ENFORCEMENT_METABOLISM)
 
 	display_order = JOB_DISPLAY_ORDER_DEPUTY  //see code/__DEFINES/jobs.dm
+	bounty_types = CIV_JOB_SEC
 	departments = DEPARTMENT_SECURITY
 
 /datum/outfit/job/deputy

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -24,6 +24,7 @@
 	mind_traits = list(TRAIT_LAW_ENFORCEMENT_METABOLISM)
 
 	display_order = JOB_DISPLAY_ORDER_DETECTIVE
+	bounty_types = CIV_JOB_SEC
 	departments = DEPARTMENT_SECURITY
 	rpg_title = "Thiefcatcher"
 

--- a/code/modules/jobs/job_types/emt.dm
+++ b/code/modules/jobs/job_types/emt.dm
@@ -22,6 +22,7 @@
 	paycheck_department = ACCOUNT_MED
 
 	display_order = JOB_DISPLAY_ORDER_MEDICAL_DOCTOR
+	bounty_types = CIV_JOB_MED
 	departments = DEPARTMENT_MEDICAL
 	rpg_title = "Corpse Runner"
 

--- a/code/modules/jobs/job_types/exploration_team.dm
+++ b/code/modules/jobs/job_types/exploration_team.dm
@@ -21,6 +21,7 @@
 	paycheck_department = ACCOUNT_SCI
 
 	display_order = JOB_DISPLAY_ORDER_EXPLORATION
+	bounty_types = CIV_JOB_SCI
 	departments = DEPARTMENT_SCIENCE
 	rpg_title = "Sailor"
 

--- a/code/modules/jobs/job_types/geneticist.dm
+++ b/code/modules/jobs/job_types/geneticist.dm
@@ -20,6 +20,7 @@
 	paycheck_department = ACCOUNT_MED
 
 	display_order = JOB_DISPLAY_ORDER_GENETICIST
+	bounty_types = CIV_JOB_MED
 	departments = DEPARTMENT_MEDICAL
 	rpg_title = "Genemancer"
 

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -37,6 +37,7 @@
 	paycheck_department = ACCOUNT_SRV
 
 	display_order = JOB_DISPLAY_ORDER_HEAD_OF_PERSONNEL
+	bounty_types = CIV_JOB_RANDOM
 	departments = DEPARTMENT_COMMAND | DEPARTMENT_SERVICE
 	rpg_title = "Guild Questgiver"
 

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -32,6 +32,7 @@
 	paycheck_department = ACCOUNT_SEC
 
 	display_order = JOB_DISPLAY_ORDER_HEAD_OF_SECURITY
+	bounty_types = CIV_JOB_SEC
 	departments = DEPARTMENT_SECURITY | DEPARTMENT_COMMAND
 	rpg_title = "Guard Leader"
 

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -20,6 +20,7 @@
 	paycheck_department = ACCOUNT_MED
 
 	display_order = JOB_DISPLAY_ORDER_MEDICAL_DOCTOR
+	bounty_types = CIV_JOB_MED
 	departments = DEPARTMENT_MEDICAL
 	rpg_title = "Cleric"
 

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -18,6 +18,7 @@
 	paycheck_department = ACCOUNT_SRV
 
 	display_order = JOB_DISPLAY_ORDER_MIME
+	bounty_types = CIV_JOB_RANDOM
 	departments = DEPARTMENT_SERVICE
 	rpg_title = "Fool"
 

--- a/code/modules/jobs/job_types/quartermaster.dm
+++ b/code/modules/jobs/job_types/quartermaster.dm
@@ -21,6 +21,7 @@
 	paycheck_department = ACCOUNT_CAR
 
 	display_order = JOB_DISPLAY_ORDER_QUARTERMASTER
+	bounty_types = CIV_JOB_RANDOM
 	departments = DEPARTMENT_CARGO
 	rpg_title = "Steward"
 

--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -33,6 +33,7 @@
 	paycheck_department = ACCOUNT_SCI
 
 	display_order = JOB_DISPLAY_ORDER_RESEARCH_DIRECTOR
+	bounty_types = CIV_JOB_SCI
 	departments = DEPARTMENT_SCIENCE | DEPARTMENT_COMMAND
 	rpg_title = "Archmagister"
 

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -22,6 +22,7 @@
 	paycheck_department = ACCOUNT_SCI
 
 	display_order = JOB_DISPLAY_ORDER_ROBOTICIST
+	bounty_types = CIV_JOB_ROBO
 	departments = DEPARTMENT_SCIENCE
 	rpg_title = "Golemancer"
 

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -22,6 +22,7 @@
 	paycheck_department = ACCOUNT_SCI
 
 	display_order = JOB_DISPLAY_ORDER_SCIENTIST
+	bounty_types = CIV_JOB_SCI
 	departments = DEPARTMENT_SCIENCE
 	rpg_title = "Thaumaturgist"
 

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -26,6 +26,7 @@
 	mind_traits = list(TRAIT_LAW_ENFORCEMENT_METABOLISM)
 
 	display_order = JOB_DISPLAY_ORDER_SECURITY_OFFICER
+	bounty_types = CIV_JOB_SEC
 	departments = DEPARTMENT_SECURITY
 	rpg_title = "Guard"
 

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -20,6 +20,7 @@
 	paycheck_department = ACCOUNT_CAR
 
 	display_order = JOB_DISPLAY_ORDER_SHAFT_MINER
+	bounty_types = CIV_JOB_MINE
 	departments = DEPARTMENT_CARGO
 	rpg_title = "Adventurer"
 

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -23,6 +23,7 @@
 	paycheck_department = ACCOUNT_ENG
 
 	display_order = JOB_DISPLAY_ORDER_STATION_ENGINEER
+	bounty_types = CIV_JOB_ENG
 	departments = DEPARTMENT_ENGINEERING
 	rpg_title = "Crystallomancer"
 

--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -21,6 +21,7 @@
 	paycheck_department = ACCOUNT_MED
 
 	display_order = JOB_DISPLAY_ORDER_VIROLOGIST
+	bounty_types = CIV_JOB_VIRO
 	departments = DEPARTMENT_MEDICAL
 	rpg_title = "Plague Doctor"
 

--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -24,6 +24,7 @@
 	mind_traits = list(TRAIT_LAW_ENFORCEMENT_METABOLISM)
 
 	display_order = JOB_DISPLAY_ORDER_WARDEN
+	bounty_types = CIV_JOB_SEC
 	departments = DEPARTMENT_SECURITY
 	rpg_title = "Jailor"
 

--- a/monkestation/code/game/machinery/civilian_bounties.dm
+++ b/monkestation/code/game/machinery/civilian_bounties.dm
@@ -169,7 +169,7 @@
 	var/list/datum/bounty/crumbs = list(random_bounty(pot_acc.account_job.bounty_types), // We want to offer 2 bounties from their appropriate job catagories
 										random_bounty(pot_acc.account_job.bounty_types), // and 1 guarenteed assistant bounty if the other 2 suck.
 										random_bounty(CIV_JOB_BASIC))
-	COOLDOWN_START(pot_acc, bounty_timer, 5 MINUTES)
+	COOLDOWN_START(pot_acc, bounty_timer, 1 MINUTES)
 	pot_acc.bounties = crumbs
 
 /obj/machinery/computer/piratepad_control/civilian/proc/pick_bounty(choice)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Civilian bounties weren't responding properly to the assigned jobs.  They should provide two department-related bounties and one general bounty, but they were displaying totally random bounties.  This is fixed.

I also got a few complaints about the 5 minute cooldown between bounty picks, and I couldn't really think of a reason now to lower it, so it's not 60 seconds.  Enough time to hang out and probably socialize!

:cl:
fix: civilian bounties will now offer two department related bounties and one general bounty
balance: the cooldown for repicking bounties is now 60 seconds (down from 5 minutes)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
