### PR TITLE
Vehicles now rev and waddle

### DIFF
--- a/code/modules/vehicles/bicycle.dm
+++ b/code/modules/vehicles/bicycle.dm
@@ -6,6 +6,7 @@
 	max_integrity = 150
 	integrity_failure = 0.5
 	var/fried = FALSE
+	has_engine = FALSE
 
 /obj/vehicle/ridden/bicycle/Initialize(mapload)
 	. = ..()

--- a/code/modules/vehicles/cars/car.dm
+++ b/code/modules/vehicles/cars/car.dm
@@ -3,9 +3,6 @@
 	move_resist = MOVE_FORCE_OVERPOWERING
 	default_driver_move = FALSE
 	var/car_traits = NONE //Bitflag for special behavior such as kidnapping
-	var/engine_sound = 'sound/vehicles/carrev.ogg'
-	var/last_enginesound_time
-	var/engine_sound_length = 20 //Set this to the length of the engine sound
 	var/escape_time = 60 //Time it takes to break out of the car
 
 /obj/vehicle/sealed/car/Initialize(mapload)
@@ -26,10 +23,6 @@
 		return FALSE
 	var/datum/component/riding/R = GetComponent(/datum/component/riding)
 	R.handle_ride(user, direction)
-	if(world.time < last_enginesound_time + engine_sound_length)
-		return
-	last_enginesound_time = world.time
-	playsound(src, engine_sound, 100, TRUE)
 	return TRUE
 
 /obj/vehicle/sealed/car/proc/RunOver(mob/living/carbon/human/H) //pasted right out of mulebot code

--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -113,7 +113,6 @@
 	to_chat(user, "<span class='danger'>You scramble the clowncar child safety lock and a panel with 6 colorful buttons appears!</span>")
 	initialize_controller_action_type(/datum/action/vehicle/sealed/RollTheDice, VEHICLE_CONTROL_DRIVE)
 	initialize_controller_action_type(/datum/action/vehicle/sealed/Cannon, VEHICLE_CONTROL_DRIVE)
-	AddComponent(/datum/component/waddling)
 
 /obj/vehicle/sealed/car/clowncar/Destroy()
   playsound(src, 'sound/vehicles/clowncar_fart.ogg', 100)

--- a/code/modules/vehicles/lavaboat.dm
+++ b/code/modules/vehicles/lavaboat.dm
@@ -10,6 +10,7 @@
 	can_buckle = TRUE
 	legs_required = 0
 	arms_required = 0
+	has_engine = FALSE
 
 /obj/vehicle/ridden/lavaboat/Initialize(mapload)
 	. = ..()

--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -10,6 +10,8 @@
 							/obj/item/stock_parts/manipulator,
 							/obj/item/stock_parts/capacitor)
 	var/obj/item/stock_parts/cell/power_cell
+	has_engine = FALSE //it's electric, alright?
+	waddles = FALSE
 
 /obj/vehicle/ridden/wheelchair/motorized/CheckParts(list/parts_list)
 	..()

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -12,6 +12,7 @@
 	var/obj/item/storage/bag/trash/trash_bag
 	/// The installed upgrade, if present
 	var/obj/item/janicart_upgrade/installed_upgrade
+	waddles = FALSE
 
 /obj/vehicle/ridden/janicart/Initialize(mapload)
 	. = ..()

--- a/code/modules/vehicles/ridden.dm
+++ b/code/modules/vehicles/ridden.dm
@@ -13,13 +13,19 @@
 	var/waddles = TRUE //bad shocks
 	var/engine_sound = 'sound/vehicles/carrev.ogg'
 	var/last_enginesound_time
-	var/engine_sound_length = 20 //Set this to the length of the engine sound
+	var/engine_sound_length = 2 SECONDS //Set this to the length of the engine sound
 
 /obj/vehicle/ridden/Initialize(mapload)
 	. = ..()
 	LoadComponent(/datum/component/riding)
 	if(waddles)
 		AddComponent(/datum/component/waddling)
+
+/obj/vehicle/ridden/Destroy(force=FALSE)
+	var/datum/component/waddling/waddles = src.GetComponent(/datum/component/waddling)
+	if(waddles)
+		waddles.RemoveComponent()
+	. = ..()
 
 /obj/vehicle/ridden/examine(mob/user)
 	. = ..()

--- a/code/modules/vehicles/ridden.dm
+++ b/code/modules/vehicles/ridden.dm
@@ -9,10 +9,17 @@
 	var/arms_required = 1	//why not?
 	var/fall_off_if_missing_arms = FALSE //heh...
 	var/message_cooldown
+	var/has_engine = TRUE
+	var/waddles = TRUE //bad shocks
+	var/engine_sound = 'sound/vehicles/carrev.ogg'
+	var/last_enginesound_time
+	var/engine_sound_length = 20 //Set this to the length of the engine sound
 
 /obj/vehicle/ridden/Initialize(mapload)
 	. = ..()
 	LoadComponent(/datum/component/riding)
+	if(waddles)
+		AddComponent(/datum/component/waddling)
 
 /obj/vehicle/ridden/examine(mob/user)
 	. = ..()
@@ -30,10 +37,15 @@
 
 /obj/vehicle/ridden/post_unbuckle_mob(mob/living/M)
 	remove_occupant(M)
+	var/datum/component/waddling/is_waddling = M.GetComponent(/datum/component/waddling/)
+	if(is_waddling)
+		is_waddling.RemoveComponent()
 	return ..()
 
 /obj/vehicle/ridden/post_buckle_mob(mob/living/M)
 	add_occupant(M)
+	if(has_engine)
+		M.AddComponent(/datum/component/waddling)
 	return ..()
 
 /obj/vehicle/ridden/attackby(obj/item/I, mob/user, params)
@@ -86,6 +98,11 @@
 			return FALSE
 	var/datum/component/riding/R = GetComponent(/datum/component/riding)
 	R.handle_ride(user, direction)
+	if(has_engine)
+		if(world.time < last_enginesound_time + engine_sound_length)
+			return
+		last_enginesound_time = world.time
+		playsound(src, engine_sound, 100, TRUE)
 	return ..()
 
 /obj/vehicle/ridden/user_buckle_mob(mob/living/M, mob/user, check_loc = TRUE)

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -4,6 +4,8 @@
 	icon_state = "scooter"
 	are_legs_exposed = TRUE
 	fall_off_if_missing_arms = TRUE
+	has_engine = FALSE
+	waddles = FALSE
 
 /obj/vehicle/ridden/scooter/Initialize(mapload)
 	. = ..()

--- a/code/modules/vehicles/secway.dm
+++ b/code/modules/vehicles/secway.dm
@@ -8,6 +8,7 @@
 	armor = list("melee" = 20, "bullet" = 15, "laser" = 10, "energy" = 0, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60, "stamina" = 0)
 	key_type = /obj/item/key/security
 	integrity_failure = 50
+	waddles = FALSE
 
 /obj/vehicle/ridden/secway/Initialize(mapload)
 	. = ..()

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -11,6 +11,8 @@
 	density = FALSE		//Thought I couldn't fix this one easily, phew
 	// Run speed delay is multiplied with this for vehicle move delay.
 	var/delay_multiplier = 3 //MonkeStation Edit: Better Speed
+	has_engine = FALSE
+	waddles = FALSE
 
 /obj/vehicle/ridden/wheelchair/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This makes vehicles by default rev and waddle similar to the clown car.  They're variables that can be turned off, so for instance the secway will rev but not waddle, and the bicycle will do neither

## Why It's Good For The Game

Makes vehicles more interesting and noticeable.  Also slightly disguises the clown car which may or may not lead to fun.  I felt the clown car revving and shaking wasn't necessarily idiosyncratic to it.  Sec riding down the hall revving their secway (I'm saying it's gas powered lol), or cargo ordering their ATVs and rattling down the hall amuse me.  I think it's a harmless but fun change.

## Changelog

:cl:
add: Vehicles are a bit more noisy and lively!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
