### PR TITLE
Flashed Status Effect Changes

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -1035,14 +1035,14 @@
 
 /datum/status_effect/flashed
 	id = "flashed"
-	duration = 3 SECONDS
+	duration = 5 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/flashed
 	examine_text = "<span class='warning'>They're squinting their eyes!</span>"
 	status_type = STATUS_EFFECT_UNIQUE
 
 /datum/status_effect/flashed/on_apply()
 	. = ..()
-	to_chat(owner, "<span class='notice'>You close your eyes from the flash!</span>")
+	to_chat(owner, "<span class='notice'>You squint your eyes from the brightness!</span>")
 	owner.overlay_fullscreen("flashed", /atom/movable/screen/fullscreen/impaired, 2)
 
 /datum/status_effect/flashed/on_remove()

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -335,6 +335,7 @@
 	if(.) // we've been flashed
 		if(visual)
 			return
+		apply_status_effect(/datum/status_effect/flashed)
 		switch(damage)
 			if(1)
 				to_chat(src, "<span class='warning'>Your eyes sting a little.</span>")
@@ -343,12 +344,10 @@
 
 			if (2)
 				to_chat(src, "<span class='warning'>Your eyes burn.</span>")
-				apply_status_effect(/datum/status_effect/flashed)
 				eyes.applyOrganDamage(rand(2, 4))
 
 			if(3 to INFINITY)
 				to_chat(src, "<span class='warning'>Your eyes itch and burn severely!</span>")
-				apply_status_effect(/datum/status_effect/flashed)
 				eyes.applyOrganDamage(rand(12, 16))
 
 		if(eyes.damage > 10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Moves the status effect application to be independent of the strength of the flash. Any brightness that would damage is enough to cause the effect.

Changes the flavor text of the status effect to reflect the examine text.

Changes the duration of the status effect to be more in line with the length of an actual flash stun.


## Why It's Good For The Game

Unintended behavior, you should get some form of feedback when hit by any level of flash.

## Changelog

:cl:
fix: Getting flashed by any bright light should now properly apply the screen overlay
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
