### PR TITLE
fixes car waddling

### DIFF
--- a/code/modules/vehicles/ridden.dm
+++ b/code/modules/vehicles/ridden.dm
@@ -50,7 +50,7 @@
 
 /obj/vehicle/ridden/post_buckle_mob(mob/living/M)
 	add_occupant(M)
-	if(has_engine)
+	if(waddles)
 		M.AddComponent(/datum/component/waddling)
 	return ..()
 

--- a/code/modules/vehicles/secway.dm
+++ b/code/modules/vehicles/secway.dm
@@ -8,7 +8,6 @@
 	armor = list("melee" = 20, "bullet" = 15, "laser" = 10, "energy" = 0, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60, "stamina" = 0)
 	key_type = /obj/item/key/security
 	integrity_failure = 50
-	waddles = FALSE
 
 /obj/vehicle/ridden/secway/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

A minor fuckup with car waddling had resulted in secways causing the rider to waddle but NOT the car.  This is fixed.  Also secways are made to fully waddle, on request from the players!

</details>

## Changelog

:cl:
fix: cars should waddle more consistently
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
