### PR TITLE
Stowaways no longer take up job slots

### DIFF
--- a/monkestation/code/datums/traits/negative.dm
+++ b/monkestation/code/datums/traits/negative.dm
@@ -52,6 +52,7 @@
 	var/mob/living/carbon/human/stowaway = quirk_holder
 	var/perpname = stowaway.name
 	var/datum/data/record/record_deletion = find_record("name", perpname, GLOB.data_core.general)
+	SSjob.FreeRole(quirk_holder.mind.assigned_role)  //open their job slot back up
 	qdel(record_deletion)
 
 /datum/quirk/unstable_ass


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This makes it so when a stowaway gets a job, their slot is refunded, so others might wind up joining as their position later.

I was initially working on this to fix a reported issue of stowaways appearing on the manifest, but as far as I can tell they do not, as is intended.

## Why It's Good For The Game

The implication is that they were stowed away, so it's logical that they wouldn't take up a job slot.  This creates potential for fun interactions, confusion and drama.

## Changelog

:cl:
tweak: Stowaways no longer take up a job slot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
