### PR TITLE
You now wring mops with alt-click, also speeds up mopping, allows trash bags in janibelts, adds exception_hold functionality

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -626,7 +626,7 @@
 		if(!stop_messages)
 			host.balloon_alert(M, "It doesn't fit")
 		return FALSE
-	if(I.w_class > max_w_class)
+	if((I.w_class > max_w_class) && !is_type_in_typecache(I, exception_hold))
 		if(!stop_messages)
 			host.balloon_alert(M, "[I] is too big")
 		return FALSE

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -18,7 +18,7 @@
 	var/mopping = 0
 	var/mopcount = 0
 	var/mopcap = 100 //MONKESTATION EDIT CHANGE
-	var/mopspeed = 15
+	var/mopspeed = 8
 	var/insertable = TRUE
 
 /obj/item/mop/Initialize(mapload)
@@ -85,7 +85,7 @@
 
 	var/turf/T = get_turf(A)
 
-	if(istype(A, /obj/item/reagent_containers/glass/bucket) || istype(A, /obj/structure/janitorialcart))
+	if(istype(A, /obj/item/reagent_containers/glass/bucket) || istype(A, /obj/structure/janitorialcart) || istype(A, /obj/structure/mopbucket))
 		return
 
 	if(T)
@@ -126,7 +126,7 @@
 	force = 12
 	throwforce = 14
 	throw_range = 4
-	mopspeed = 8
+	mopspeed = 4
 	var/refill_enabled = TRUE //Self-refill toggle for when a janitor decides to mop with something other than water.
 	/// Amount of reagent to refill per second
 	var/refill_rate = 0.5

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -102,6 +102,10 @@
 	else
 		return ..()
 
+/obj/item/mop/examine(mob/user)
+	. = ..()
+	. += span_info("<b>Alt-click</b> a bucket to wring out the fluids.")
+
 
 /obj/item/mop/proc/janicart_insert(mob/user, obj/structure/janitorialcart/J)
 	if(insertable)

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -622,6 +622,7 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_items = 6
 	STR.max_w_class = WEIGHT_CLASS_BULKY // Set to this so the  light replacer can fit.
+	STR.allow_big_nesting = TRUE //This allows the trashbag to fit
 	STR.can_hold = typecacheof(list(
 		/obj/item/grenade/chem_grenade,
 		/obj/item/lightreplacer,
@@ -635,7 +636,11 @@
 		/obj/item/melee/flyswatter,
 		/obj/item/assembly/mousetrap,
 		/obj/item/paint/paint_remover,
-		/obj/item/pushbroom
+		/obj/item/pushbroom,
+		/obj/item/storage/bag/trash
+		))
+	STR.exception_hold = typecacheof(list(
+		/obj/item/storage/bag/trash
 		))
 
 /obj/item/storage/belt/janitor/full/PopulateContents()

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -52,7 +52,7 @@
 		. += span_info("<b>Click</b> with a mop to wet it.")
 		. += span_info("<b>Crowbar</b> it to empty it onto [get_turf(src)].")
 	if(!mymop)
-		. += span_info("<b>Click</b> with a dry mop to store it in [src]")
+		. += span_info("<b>Click</b> with a mop to store it in [src]")
 	if(mybag)
 		. += span_info("<b>Click</b> with an object to put it in [mybag].")
 

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -23,8 +23,6 @@
 	var/signs = 0
 	//The max amount of signs the cart can store
 	var/max_signs = 4
-	//Allows for mop to insert into cart after drying
-	var/mop_insert_double_click = FALSE
 
 
 /obj/structure/janitorialcart/Initialize(mapload)
@@ -48,7 +46,7 @@
 	. = ..()
 	if(broken)
 		return
-	. += span_info("<b>Click</b> with a wet mop to wring out the fluids into the mop bucket.")
+	. += span_info("<b>Alt-click</b> with a wet mop to wring out the fluids into the mop bucket.")
 	if(reagents.total_volume > 1)
 		. += span_info("There is currently [reagents.total_volume] units in [src].")
 		. += span_info("<b>Click</b> with a mop to wet it.")
@@ -61,14 +59,12 @@
 /obj/structure/janitorialcart/proc/wet_mop(obj/item/mop/your_mop, mob/user)
 	if(reagents.total_volume < 1)
 		to_chat(user, span_warning("[src]'s mop bucket is empty!"))
-		mop_insert_double_click = TRUE
 		update_icon()
 		return FALSE
 	else
 		reagents.trans_to(your_mop, your_mop.mopcap, transfered_by = user)
 		to_chat(user, span_notice("You wet [your_mop] in [src]."))
 		playsound(loc, 'sound/effects/slosh.ogg', 25, TRUE)
-		mop_insert_double_click = FALSE
 	update_icon()
 	return TRUE
 
@@ -82,7 +78,6 @@
 	your_mop.reagents.trans_to(src, reagents.maximum_volume, transfered_by = user)
 	to_chat(user, span_notice("You wring [your_mop] out into the mop bucket using the wringer."))
 	playsound(loc, 'sound/effects/slosh.ogg', 25, TRUE)
-	mop_insert_double_click = TRUE
 	update_icon()
 	return TRUE
 
@@ -179,20 +174,13 @@
 			return
 
 		var/obj/item/mop/your_mop = Item
-		if(your_mop.reagents.total_volume <= 20 && mop_insert_double_click == TRUE)
-			mymop = Item
-			mop_insert_double_click = FALSE
-			if(!put_in_cart(Item, user))
-				mymop = null
-			return
-
-		if(your_mop.reagents.total_volume >= 20 && mop_insert_double_click == FALSE)
-			if(dry_mop(your_mop, user))
-				return
-
 		if(your_mop.reagents.total_volume <= your_mop.reagents.maximum_volume)
 			if(wet_mop(your_mop, user))
 				return
+			else
+				mymop = Item
+				if(!put_in_cart(Item, user))
+					mymop = null
 
 		return
 
@@ -249,6 +237,11 @@
 		return FALSE //so we can fill the cart via our afterattack without bludgeoning it
 
 	return ..()
+
+/obj/structure/janitorialcart/AltClick(mob/living/user)
+	var/obj/item/mop/held_mop = user.get_active_held_item()
+	dry_mop(held_mop, user)
+	.=..()
 
 /obj/structure/janitorialcart/crowbar_act(mob/living/user, obj/item/Crowbar)
 	..()

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -48,17 +48,21 @@
 				playsound(loc, 'sound/effects/slosh.ogg', 25, TRUE)
 				update_icon()
 				return
+	else
+		..()
+
+/obj/structure/mopbucket/AltClick(mob/living/user)
+	var/obj/item/mop/held_mop = user.get_active_held_item()
+	if(istype(held_mop, /obj/item/mop) && user.CanReach(src))
 		if(reagents.total_volume == reagents.maximum_volume)
 			to_chat(user, "<span class='warning'>[src] is full!</span>")
 			return
-		Item.reagents.remove_any(Item.reagents.total_volume*0.5)
-		Item.reagents.trans_to(src, reagents.total_volume, transfered_by = user)
-		to_chat(user, "<span class='notice'>You squeeze the liquids from [Item] to [src].</span>")
+		held_mop.reagents.remove_any(held_mop.reagents.total_volume*0.5)
+		held_mop.reagents.trans_to(src, held_mop.reagents.total_volume, transfered_by = user)
+		to_chat(user, "<span class='notice'>You squeeze the liquids from [held_mop] to [src].</span>")
 		playsound(loc, 'sound/effects/slosh.ogg', 25, TRUE)
 		update_icon()
-		return
-	else
-		..()
+	.=..()
 
 /obj/structure/mopbucket/crowbar_act(mob/living/user, obj/item/Item)
 	..()

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -251,22 +251,15 @@
 
 /obj/item/reagent_containers/glass/bucket/attackby(obj/O, mob/living/user, params) //MONKESTATION EDIT CHANGE
 	if(istype(O, /obj/item/mop)) //MONKESTATION EDIT CHANGE
-		if(O.reagents.total_volume == 0)
+		if(O.reagents.total_volume < O.reagents.maximum_volume)
 			if(reagents.total_volume < 1)
 				to_chat(user, "<span class='warning'>[src] is out of water!</span>")
 				return
 			else
 				reagents.trans_to(O, 5, transfered_by = user)
 				to_chat(user, "<span class='notice'>You wet [O] in [src].</span>")
-				playsound(loc, 'sound/effects/slosh.ogg', 25, TRUE) //MONKESTATION EDIT CHANGE END
+				playsound(loc, 'sound/effects/slosh.ogg', 25, TRUE)
 				return
-		if(reagents.total_volume == reagents.maximum_volume)
-			to_chat(user, "<span class='warning'>[src] is full!</span>")
-			return
-		O.reagents.remove_any(O.reagents.total_volume*SQUEEZING_DISPERSAL_PERCENT)
-		O.reagents.trans_to(src, O.reagents.total_volume, transfered_by = user)
-		to_chat(user, "<span class='notice'>You squeeze the liquids from [O] to [src].</span>")
-
 	else if(isprox(O))
 		to_chat(user, "<span class='notice'>You add [O] to [src].</span>")
 		qdel(O)
@@ -274,7 +267,21 @@
 		user.put_in_hands(new /obj/item/bot_assembly/cleanbot)
 	else
 		..()
+
+/obj/item/reagent_containers/glass/bucket/AltClick(mob/living/user)
+	var/obj/item/mop/held_mop = user.get_active_held_item()
+	if(istype(held_mop, /obj/item/mop) && user.CanReach(src))
+		if(reagents.total_volume == reagents.maximum_volume)
+			to_chat(user, "<span class='warning'>[src] is full!</span>")
+			return
+		held_mop.reagents.remove_any(held_mop.reagents.total_volume*SQUEEZING_DISPERSAL_PERCENT)
+		held_mop.reagents.trans_to(src, held_mop.reagents.total_volume, transfered_by = user)
+		to_chat(user, "<span class='notice'>You squeeze the liquids from [held_mop] to [src].</span>")
+		playsound(loc, 'sound/effects/slosh.ogg', 25, TRUE)
+	.=..()	//MONKESTATION EDIT CHANGE END
+
 #undef SQUEEZING_DISPERSAL_PERCENT //MONKESTATION EDIT ADDITION
+
 /obj/item/reagent_containers/glass/bucket/equipped(mob/user, slot)
 	..()
 	if (slot == ITEM_SLOT_HEAD)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This PR does some janitor related things
- Mops are now wrung dry with alt-click, left-click wets them, and stores them in the case of the janicart
- Trash bags now fit in janibelts making the "nomad janitor" playstyle easier
- Mopping is now faster, to help compete with the instant methods of cleaning tiles

It also cleans up a couple things, exception_hold should actually do something now.  The mopbucket should behave slightly better when wetting a mop.

## Why It's Good For The Game

Janitor needs love too!  And I was seeing complaints about the janicart-mop interactions being unintuitive and difficult.

As for the trash bag, when I would play janitor without a cart I would wind up with a bag on my belt and two belts in my backpack which was just a nightmare to navigate.  This will make it far far easier.  I've heard at least one other person ask for this change as well.

## Changelog

:cl:
add: You now dry mops with alt-click, which should hopefully make the janicart a bit more intuitive to use!
add: Mops are much faster than they used to be!
add: Trash bags now fit in janibelts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
