### PR TITLE
Werebear Serum

### DIFF
--- a/beestation.dme
+++ b/beestation.dme
@@ -3761,6 +3761,7 @@
 #include "monkestation\code\game\objects\items\stickables.dm"
 #include "monkestation\code\game\objects\items\circuitboards\computer_circuitboards.dm"
 #include "monkestation\code\game\objects\items\circuitboards\machine_circuitboards.dm"
+#include "monkestation\code\game\objects\items\devices\traitordevices.dm"
 #include "monkestation\code\game\objects\items\grenades\monkey_barrel.dm"
 #include "monkestation\code\game\objects\items\implants\implant_hard_spear.dm"
 #include "monkestation\code\game\objects\items\melee\misc.dm"

--- a/monkestation/code/game/objects/items/devices/traitordevices.dm
+++ b/monkestation/code/game/objects/items/devices/traitordevices.dm
@@ -1,0 +1,56 @@
+/obj/item/bearserum
+	name = "Bear Serum"
+	desc = "This serum made by BEAR Co (A group of very wealthy bears) will give other species the chance to be bear."
+	icon = 'icons/obj/items_and_weapons.dmi'
+	icon_state = "implanter0"
+	item_state = "syringe_0"
+	var/mob/living/simple_animal/hostile/bear/russian/created_bear
+
+/obj/item/bearserum/attack(mob/living/target, mob/living/user)
+	. = ..()
+	if(target != user)
+		return
+
+	created_bear = new(get_turf(target))
+	target.forceMove(created_bear)
+	target.mind.transfer_to(created_bear)
+	ADD_TRAIT(target, TRAIT_NOBREATH, "werebear_transform")
+
+	RegisterSignal(created_bear, COMSIG_MOB_DEATH, .proc/on_bear_death)
+
+	var/obj/effect/proc_holder/spell/self/werebear_revert/revert = new
+	created_bear.AddSpell(revert)
+
+	qdel(src)
+
+/obj/item/bearserum/proc/on_bear_death()
+	if(!created_bear)
+		return
+	var/mob/living/carbon/human/human_mob = locate() in created_bear
+	created_bear.mind.transfer_to(human_mob)
+	human_mob.grab_ghost()
+	human_mob.forceMove(get_turf(created_bear))
+	REMOVE_TRAIT(human_mob, TRAIT_NOBREATH, "werebear_transform")
+	created_bear.death()
+	human_mob.adjustBruteLoss(30)
+	human_mob.Knockdown(2 SECONDS)
+
+//Ability
+
+/obj/effect/proc_holder/spell/self/werebear_revert
+	name = "Revert to Self"
+	desc = "Revert to your previous, much less bearlike form."
+	action_icon = 'icons/mob/actions/actions_changeling.dmi'
+	action_icon_state = "image.png"
+	action_background_icon_state = "bg_alien"
+	human_req = FALSE
+	clothes_req = FALSE
+	charge_max = 600
+
+/obj/effect/proc_holder/spell/self/werebear_revert/cast(list/targets, mob/living/user)
+	var/mob/living/carbon/human/human_mob = locate() in user
+	user.mind.transfer_to(human_mob)
+	human_mob.grab_ghost()
+	human_mob.forceMove(get_turf(user))
+	REMOVE_TRAIT(human_mob, TRAIT_NOBREATH, "werebear_transform")
+	user.death()

--- a/monkestation/code/modules/uplink/uplink_items.dm
+++ b/monkestation/code/modules/uplink/uplink_items.dm
@@ -30,7 +30,7 @@
 	item = /obj/item/storage/box/syndie_kit/imp_hard_spear
 	cost = 10
 
-/datum/uplink_item/bearserum
+/datum/uplink_item/device_tools/bearserum
 	name = "Werebear Serum"
 	desc = "This serum made by BEAR Co (A group of very wealthy bears) will give other species the chance to be bear."
 	item = /obj/item/bearserum

--- a/monkestation/code/modules/uplink/uplink_items.dm
+++ b/monkestation/code/modules/uplink/uplink_items.dm
@@ -30,6 +30,12 @@
 	item = /obj/item/storage/box/syndie_kit/imp_hard_spear
 	cost = 10
 
+/datum/uplink_item/bearserum
+	name = "Werebear Serum"
+	desc = "This serum made by BEAR Co (A group of very wealthy bears) will give other species the chance to be bear."
+	item = /obj/item/bearserum
+	cost = 12
+
 //Species Specific Items
 
 /datum/uplink_item/race_restricted/monkey_barrel


### PR DESCRIPTION
# About The Pull Request

Adds the Werebear Serum as a traitor uplink item.

## Why It's Good For The Game

A fun new traitor item that lets you just be a big ole goofy bear! It's also my first PR so that's cool.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://user-images.githubusercontent.com/124001098/216507602-6d3e343f-8453-4ff8-8fc7-8b5518e42486.png)


</details>

## Changelog

:cl:
add: Added Werebear Serum traitor item
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
