### PR TITLE
Swaps bee's wiki to ours.

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -262,7 +262,7 @@ SERVER  byond://sage.beestation13.com:7878
 FORUMURL https://forums.beestation13.com
 
 ## Wiki address
-WIKIURL https://wiki.beestation13.com/view
+WIKIURL https://monkestation.miraheze.org/wiki/Main_Page
 
 ## Rules address
 RULESURL https://beestation13.com/rules


### PR DESCRIPTION

# About The Pull Request

Changes the wiki button to redirect users to our wiki instead of bee's one. This is the smallest PR in existence

## Why It's Good For The Game

People can actually see the content we have, instead of content we dont have

## Testing Photographs and Procedure
<details>
<summary>Testing procedure</summary>

*clicking sounds*
"Yep, it works. Probably"

</details>

## Changelog

:cl:
config: changed the wiki button to monke wiki instead of bee one.
/:cl:
