### PR TITLE
Reverts a few chem gases changes

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -166,9 +166,6 @@
 	UNSETEMPTY(new_overlay_types)
 	src.atmos_overlay_types = new_overlay_types
 
-	for(var/obj/effect/overlay/gas/tile_overlay in src.atmos_overlay_types)
-		tile_overlay.alpha /= min((src.atmos_overlay_types.len * 0.25), 1)
-
 /turf/open/proc/set_visuals(list/new_overlay_types)
 	if (atmos_overlay_types)
 		for(var/overlay in atmos_overlay_types-new_overlay_types) //doesn't remove overlays that would only be added

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -63,7 +63,7 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	///if this reagent should condense down into a liquid
 	var/condenses_liquid = TRUE
 	///does this reagent convert into a gas
-	var/aerolizes = FALSE
+	var/converts_to_gas = FALSE
 	//MONKESTATION EDIT END
 /datum/reagent/Destroy() // This should only be called by the holder, so it's already handled clearing its references
 	. = ..()
@@ -84,7 +84,7 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	return
 
 /datum/reagent/proc/reaction_evaporation(turf/T, volume)
-	if(aerolizes)
+	if(converts_to_gas)
 		var/temp = holder ? holder.chem_temp : T20C
 		if(get_gas())
 			T.atmos_spawn_air("[get_gas()]=[(volume/molarity) * 0.5];TEMP=[temp]") // each cycle produces half as much gas as the last

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -62,6 +62,8 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/evaporation_rate = 0.5
 	///if this reagent should condense down into a liquid
 	var/condenses_liquid = TRUE
+	///does this reagent convert into a gas
+	var/aerolizes = FALSE
 	//MONKESTATION EDIT END
 /datum/reagent/Destroy() // This should only be called by the holder, so it's already handled clearing its references
 	. = ..()
@@ -82,9 +84,10 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	return
 
 /datum/reagent/proc/reaction_evaporation(turf/T, volume)
-	var/temp = holder ? holder.chem_temp : T20C
-	if(get_gas())
-		T.atmos_spawn_air("[get_gas()]=[(volume/molarity) * 0.5];TEMP=[temp]") // each cycle produces half as much gas as the last
+	if(aerolizes)
+		var/temp = holder ? holder.chem_temp : T20C
+		if(get_gas())
+			T.atmos_spawn_air("[get_gas()]=[(volume/molarity) * 0.5];TEMP=[temp]") // each cycle produces half as much gas as the last
 
 /datum/reagent/proc/reaction_turf(turf/T, volume, show_message, from_gas)
 	return

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -2,6 +2,7 @@
 	name = "Drug"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	taste_description = "bitterness"
+	aerolizes = TRUE
 	var/trippy = TRUE //Does this drug make you trip?
 
 /datum/reagent/drug/on_mob_end_metabolize(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -2,7 +2,7 @@
 	name = "Drug"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	taste_description = "bitterness"
-	aerolizes = TRUE
+	converts_to_gas = TRUE
 	var/trippy = TRUE //Does this drug make you trip?
 
 /datum/reagent/drug/on_mob_end_metabolize(mob/living/M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Reverts the overlay change as it was to heavy on performance
same reasoning applys for liquid evaporation now its controlled by a variable and it has been giving to the drug class for now
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
del: Only drug type reagents will evaporate now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
