### PR TITLE
Couple beepsky fixes [NO GBP]

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -252,7 +252,7 @@ Auto Patrol: []"},
 	if(!C.handcuffed)
 		C.set_handcuffed(new /obj/item/restraints/handcuffs/cable/zipties/used(C))
 		C.update_handcuffed()
-		if(EMAGGED && prob(50)) //if it's emagged, there's a chance it'll play a special sound instead
+		if(emagged == 1  && prob(50)) //if it's emagged, there's a chance it'll play a special sound instead
 			playsound(src, emagsounds, 50, 0)
 		else
 			playsound(src, arrestsounds, 50, 0)//monkestation edit for custom arrest sounds

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -295,7 +295,7 @@ Auto Patrol: []"},
 
 			SSmove_manager.stop_looping(src)
 			look_for_perp()	// see if any criminals are in range
-			if(!mode && auto_patrol)	// still idle, and set to patrol
+			if(mode == BOT_IDLE && auto_patrol)	// still idle, and set to patrol
 				mode = BOT_START_PATROL	// switch to patrol mode
 
 		if(BOT_HUNT)		// hunting for perp

--- a/monkestation/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/monkestation/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -26,8 +26,8 @@
 		playsound(src, messagevoice[message], 40, 0) //and pretty quiet
 		last_grumble_speak = world.time
 
-/mob/living/simple_animal/bot/secbot/pizzky/New()
-	..()
+/mob/living/simple_animal/bot/secbot/pizzky/Initialize(mapload)
+	. = ..()
 	last_grumble_speak = world.time //so he doesn't grumble on spawn
 	var/list/messagevoice = list("I AM NOW ALIVE AND I'M ABOUT TO MAKE IT EVERYONE ELSE'S PROBLEM!" = 'monkestation/sound/voice/pizzky/spawn1.ogg',
 								 "WHY THE FUCK WOULD YOU BUILD THIS? WHAT THE FUCK IS WRONG WITH YOU?!" = 'monkestation/sound/voice/pizzky/spawn2.ogg')


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes some beepsky related bugs

1.  Securitrons should now patrol correctly on spawn
2.  Arrest sounds were fixed -- only emagged securitrons will make the shitcuritron sounds.
3.  Fixed shitcuritron spawning, should be able to place them on the map now.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->
gib me the gbp!!!! :DD:D:D:DD:D:DDD

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
fix: Securitrons should now patrol correctly on spawn
fix: Securitrons will no longer play shitcuritron sounds when arresting people
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
