### PR TITLE
Mosin Nagants now have a chance to seize

### DIFF
--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -66,6 +66,7 @@
 /obj/item/gun/ballistic/rifle/boltaction/rack(mob/user = null)
 	if(prob(33)) //33% chance of being seized up
 		to_chat(user, "<span class='warning'>Try as you might, the bolt refuses to move! Give it another yank.</span>")
+		user.balloon_alert(user, "Jammed!")
 		playsound(src, bolt_stuck_sound, rack_sound_volume, rack_sound_vary) //it's still involved in racking so inherit those properties for ease
 		return
 	else

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -15,6 +15,7 @@
 	bolt_drop_sound = "sound/weapons/mosinboltin.ogg"
 	tac_reloads = FALSE
 	weapon_weight = WEAPON_MEDIUM
+	var/bolt_stuck_sound = "sound/weapons/gun_slide_lock_4.ogg"
 
 /obj/item/gun/ballistic/rifle/update_icon()
 	..()
@@ -61,6 +62,14 @@
 	knife_y_offset = 13
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
+
+/obj/item/gun/ballistic/rifle/boltaction/rack(mob/user = null)
+	if(prob(33)) //33% chance of being seized up
+		to_chat(user, "<span class='warning'>Try as you might, the bolt refuses to move! Give it another yank.</span>")
+		playsound(src, bolt_stuck_sound, rack_sound_volume, rack_sound_vary) //it's still involved in racking so inherit those properties for ease
+		return
+	else
+		return ..()
 
 /obj/item/gun/ballistic/rifle/boltaction/enchanted
 	name = "enchanted bolt action rifle"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This gives the mosin nagant a 33% chance to be seized up when you go to rack it.  Making it slower and more awkward to use.

## Why It's Good For The Game

People frequently complain about the mosin and its relative ease of acquiring combined with its extreme damage output.  I think it's good for it to have a real kick.  The weakness I've witnessed is how awkward it is to cycle the rounds.  This applies the oft-asked-for nerf by making it even more likely for someone to fumble with the bolt and drop rounds on the floor and generally mess up after that first shot.

![image](https://user-images.githubusercontent.com/31165061/202076380-6c8d2a05-1348-45a5-8717-7722c608bf95.png)

## Changelog

:cl:
balance: Those mosin-nagants could really use some oil!  They now have a chance to seize up when cycling.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
