### PR TITLE
Fixes Hardlight spear typepath (1 line pr)

### DIFF
--- a/monkestation/code/modules/uplink/uplink_items.dm
+++ b/monkestation/code/modules/uplink/uplink_items.dm
@@ -23,7 +23,7 @@
 	restricted_roles = list("Stage Magician")
 	surplus = 0
 
-/datum/uplink_item/implants/freedom
+/datum/uplink_item/implants/hardlight
 	name = "Hardlight Spear Implant"
 	desc = "An implant injected into the body, and later activated at the user's will. It will summon a spear \
 			made out of hardlight that the user can use to wreak havoc."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

My first pr was a little wrong

## Why It's Good For The Game

I haven't heard anyone mention it so I have no idea but it's possible that this just got rid of freedom implants from the uplink lol. or even if it didnt, the type paths shouldn't be the same.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
fix: fixes hardlight spear's uplink type path
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
