### PR TITLE
Ventcrawling Pipevision light refactor

### DIFF
--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -103,12 +103,12 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 	// 			pipes_shown += A.pipe_vision_img
 
 	if(client)
-		for(var/obj/machinery/atmospherics/member in range(4,get_turf(src)))
+		for(var/obj/machinery/atmospherics/member in range(8,get_turf(src)))
 			if(!istype(member))
 				continue
 			// if(in_view_range(client.mob, member))
 			if(member in totalMembers)
-				to_chat(world,"[member]")
+				// to_chat(world,"[member]")
 				if(!member.pipe_vision_img)
 					member.pipe_vision_img = image(member, member.loc, dir = member.dir)
 					member.pipe_vision_img.plane = ABOVE_HUD_PLANE

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -94,8 +94,6 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 
 	if(client) //MONKESTATION EDIT: Refactors Ventcawling to be less laggy
 		for(var/obj/machinery/atmospherics/member in range(8,get_turf(src)))
-			if(!istype(member))
-				continue
 			if(member in totalMembers)
 				if(!member.pipe_vision_img)
 					member.pipe_vision_img = image(member, member.loc, dir = member.dir)

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -92,23 +92,11 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 	if(!totalMembers.len)
 		return
 
-	// if(client)
-	// 	for(var/X in totalMembers)
-	// 		var/obj/machinery/atmospherics/A = X //all elements in totalMembers are necessarily of this type.
-	// 		if(in_view_range(client.mob, A))
-	// 			if(!A.pipe_vision_img)
-	// 				A.pipe_vision_img = image(A, A.loc, dir = A.dir)
-	// 				A.pipe_vision_img.plane = ABOVE_HUD_PLANE
-	// 			client.images += A.pipe_vision_img
-	// 			pipes_shown += A.pipe_vision_img
-
 	if(client)
 		for(var/obj/machinery/atmospherics/member in range(8,get_turf(src)))
 			if(!istype(member))
 				continue
-			// if(in_view_range(client.mob, member))
 			if(member in totalMembers)
-				// to_chat(world,"[member]")
 				if(!member.pipe_vision_img)
 					member.pipe_vision_img = image(member, member.loc, dir = member.dir)
 					member.pipe_vision_img.plane = ABOVE_HUD_PLANE
@@ -119,8 +107,6 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 
 /mob/living/proc/remove_ventcrawl()
 	if(client)
-		// for(var/image/current_image in pipes_shown)
-		// 	client.images -= current_image
 		client.images -= pipes_shown
 	pipes_shown.len = 0
 	setMovetype(movement_type & ~VENTCRAWLING)

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -92,7 +92,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 	if(!totalMembers.len)
 		return
 
-	if(client)
+	if(client) //MONKESTATION EDIT: Refactors Ventcawling to be less laggy
 		for(var/obj/machinery/atmospherics/member in range(8,get_turf(src)))
 			if(!istype(member))
 				continue

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -92,22 +92,36 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 	if(!totalMembers.len)
 		return
 
+	// if(client)
+	// 	for(var/X in totalMembers)
+	// 		var/obj/machinery/atmospherics/A = X //all elements in totalMembers are necessarily of this type.
+	// 		if(in_view_range(client.mob, A))
+	// 			if(!A.pipe_vision_img)
+	// 				A.pipe_vision_img = image(A, A.loc, dir = A.dir)
+	// 				A.pipe_vision_img.plane = ABOVE_HUD_PLANE
+	// 			client.images += A.pipe_vision_img
+	// 			pipes_shown += A.pipe_vision_img
+
 	if(client)
-		for(var/X in totalMembers)
-			var/obj/machinery/atmospherics/A = X //all elements in totalMembers are necessarily of this type.
-			if(in_view_range(client.mob, A))
-				if(!A.pipe_vision_img)
-					A.pipe_vision_img = image(A, A.loc, dir = A.dir)
-					A.pipe_vision_img.plane = ABOVE_HUD_PLANE
-				client.images += A.pipe_vision_img
-				pipes_shown += A.pipe_vision_img
+		for(var/obj/machinery/atmospherics/member in range(4,get_turf(src)))
+			if(!istype(member))
+				continue
+			// if(in_view_range(client.mob, member))
+			if(member in totalMembers)
+				to_chat(world,"[member]")
+				if(!member.pipe_vision_img)
+					member.pipe_vision_img = image(member, member.loc, dir = member.dir)
+					member.pipe_vision_img.plane = ABOVE_HUD_PLANE
+				client.images += member.pipe_vision_img
+				pipes_shown += member.pipe_vision_img
 	setMovetype(movement_type | VENTCRAWLING)
 
 
 /mob/living/proc/remove_ventcrawl()
 	if(client)
-		for(var/image/current_image in pipes_shown)
-			client.images -= current_image
+		// for(var/image/current_image in pipes_shown)
+		// 	client.images -= current_image
+		client.images -= pipes_shown
 	pipes_shown.len = 0
 	setMovetype(movement_type & ~VENTCRAWLING)
 


### PR DESCRIPTION
# About The Pull Request

I doubt I did this the best way possible, but it's better than it was before (i hope).

Before it would run in_view_range() (which would also run getviewsize()) on every single pipe in the pipenet, every single time someone moved inside the vents.

With my approach, it replaces all that with a range() check and just matches it against the pipenet list, making it check if(member in totalMembers) ~20 ish times on average rather than in_view_range() ~208 times every time someone moved.

I don't doubt someone more experienced with optimizing stuff could find a way to remove even more unneeded stuff, but this is over 10x better than nothing.

(This is all based on the assumption the "in" in byond isn't horribly optimized, which I would totally expect to just be like that)

## Why It's Good For The Game

Less lag means more little guys crawling around in vents ( mimics :) )

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Profiler before the optimization
![image](https://user-images.githubusercontent.com/99915170/216241073-4d19fc58-6259-4a03-9b12-af8e288938e7.png)

Profiler after the optimization (it doesn't run the procs anymore)
![image](https://user-images.githubusercontent.com/99915170/216241166-b7f92527-ef65-493f-976e-d01cd6447a39.png)

</details>

## Changelog

:cl:
refactor: refactors ventcrawling to cause less lag
/:cl:
