### PR TITLE
Changes CACHE_ASSETS val to 0 in config.txt

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -606,4 +606,4 @@ ELASTICSEARCH_METRICS_APIKEY thisIsSomethingThatsBased64Encoded==
 ## The cache is assumed to be cleared by TGS recompiling, which deletes `tmp`.
 ## This should be disabled (through `CACHE_ASSETS 0`) on development,
 ## but enabled on production (the default).
-CACHE_ASSETS 1
+CACHE_ASSETS 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
* Changes CACHE_ASSETS val to 0 in config.txt
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
it is supposed to be 0 in general, and disabling it every time when dev environment is supposed to change is kinda shit
and I am 100% sure you didn't know you shouldn't enable it as default.

server op is supposed to turn it on their server side, otherwise, it should be 0 on dev side

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
It's hard to show what's difference.
Original TG PR has it as 0, and this PR is just matching it. (https://github.com/tgstation/tgstation/pull/63503)

## Changelog

:cl:
config: CACHE_ASSETS is set to 0. server op should set it to 1 in config.txt if you're operating a real server. for devs, it should be 0.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
