### PR TITLE
Adds nugget and corpse and lets nuggets move

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -424,6 +424,39 @@
 	to_chat(quirk_holder, "<span class='boldannounce'>Your [slot_string] has been replaced with a surplus prosthetic. It is fragile and will easily come apart under duress. Additionally, \
 	you need to use a welding tool and cables to repair it, instead of bruise packs and ointment.</span>")
 
+/datum/quirk/nugget
+	name = "Nugget"
+	desc = "An accident caused you to lose ALL of your limbs. There's no way your insurance payed for all those prosthetics!"
+	value = -1
+	var/slot_string = "limb"
+
+/datum/quirk/nugget/on_spawn()
+	var/mob/living/carbon/human/nuggeted = quirk_holder
+	for(var/X in nuggeted.bodyparts)
+		var/obj/item/bodypart/BP = X
+		if(BP.body_part != HEAD && BP.body_part != CHEST)
+			if(BP.dismemberable)
+				BP.dismember()
+	if(nuggeted.buckled)
+		nuggeted.buckled.unbuckle_mob(nuggeted)
+	nuggeted.suppress_bloodloss(1800) //stop them from bleeding out
+	nuggeted.update_body_parts(TRUE)
+
+/datum/quirk/nugget/post_add()
+	to_chat(quirk_holder, "<span class='boldannounce'>What cruel twist of fate has led to you arriving aboard a space station with no limbs?")
+
+/datum/quirk/corpse
+	name = "Corpse"
+	desc = "Something terrible happened on the shuttle to the station, you arrive dead as a doornail!"
+	value = -1
+
+/datum/quirk/corpse/post_add()
+	to_chat(quirk_holder, pick("<span class='boldannounce'>F", "<span class='boldannounce'>RIP", "<span class='boldannounce'>RIP in peace", "<span class='boldannounce'>RIP in pepperoni", "<span class='boldannounce'>You were THIS close to surviving"))
+	quirk_holder.adjustFireLoss(200)
+	quirk_holder.adjustBruteLoss(200)
+	quirk_holder.adjustToxLoss(200)
+	quirk_holder.adjustCloneLoss(200)
+
 /datum/quirk/pushover
 	name = "Pushover"
 	desc = "Your first instinct is always to let people push you around. Resisting out of grabs will take conscious effort."

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1124,7 +1124,7 @@
 	var/knockdown = IsKnockdown()
 	var/ignore_legs = get_leg_ignore()
 	var/in_stasis = IsInStasis()
-	var/canmove = !IsImmobilized() && !stun && conscious && !paralyzed && !buckled && (!stat_softcrit || !pulledby) && !chokehold && !IsFrozen() && !in_stasis && (has_arms || ignore_legs || has_legs)
+	var/canmove = !IsImmobilized() && !stun && conscious && !paralyzed && !buckled && (!stat_softcrit || !pulledby) && !chokehold && !IsFrozen() && !in_stasis
 	if(canmove)
 		mobility_flags |= MOBILITY_MOVE
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This PR adds the quirks nugget and corpse.
Nugget immediately delimbs you, so you spawn with no limbs, nearly helpless.
Corpse immediately kills you on spawn.

Delimbed creatures are now allowed to very slowly crawl, so they aren't entirely immobile.

## Why It's Good For The Game

Mainly, goon had it.

They're both very funny quirks.  They're only worth 1 point so you can't really powergame them.  They can enable some silly gimmicks.

Nuggets being able to crawl gives less of a sense of loss of control which makes it less frustrating to players.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
Spawn as a nugget, you should see (and hear) your limbs fly off.  But your bleeding will be stopped and you'll be able to crawl around.
Spawn as a corpse, you'll get to move 2-3 steps before you drop dead.

</details>

## Changelog

:cl:
add: Two new negative quirks, nugget and corpse!  Now you can roleplay your favorite dead limbless character, finally!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
