### PR TITLE
Gives black powder explosions sparks

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -17,7 +17,9 @@
 /datum/chemical_reaction/reagent_explosion/in_progress_explosion/proc/move_explosion()
 	SIGNAL_HANDLER
 	if(src.holder.my_atom)
+		src.turf.remove_emitter("explosion_spark")
 		src.turf = get_turf(src.holder.my_atom)
+		src.turf.add_emitter(/obj/emitter/sparks, "explosion_spark")
 
 /datum/chemical_reaction/reagent_explosion/proc/explode(datum/reagents/holder, created_volume, delay = 0)
 	var/datum/chemical_reaction/reagent_explosion/in_progress_explosion/boom = new()
@@ -26,6 +28,7 @@
 	boom.turf = get_turf(holder.my_atom)
 	boom.lastkey = holder.my_atom?.fingerprintslast
 	if(boom.power > 0)
+		boom.turf.add_emitter(/obj/emitter/sparks, "explosion_spark")
 		RegisterSignal(boom, COMSIG_MOVABLE_MOVED, .in_progress_explosion/proc/move_explosion)
 		sleep(delay)
 		var/inside_msg
@@ -42,6 +45,7 @@
 		e.set_up(boom.power , boom.turf, 0, 0)
 		e.start()
 		holder.clear_reagents()
+		boom.turf.remove_emitter("explosion_spark")
 
 
 /datum/chemical_reaction/reagent_explosion/nitroglycerin

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -41,11 +41,11 @@
 		if(!istype(boom.holder.my_atom, /obj/machinery/plumbing)) //excludes standard plumbing equipment from spamming admins with this shit
 			message_admins("Reagent explosion reaction occurred at [ADMIN_VERBOSEJMP(boom.turf)][inside_msg]. Last Fingerprint: [touch_msg].")
 		log_game("Reagent explosion reaction occurred at [AREACOORD(boom.turf)]. Last Fingerprint: [boom.lastkey ? boom.lastkey : "N/A"]." )
+		boom.turf.remove_emitter("explosion_spark")
 		var/datum/effect_system/reagents_explosion/e = new()
 		e.set_up(boom.power , boom.turf, 0, 0)
 		e.start()
 		holder.clear_reagents()
-		boom.turf.remove_emitter("explosion_spark")
 
 
 /datum/chemical_reaction/reagent_explosion/nitroglycerin


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This adds a particle emitter to black powder-originated explosions.  It looks similar to welding tool sparks.  It should happen any time you see the message about powder throwing sparks

![image](https://user-images.githubusercontent.com/31165061/204061089-60ff8edc-1083-43c4-84d4-58164147a748.png)
Pictured: bomb igniter (top), spent bomb that was picked up and thrown after ignition (bottom), and the location where the bomb was primed and the explosion will occur (middle)

## Why It's Good For The Game

No more weird cases of invisible explosions!  You should now be able to visually see where black powder is about to explode even if the bomber and reagent container are both moved away before the boom happens.

## Changelog

:cl:
add: Black powder now means it when it says that it's throwing sparks!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
