### PR TITLE
Fixes metastation's atmospheric flaps windoor

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -23017,6 +23017,11 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/door/window/eastright{
+	name = "Atmospherics Delivery";
+	req_access_txt = "24";
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
 	},


### PR DESCRIPTION

# About The Pull Request

Adds a windoor behind the plastic flaps in atmospherics

## Why It's Good For The Game

So people wont steal the hardsuit, atmospheric lockers and canisters round-start. Must have forgot that windoor while i was editing atmos a while back

## Changelog

:cl:
add: Added a windoor to metastation atmospheric flaps
/:cl:
