### PR TITLE
fixes cherry bombs

### DIFF
--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -203,6 +203,8 @@
 	max_integrity = 40
 	wine_power = 80
 	discovery_points = 300
+	var/fusetime = 40 //in deciseconds
+	var/fusevariance = 10
 
 /obj/item/food/grown/cherry_bomb/attack_self(mob/living/user)
 	user.visible_message("<span class='warning'>[user] plucks the stem from [src]!</span>", "<span class='userdanger'>You pluck the stem from [src], which begins to hiss loudly!</span>")
@@ -221,6 +223,9 @@
 /obj/item/food/grown/cherry_bomb/proc/prime(mob/living/lanced_by)
 	icon_state = "cherry_bomb_lit"
 	playsound(src, 'sound/effects/fuse.ogg', seed.potency, 0)
+	addtimer(CALLBACK(src,.proc/heatup),rand(fusetime-fusevariance, fusetime+fusevariance)) //heat it up after a delay with variance, there will be a double delay from the powder itself
+
+/obj/item/food/grown/cherry_bomb/proc/heatup(mob/living/lanced_by)
 	reagents.chem_temp = 1000 //Sets off the black powder
 	reagents.handle_reactions()
-
+	qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Cherry bombs were blowing up oddly after the black powder fix.  This patches that up.  They now have a random time before they ignite the powder within them, and will disappear when the powder starts to explode rather than when it ends.

## Why It's Good For The Game

Things working as intended and people not exploding at random!

## Further notes

I or someone really needs to add an effect to the black powder reaction, some visual cue after the "sparks begin flying from the black powder!" message.  It works for now but that would both add some visual flair and ensure nobody gets hit with invisible explosions.

## Changelog

:cl:
fix: cherry bombs should now work as expected
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
