### PR TITLE
Jailbird crimes show up in memories, and Stowaway description fixed

### DIFF
--- a/monkestation/code/datums/traits/negative.dm
+++ b/monkestation/code/datums/traits/negative.dm
@@ -13,6 +13,7 @@
 
 /datum/quirk/jailbird/proc/apply_arrest(crime_name)
 	var/mob/living/carbon/human/jailbird = quirk_holder
+	jailbird.mind.store_memory("You have the law on your back because of your crime of: [crime_name]!")
 	var/crime = GLOB.data_core.createCrimeEntry(crime_name, "Galactic Crime Broadcast", "[pick(world.file2list("monkestation/strings/random_police.txt"))]", "[(rand(9)+1)] [pick("days", "weeks", "months", "years")] ago", 0)
 	var/perpname = jailbird.name
 	var/datum/data/record/jailbird_record = find_record("name", perpname, GLOB.data_core.security)
@@ -23,7 +24,7 @@
 
 /datum/quirk/stowaway
 	name = "Stowaway"
-	desc = "You wake up up inside a random locker with only a crude fake for an ID card.  You still have an employee contract on file, at least."
+	desc = "You wake up up inside a random locker with only a crude fake for an ID card."
 	value = -2
 
 /datum/quirk/stowaway/on_spawn()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This adds your jailbird crime to your notes, for easy reference.
It also fixes stowaway's description, some FANTASTIC roleplaying had led me to believe there was actually an employee record I wasn't aware of at the time.

## Why It's Good For The Game

Easy reference so people can play out gimmicks and have roleplay prompts!  Also no misleading descriptions.

## Testing Photographs and Procedure
![image](https://user-images.githubusercontent.com/31165061/208990900-59151246-9184-4cd6-8490-7d5cc9dce3d3.png)

## Changelog

:cl:
add: Jailbird crimes now get added to your memories, so you know what you're on the run for!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
