### PR TITLE
TOOLBOX ROYALE

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -82,6 +82,7 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	/client/proc/stabilize_atmos,
 	/client/proc/openTicketManager,
 	/client/proc/battle_royale,
+	/client/proc/toolbox_royale,
 	/client/proc/delete_book
 	)
 GLOBAL_LIST_INIT(admin_verbs_ban, list(/client/proc/unban_panel, /client/proc/ban_panel, /client/proc/stickybanpanel))

--- a/code/modules/admin/battle_royale.dm
+++ b/code/modules/admin/battle_royale.dm
@@ -135,6 +135,32 @@ GLOBAL_DATUM(battle_royale, /datum/battle_royale_controller)
 	GLOB.battle_royale = new()
 	GLOB.battle_royale.start()
 
+/client/proc/toolbox_royale() //just a battle royale with all toolboxes, for ease
+	set name = "Toolbox Royale"
+	set category = "Adminbus"
+	if(!(check_rights(R_FUN) || (check_rights(R_ADMIN) && SSticker.current_state == GAME_STATE_FINISHED)))
+		to_chat(src, "<span class='warning'>You do not have permission to do that! (If you don't have +FUN, wait until the round is over then you can trigger it.)</span>")
+		return
+	if(GLOB.battle_royale)
+		to_chat(src, "<span class='warning'>A game is already in progress!</span>")
+		return
+	if(alert(src, "ARE YOU SURE YOU ARE SURE YOU WANT TO START TOOLBOX ROYALE?",,"Yes","No") != "Yes")
+		to_chat(src, "<span class='notice'>oh.. ok then.. I see how it is.. :(</span>")
+		return
+	log_admin("[key_name(usr)] HAS TRIGGERED TOOLBOX ROYALE")
+	message_admins("[key_name(usr)] HAS TRIGGERED TOOLBOX ROYALE")
+
+	for(var/client/admin in GLOB.admins)
+		if(check_rights(R_ADMIN) && !GLOB.battle_royale && admin.tgui_panel)
+			admin.tgui_panel.clear_br_popup()
+
+	GLOB.battle_royale_basic_loot = list(/obj/item/storage/toolbox/mechanical) //all toolboxes
+	GLOB.battle_royale_good_loot = list(/obj/item/storage/toolbox/syndicate) //higher damage
+	GLOB.battle_royale_insane_loot = list(/obj/item/his_grace) //THE LEGEND
+
+	GLOB.battle_royale = new()
+	GLOB.battle_royale.start()
+
 /client/proc/battle_royale_speed()
 	set name = "Battle Royale - Change wall speed"
 	set category = "Event"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

TOOLBOX ROYALE

Ook requested this.

Adds a new admin verb which triggers battle royale, except all the loot is replaced with toolboxes.  Rarely syndicate toolboxes, super rarely His Grace.

## Why It's Good For The Game

TOOLBOX ROYALE

## Testing Photographs and Procedure

TOOLBOX ROYALE
(don't worry I replaced them with blue ones)
![image](https://user-images.githubusercontent.com/31165061/200094881-211bba7e-f188-4ac9-8a86-8f32215e7a1a.png)

## Changelog

:cl:
add: a special variant of battle royale
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
