### PR TITLE
Fixes the wabajack on the NT lepton violet so it no longer incorrectly requires power

### DIFF
--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -52,6 +52,9 @@
 /obj/machinery/power/emitter/energycannon/magical/emag_act(mob/user)
 	return
 
+/obj/machinery/power/emitter/energycannon/magical/RefreshParts()//monkestation edit, makes it correctly not require power
+	return
+
 /obj/structure/table/abductor/wabbajack
 	name = "wabbajack altar"
 	desc = "Whether you're sleeping or waking, it's going to be quite chaotic."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Makes the wabajack emitter on the NT lepton violet return when RefreshParts is called making it no longer incorrectly require power.

## Why It's Good For The Game

Fix good

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
fix: The NT lepton violet evac shuttle wabajack statue no longer incorrectly requires power
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
