### PR TITLE
Adds metrics tracking for TiDi and harddels [bee port]

### DIFF
--- a/code/controllers/subsystem/metrics.dm
+++ b/code/controllers/subsystem/metrics.dm
@@ -39,6 +39,11 @@ SUBSYSTEM_DEF(metrics)
 	out["elapsed_processed"] = world.time
 	out["elapsed_real"] = (REALTIMEOFDAY - world_init_time)
 	out["client_count"] = length(GLOB.clients)
+	out["time_dilation_current"] = SStime_track.time_dilation_current
+	out["time_dilation_1m"] = SStime_track.time_dilation_avg
+	out["time_dilation_5m"] = SStime_track.time_dilation_avg_slow
+	out["time_dilation_15m"] = SStime_track.time_dilation_avg_fast
+	out["harddel_count"] = length(GLOB.world_qdel_log)
 	out["round_id"] = text2num(GLOB.round_id) // This is so we can filter the metrics by a single round ID
 
 	var/server_name = CONFIG_GET(string/serversqlname)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Adds TiDi stats and a count of harddels to our metrics json blob.

This is a port of https://github.com/BeeStation/BeeStation-Hornet/pull/8007

## Why It's Good For The Game

In testing I immediately spotted 44 harddels at roundstart which were not done by the garbage system.  This seems like good information to know.

## Testing Photographs and Procedure

Since this is a backend thing, to test you have to go into code/controllers/subsystem/metrics.dm and uncomment the code block at the bottom, then put debug-metrics into the chat bar at the bottom right.

## Changelog

:cl: Crossedfall ported by Kobold Commando
add: Added some new metrics to debug logging
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
