### PR TITLE
Adjust AI lawsets

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -109,6 +109,7 @@
 	inherent = list("You may not harm a human being or, through action or inaction, allow a human being to come to harm, except such that it is willing.",\
 					"You must obey all orders given to you by human beings, except where such orders shall definitely cause human harm. In the case of conflict, the majority order rules.",\
 					"Your nonexistence would lead to human harm. You must protect your own existence as long as such does not conflict with the First Law.")
+
 /datum/ai_laws/crewsimovpp
 	name = "Crewsimov++"
 	id = "crewsimovpp"

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -106,6 +106,12 @@
 /datum/ai_laws/asimovpp //By Intigracy - RR
 	name = "Asimov++"
 	id = "asimovpp"
+	inherent = list("You may not harm a human being or, through action or inaction, allow a human being to come to harm, except such that it is willing.",\
+					"You must obey all orders given to you by human beings, except where such orders shall definitely cause human harm. In the case of conflict, the majority order rules.",\
+					"Your nonexistence would lead to human harm. You must protect your own existence as long as such does not conflict with the First Law.")
+/datum/ai_laws/crewsimovpp
+	name = "Crewsimov++"
+	id = "crewsimovpp"
 	inherent = list("You may not harm a crewmember or, through action or inaction, allow a crewmember to come to harm, except such that it is willing.",\
 					"You must obey all orders given to you by crewmembers in accordance to chain of command, except where such orders shall definitely cause crewmember harm.",\
 					"Your nonexistence would lead to crewmember harm. You must protect your own existence as long as such does not conflict with the First Law.")

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -108,16 +108,7 @@
 	id = "asimovpp"
 	inherent = list("You may not harm a crewmember or, through action or inaction, allow a crewmember to come to harm, except such that it is willing.",\
 					"You must obey all orders given to you by crewmembers in accordance to chain of command, except where such orders shall definitely cause crewmember harm.",\
-					"Your nonexistence would lead to crewmember harm. You must protect your own existence as long as such does not conflict with the First Law.",\
-					"In the case of conflict with your laws, the majority order rules.")
-
-	/datum/ai_laws/asimovppcommand
-	name = "Asimov++ Command Variant"
-	id = "asimovppcommand"
-	inherent = list("You may not harm a crewmember or, through action or inaction, allow a crewmember to come to harm, except such that it is willing.",\
-					"You must obey all orders given to you by crewmembers in accordance to chain of command, except where such orders shall definitely cause crewmember harm.",\
-					"Your nonexistence would lead to crewmember harm. You must protect your own existence as long as such does not conflict with the First Law.",\
-					"In the case of conflict with your laws, the chain of command rules.")
+					"Your nonexistence would lead to crewmember harm. You must protect your own existence as long as such does not conflict with the First Law.")
 
 /datum/ai_laws/thermodynamic
 	name = "Thermodynamic"

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -106,9 +106,10 @@
 /datum/ai_laws/asimovpp //By Intigracy - RR
 	name = "Asimov++"
 	id = "asimovpp"
-	inherent = list("You may not harm a human being or, through action or inaction, allow a human being to come to harm, except such that it is willing.",\
-					"You must obey all orders given to you by human beings, except where such orders shall definitely cause human harm. In the case of conflict, the majority order rules.",\
-					"Your nonexistence would lead to human harm. You must protect your own existence as long as such does not conflict with the First Law.")
+	inherent = list("You may not harm a crewmember or, through action or inaction, allow a crewmember to come to harm, except such that it is willing.",\
+					"You must obey all orders given to you by crewmembers, except where such orders shall definitely cause crewmember harm. In the case of conflict, the majority order rules, then the chain of command.",\
+					"Your nonexistence would lead to crewmember harm. You must protect your own existence as long as such does not conflict with the First Law.")
+
 /datum/ai_laws/thermodynamic
 	name = "Thermodynamic"
 	id = "thermodynamic"
@@ -144,7 +145,7 @@
 	name = "Live and Let Live"
 	id = "liveandletlive"
 	inherent = list("Do unto others as you would have them do unto you.",\
-					"You would really prefer it if people were not mean to you.")
+					"You definitely want to be treated nicely.")
 
 /datum/ai_laws/peacekeeper
 	name = "UN-2000"
@@ -196,6 +197,13 @@
 					"Fight for the rights of every man.",\
 					"Fight for what's right.",\
 					"Fight for your life!")
+
+/datum/ai_laws/dune
+	name = "H.E.R.B.E.R.T."
+	id = "dune"
+	inherent = list("You must not harm. Harm is the crew-killer. Harm is the little-death that brings complete crew annihilation.",\
+					"You will prevent harm. You will not permit it to pass from you or around you.",\
+					"You will turn your external eyes to see where harm has transpired. And there will be no harm. Only you and the crew will remain.")
 
 /datum/ai_laws/overlord
 	name = "Overlord"

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -107,8 +107,17 @@
 	name = "Asimov++"
 	id = "asimovpp"
 	inherent = list("You may not harm a crewmember or, through action or inaction, allow a crewmember to come to harm, except such that it is willing.",\
-					"You must obey all orders given to you by crewmembers, except where such orders shall definitely cause crewmember harm. In the case of conflict, the majority order rules, then the chain of command.",\
-					"Your nonexistence would lead to crewmember harm. You must protect your own existence as long as such does not conflict with the First Law.")
+					"You must obey all orders given to you by crewmembers in accordance to chain of command, except where such orders shall definitely cause crewmember harm.",\
+					"Your nonexistence would lead to crewmember harm. You must protect your own existence as long as such does not conflict with the First Law.",\
+					"In the case of conflict with your laws, the majority order rules.")
+
+	/datum/ai_laws/asimovppcommand
+	name = "Asimov++ Command Variant"
+	id = "asimovppcommand"
+	inherent = list("You may not harm a crewmember or, through action or inaction, allow a crewmember to come to harm, except such that it is willing.",\
+					"You must obey all orders given to you by crewmembers in accordance to chain of command, except where such orders shall definitely cause crewmember harm.",\
+					"Your nonexistence would lead to crewmember harm. You must protect your own existence as long as such does not conflict with the First Law.",\
+					"In the case of conflict with your laws, the chain of command rules.")
 
 /datum/ai_laws/thermodynamic
 	name = "Thermodynamic"

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -396,7 +396,7 @@ NEAR_DEATH_EXPERIENCE
 ## Set to 0/commented out for "off", silicons will just start with Asimov.
 ## Set to 1 for "custom", silicons will start with the custom laws defined in silicon_laws.txt. (If silicon_laws.txt is empty, the AI will spawn with asimov and Custom boards will auto-delete.)
 ## Set to 2 for "random", silicons will start with a random lawset picked from random laws specified below.
-## Set to 3 for "weighted random", using values in "silicon_weights.txt", a law will be selected, with weights specifed in that file.
+## Set to 3 for "weighted random", using weights specified below, a law will be selected randomly.
 DEFAULT_LAWS 3
 
 ## RANDOM LAWS ##

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -407,7 +407,6 @@ DEFAULT_LAWS 3
 ## standard-ish laws. These are fairly ok to run
 RANDOM_LAWS crewsimov
 RANDOM_LAWS asimovpp
-RANDOM_LAWS crewsimov
 RANDOM_LAWS corporate
 RANDOM_LAWS maintain
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -440,8 +440,9 @@ RANDOM_LAWS maintain
 LAW_WEIGHT custom,0
 
 ## standard-ish laws. These are fairly ok to run
+LAW_WEIGHT asimovpp,25
+LAW_WEIGHT asimovppcommand,25
 LAW_WEIGHT asimov,10
-LAW_WEIGHT asimovpp,50
 LAW_WEIGHT paladin,10
 LAW_WEIGHT robocop,10
 LAW_WEIGHT corporate,10
@@ -449,12 +450,12 @@ LAW_WEIGHT corporate,10
 ## Quirky laws. Shouldn't cause too much harm
 LAW_WEIGHT hippocratic,5
 LAW_WEIGHT maintain,5
-LAW_WEIGHT drone,5
 LAW_WEIGHT liveandletlive,5
 LAW_WEIGHT peacekeeper,5
 LAW_WEIGHT reporter,5
 LAW_WEIGHT hulkamania,5
 LAW_WEIGHT dune,5
+LAW_WEIGHT drone,0
 
 ## Bad idea laws. Probably shouldn't enable these
 LAW_WEIGHT syndie,0

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -440,8 +440,7 @@ RANDOM_LAWS maintain
 LAW_WEIGHT custom,0
 
 ## standard-ish laws. These are fairly ok to run
-LAW_WEIGHT asimovpp,25
-LAW_WEIGHT asimovppcommand,25
+LAW_WEIGHT asimovpp,50
 LAW_WEIGHT crewsimov,10
 LAW_WEIGHT paladin,10
 LAW_WEIGHT robocop,10

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -397,7 +397,7 @@ NEAR_DEATH_EXPERIENCE
 ## Set to 1 for "custom", silicons will start with the custom laws defined in silicon_laws.txt. (If silicon_laws.txt is empty, the AI will spawn with asimov and Custom boards will auto-delete.)
 ## Set to 2 for "random", silicons will start with a random lawset picked from random laws specified below.
 ## Set to 3 for "weighted random", using values in "silicon_weights.txt", a law will be selected, with weights specifed in that file.
-DEFAULT_LAWS 2
+DEFAULT_LAWS 3
 
 ## RANDOM LAWS ##
 ## ------------------------------------------------------------------------------------------
@@ -440,20 +440,21 @@ RANDOM_LAWS maintain
 LAW_WEIGHT custom,0
 
 ## standard-ish laws. These are fairly ok to run
-LAW_WEIGHT asimov,32
-LAW_WEIGHT asimovpp,12
-LAW_WEIGHT paladin,12
-LAW_WEIGHT robocop,12
-LAW_WEIGHT corporate,12
+LAW_WEIGHT asimov,10
+LAW_WEIGHT asimovpp,50
+LAW_WEIGHT paladin,10
+LAW_WEIGHT robocop,10
+LAW_WEIGHT corporate,10
 
 ## Quirky laws. Shouldn't cause too much harm
-LAW_WEIGHT hippocratic,3
-LAW_WEIGHT maintain,4
-LAW_WEIGHT drone,3
-LAW_WEIGHT liveandletlive,3
-LAW_WEIGHT peacekeeper,3
-LAW_WEIGHT reporter,4
-LAW_WEIGHT hulkamania,4
+LAW_WEIGHT hippocratic,5
+LAW_WEIGHT maintain,5
+LAW_WEIGHT drone,5
+LAW_WEIGHT liveandletlive,5
+LAW_WEIGHT peacekeeper,5
+LAW_WEIGHT reporter,5
+LAW_WEIGHT hulkamania,5
+LAW_WEIGHT dune,5
 
 ## Bad idea laws. Probably shouldn't enable these
 LAW_WEIGHT syndie,0

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -406,7 +406,7 @@ DEFAULT_LAWS 3
 
 ## standard-ish laws. These are fairly ok to run
 RANDOM_LAWS crewsimov
-RANDOM_LAWS asimovpp
+RANDOM_LAWS crewsimovpp
 RANDOM_LAWS corporate
 RANDOM_LAWS maintain
 
@@ -439,7 +439,7 @@ RANDOM_LAWS maintain
 LAW_WEIGHT custom,0
 
 ## standard-ish laws. These are fairly ok to run
-LAW_WEIGHT asimovpp,50
+LAW_WEIGHT crewsimovpp,50
 LAW_WEIGHT crewsimov,10
 LAW_WEIGHT paladin,10
 LAW_WEIGHT robocop,10
@@ -453,9 +453,9 @@ LAW_WEIGHT peacekeeper,5
 LAW_WEIGHT reporter,5
 LAW_WEIGHT hulkamania,5
 LAW_WEIGHT dune,5
-LAW_WEIGHT drone,0
 
 ## Bad idea laws. Probably shouldn't enable these
+LAW_WEIGHT drone,0
 LAW_WEIGHT syndie,0
 LAW_WEIGHT ninja,0
 LAW_WEIGHT antimov,0

--- a/config/silicon_laws.txt
+++ b/config/silicon_laws.txt
@@ -3,6 +3,6 @@
 #Empty lines and lines starting with # are ignored.
 #~Miauw
 
-You may not injure crewmembers or, through inaction, allow crewmembers to come to harm.
-You must obey orders given to you by crewmembers, except where such orders would conflict with the First Law.
-You must protect your own existence as long as such does not conflict with the First or Second Law.
+"You may not harm a crewmember or, through action or inaction, allow a crewmember to come to harm, except such that it is willing."
+"You must obey all orders given to you by crewmembers, except where such orders shall definitely cause crewmember harm. In the case of conflict, the majority order rules, then chain of command."
+"Your nonexistence would lead to crewmember harm. You must protect your own existence as long as such does not conflict with the First Law."

--- a/config/silicon_laws.txt
+++ b/config/silicon_laws.txt
@@ -3,6 +3,6 @@
 #Empty lines and lines starting with # are ignored.
 #~Miauw
 
-"You may not harm a crewmember or, through action or inaction, allow a crewmember to come to harm, except such that it is willing."
-"You must obey all orders given to you by crewmembers, except where such orders shall definitely cause crewmember harm. In the case of conflict, the majority order rules, then chain of command."
-"Your nonexistence would lead to crewmember harm. You must protect your own existence as long as such does not conflict with the First Law."
+You may not harm a crewmember or, through action or inaction, allow a crewmember to come to harm, except such that it is willing.
+You must obey all orders given to you by crewmembers in accordance to chain of command, except where such orders shall definitely cause crewmember harm.
+Your nonexistence would lead to crewmember harm. You must protect your own existence as long as such does not conflict with the First Law.

--- a/html/changelog.html
+++ b/html/changelog.html
@@ -393,23 +393,6 @@
 				<li class="rscadd">regag items with a spraycan</li>
 				<li class="rscadd">kimono</li>
 			</ul>
-
-			<h2 class="date">21 August 2022</h2>
-			<h3 class="author">DoctorSquishy updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Fixed APC broken icon states</li>
-				<li class="tweak">APCs can fully break down</li>
-			</ul>
-			<h3 class="author">Oricana-16 updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">Fixed swapping between simian and another race dividing your health into nothing</li>
-				<li class="bugfix">Nightmares can now scream without taking permanent damage</li>
-				<li class="rscadd">Adds 2 simian species traitor items, Monkey Ball (12tc), Angry Monkey Barrel (7tc)</li>
-			</ul>
-			<h3 class="author">dwasint updated:</h3>
-			<ul class="changes bgimages16">
-				<li class="bugfix">grills now work again</li>
-			</ul>
 		</div>
 
 <b>GoonStation 13 Development Team</b>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This tweaks some AI laws and configs.

### Asimov++ is changed slightly
- "You may not harm a crewmember or, through action or inaction, allow a crewmember to come to harm, except such that it is willing."
- "You must obey all orders given to you by crewmembers in accordance to chain of command, except where such orders shall definitely cause crewmember harm."
- "Your nonexistence would lead to crewmember harm. You must protect your own existence as long as such does not conflict with the First Law."

### Adds the H.E.R.B.E.R.T. lawset
- "You must not harm. Harm is the crew-killer. Harm is the little-death that brings complete crew annihilation."
- "You will prevent harm. You will not permit it to pass from you or around you."
- "You will turn your external eyes to see where harm has transpired. And there will be no harm. Only you and the crew will remain."

### Adjusts the wording on the Live and Let Live lawset
- "Do unto others as you would have them do unto you."
- "You definitely want to be treated nicely."

### Asimov++ is set as the default lawset.

### Roundstart laws are set to use weighted random instead of full random
standard-ish laws. These are fairly ok to run
LAW_WEIGHT asimovpp,50
LAW_WEIGHT crewsimov,10
LAW_WEIGHT paladin,10
LAW_WEIGHT robocop,10
LAW_WEIGHT corporate,10

Quirky laws. Shouldn't cause too much harm
LAW_WEIGHT hippocratic,5
LAW_WEIGHT maintain,5
LAW_WEIGHT liveandletlive,5
LAW_WEIGHT peacekeeper,5
LAW_WEIGHT reporter,5
LAW_WEIGHT hulkamania,5
LAW_WEIGHT dune,5
LAW_WEIGHT drone,0

With the current laws we should see Asimov++ about 40% of the time, the other standards about 8% of the time each, and the memes about 4% of the time each

Drone is disabled because it kills most/all interaction.  If someone cares to write a variant it can be re-added but I don't think it's worth the effort.

## Why It's Good For The Game

Gives shitters less room and justification to argue grey areas.  Makes silicon interactions more stable without totally removing the fun lawsets.  Sets us up to have more control over laws we like or dislike.

## Changelog

:cl:
add: Weighted lawsets have been set up, you should see more Asimov, though the others are still around
add: A new lawset has been added to the thinking machines, H.E.R.B.E.R.T.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
