### PR TITLE
Space ruins and GPS

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/DJstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation.dmm
@@ -372,6 +372,12 @@
 /obj/structure/disposaloutlet,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"hN" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/djstation)
 "Co" = (
 /obj/machinery/door/airlock/external{
 	name = "Ruskie DJ Station"
@@ -539,7 +545,7 @@ ac
 ac
 ac
 ag
-ah
+hN
 ah
 ah
 am

--- a/_maps/RandomRuins/SpaceRuins/Fast_Food.dmm
+++ b/_maps/RandomRuins/SpaceRuins/Fast_Food.dmm
@@ -986,6 +986,12 @@
 /obj/item/toy/figure/md,
 /turf/open/floor/plasteel/cafeteria,
 /area/ruin/space/has_grav/powered/macspace)
+"lK" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/space/has_grav/powered/macspace)
 "mo" = (
 /obj/structure/chair/stool/bar,
 /obj/item/toy/figure/engineer,
@@ -1529,7 +1535,7 @@ ae
 af
 aj
 al
-ag
+lK
 ag
 aW
 ag

--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -3375,7 +3375,7 @@
 "lq" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker{
-	list_reagents = list(/datum/reagent/toxin/acid = 50)
+	list_reagents = list(/datum/reagent/toxin/acid=50)
 	},
 /obj/item/paper/crumpled/bloody/ruins/thederelict/unfinished,
 /obj/item/pen,
@@ -4519,6 +4519,12 @@
 "Tm" = (
 /turf/open/floor/plating/airless,
 /area/ruin/space/derelict/hallway/primary/port)
+"Uo" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/derelict/arrival)
 "Uz" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -13188,7 +13194,7 @@ ir
 hf
 gW
 gW
-hf
+Uo
 hf
 hf
 kk

--- a/_maps/RandomRuins/SpaceRuins/abandonedteleporter.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedteleporter.dmm
@@ -78,6 +78,9 @@
 "r" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/beacon,
+/obj/item/gps{
+	gpstag = "Signal"
+	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/abandoned_tele)
 "s" = (

--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -881,6 +881,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/abandonedzoo)
+"En" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/abandonedzoo)
 "Hx" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Bio Containment";
@@ -1102,7 +1118,7 @@ ay
 ay
 aO
 ay
-ay
+En
 tP
 ay
 ay

--- a/_maps/RandomRuins/SpaceRuins/asteroid10.dmm
+++ b/_maps/RandomRuins/SpaceRuins/asteroid10.dmm
@@ -255,6 +255,12 @@
 /obj/item/food/nugget/dog,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/powered)
+"Nr" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/wood,
+/area/ruin/space/has_grav/powered)
 
 (1,1,1) = {"
 aa
@@ -873,7 +879,7 @@ ad
 ad
 ad
 aK
-ae
+Nr
 ae
 bh
 aw

--- a/_maps/RandomRuins/SpaceRuins/asteroid3.dmm
+++ b/_maps/RandomRuins/SpaceRuins/asteroid3.dmm
@@ -19,6 +19,12 @@
 /obj/item/pickaxe/diamond,
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/unpowered/no_grav)
+"k" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/ruin/unpowered/no_grav)
 
 (1,1,1) = {"
 a
@@ -191,7 +197,7 @@ c
 b
 b
 e
-b
+k
 b
 b
 c

--- a/_maps/RandomRuins/SpaceRuins/asteroid4.dmm
+++ b/_maps/RandomRuins/SpaceRuins/asteroid4.dmm
@@ -57,6 +57,9 @@
 /obj/item/storage/pod{
 	pixel_x = -26
 	},
+/obj/item/gps{
+	gpstag = "SOS"
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/ruin/unpowered)
 "o" = (

--- a/_maps/RandomRuins/SpaceRuins/asteroid9.dmm
+++ b/_maps/RandomRuins/SpaceRuins/asteroid9.dmm
@@ -19,6 +19,12 @@
 /obj/effect/decal/remains/robot,
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/unpowered)
+"Q" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/ruin/unpowered)
 
 (1,1,1) = {"
 a
@@ -287,7 +293,7 @@ d
 d
 b
 d
-d
+Q
 d
 b
 c

--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -2236,6 +2236,17 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/derelictoutpost)
+"XA" = (
+/obj/structure/alien/weeds{
+	color = "#4BAE56";
+	desc = "A thick gelatinous surface covers the floor.  Someone get the golashes.";
+	name = "gelatinous floor"
+	},
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/derelictoutpost)
 
 (1,1,1) = {"
 aa
@@ -3263,7 +3274,7 @@ bj
 cz
 bF
 ci
-bl
+XA
 dm
 dC
 dC

--- a/_maps/RandomRuins/SpaceRuins/bus.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bus.dmm
@@ -334,6 +334,12 @@
 /obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/unpowered/no_grav)
+"cz" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/ruin/unpowered/no_grav)
 "XA" = (
 /obj/structure/fluff/bus/passable/seat{
 	icon_state = "backseat"
@@ -518,7 +524,7 @@ ao
 aA
 aJ
 aQ
-ad
+cz
 aX
 ad
 ad

--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -983,6 +983,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/item/gps{
+	gpstag = "Signal"
+	},
 /turf/open/floor/plasteel{
 	initial_gas_mix = "TEMP=2.7"
 	},

--- a/_maps/RandomRuins/SpaceRuins/cloning_facility.dmm
+++ b/_maps/RandomRuins/SpaceRuins/cloning_facility.dmm
@@ -339,6 +339,15 @@
 "V" = (
 /turf/closed/wall/r_wall/rust,
 /area/space/nearstation)
+"W" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/powered/ancient_shuttle)
 
 (1,1,1) = {"
 a
@@ -445,7 +454,7 @@ b
 b
 u
 I
-I
+W
 c
 a
 a

--- a/_maps/RandomRuins/SpaceRuins/clownplanet.dmm
+++ b/_maps/RandomRuins/SpaceRuins/clownplanet.dmm
@@ -375,6 +375,12 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating/asteroid,
 /area/ruin/powered/clownplanet)
+"ck" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/engine,
+/area/ruin/powered/clownplanet)
 
 (1,1,1) = {"
 aa
@@ -692,7 +698,7 @@ ae
 ae
 ac
 ah
-ag
+ck
 aN
 aL
 aj

--- a/_maps/RandomRuins/SpaceRuins/crashedclownship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedclownship.dmm
@@ -157,6 +157,12 @@
 /obj/item/shovel,
 /turf/open/floor/mineral/bananium/airless,
 /area/ruin/unpowered)
+"A" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/mineral/bananium/airless,
+/area/ruin/unpowered)
 
 (1,1,1) = {"
 a
@@ -527,7 +533,7 @@ a
 d
 g
 h
-h
+A
 v
 x
 d

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -21,6 +21,12 @@
 /obj/effect/gibspawner/generic,
 /turf/open/floor/plating/asteroid/airless,
 /area/awaymission/BMPship)
+"bu" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/awaymission/BMPship/Aft)
 "bS" = (
 /obj/item/shard{
 	icon_state = "medium"
@@ -4534,7 +4540,7 @@ Br
 lA
 lA
 lA
-lA
+bu
 kC
 lA
 qq

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -2586,7 +2586,7 @@
 	input_tag = "o2_in_bunker";
 	name = "Oxygen Supply Control";
 	output_tag = "o2_out_bunker";
-	sensors = list("o2_sensor_bunker" = "Tank")
+	sensors = list("o2_sensor_bunker"="Tank")
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -2947,7 +2947,7 @@
 	input_tag = "n2_in_bunker";
 	name = "Nitrogen Supply Control";
 	output_tag = "n2_out_bunker";
-	sensors = list("n2_sensor_bunker" = "Tank")
+	sensors = list("n2_sensor_bunker"="Tank")
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -3304,6 +3304,13 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/crusher)
+"FJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/deepstorage/airlock)
 "Rs" = (
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -4535,7 +4542,7 @@ dX
 eq
 eI
 eU
-fi
+FJ
 ft
 eq
 hn

--- a/_maps/RandomRuins/SpaceRuins/derelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict1.dmm
@@ -79,6 +79,13 @@
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered)
+"Q" = (
+/obj/structure/alien/weeds,
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
 
 (1,1,1) = {"
 a
@@ -679,7 +686,7 @@ f
 f
 f
 f
-f
+Q
 f
 f
 f

--- a/_maps/RandomRuins/SpaceRuins/derelict2.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict2.dmm
@@ -103,6 +103,12 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/dinner_for_two)
+"Q" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/powered/dinner_for_two)
 
 (1,1,1) = {"
 a
@@ -266,7 +272,7 @@ i
 i
 i
 n
-i
+Q
 i
 i
 c

--- a/_maps/RandomRuins/SpaceRuins/derelict3.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict3.dmm
@@ -17,6 +17,12 @@
 /obj/structure/lattice,
 /turf/template_noop,
 /area/space/nearstation)
+"E" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered/no_grav)
 
 (1,1,1) = {"
 a
@@ -607,7 +613,7 @@ d
 d
 b
 c
-b
+E
 b
 b
 b

--- a/_maps/RandomRuins/SpaceRuins/derelict4.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict4.dmm
@@ -86,6 +86,12 @@
 /obj/structure/girder,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered)
+"G" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/mineral/titanium/blue/airless,
+/area/ruin/unpowered)
 "P" = (
 /turf/closed/mineral,
 /area/ruin/unpowered)
@@ -772,7 +778,7 @@ c
 c
 e
 h
-h
+G
 h
 h
 e

--- a/_maps/RandomRuins/SpaceRuins/derelict5.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict5.dmm
@@ -66,6 +66,12 @@
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
+"P" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
 "V" = (
 /turf/closed/mineral,
 /area/ruin/unpowered/no_grav)
@@ -648,7 +654,7 @@ g
 i
 i
 m
-g
+P
 f
 g
 g

--- a/_maps/RandomRuins/SpaceRuins/derelict6.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict6.dmm
@@ -503,6 +503,12 @@
 	},
 /turf/template_noop,
 /area/ruin/unpowered)
+"WD" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/unpowered)
 
 (1,1,1) = {"
 aa
@@ -765,7 +771,7 @@ ag
 an
 ag
 ag
-ag
+WD
 ag
 ai
 aL

--- a/_maps/RandomRuins/SpaceRuins/emptyshell.dmm
+++ b/_maps/RandomRuins/SpaceRuins/emptyshell.dmm
@@ -53,6 +53,12 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
+"D" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
 "Q" = (
 /obj/structure/lattice,
 /turf/template_noop,
@@ -206,7 +212,7 @@ d
 d
 d
 d
-d
+D
 c
 c
 a

--- a/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gasthelizards.dmm
@@ -364,6 +364,12 @@
 "W" = (
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/gasthelizard)
+"Y" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plasteel/airless/dark,
+/area/ruin/space/has_grav/gasthelizard)
 "Z" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -634,7 +640,7 @@ a
 b
 c
 o
-r
+Y
 y
 D
 I

--- a/_maps/RandomRuins/SpaceRuins/gondolaasteroid.dmm
+++ b/_maps/RandomRuins/SpaceRuins/gondolaasteroid.dmm
@@ -91,6 +91,12 @@
 	},
 /turf/open/floor/plating/asteroid/airless,
 /area/ruin/space/has_grav)
+"Z" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plating/asteroid/airless,
+/area/ruin/space/has_grav)
 
 (1,1,1) = {"
 a
@@ -740,7 +746,7 @@ b
 b
 b
 b
-c
+Z
 c
 c
 c

--- a/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
@@ -202,6 +202,15 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/ruin/unpowered/no_grav)
+"M" = (
+/obj/structure/table/glass,
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plasteel/grimy{
+	icon_state = "engine"
+	},
+/area/ruin/space/has_grav/hilbertresearchfacility)
 "U" = (
 /turf/open/floor/plasteel/stairs/medium{
 	initial_gas_mix = "TEMP=2.7"
@@ -756,7 +765,7 @@ g
 q
 g
 y
-g
+M
 f
 e
 f

--- a/_maps/RandomRuins/SpaceRuins/intactemptyship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/intactemptyship.dmm
@@ -146,6 +146,13 @@
 /obj/structure/bed,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/space/has_grav/powered/authorship)
+"R" = (
+/obj/structure/table/wood,
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/mineral/titanium/purple,
+/area/ruin/space/has_grav/powered/authorship)
 
 (1,1,1) = {"
 a
@@ -209,7 +216,7 @@ h
 y
 c
 h
-n
+R
 c
 "}
 (6,1,1) = {"

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -434,6 +434,9 @@
 /area/ruin/space/has_grav/listeningstation)
 "aI" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/item/gps{
+	gpstag = "Signal"
+	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/listeningstation)
 "aJ" = (

--- a/_maps/RandomRuins/SpaceRuins/mechtransport.dmm
+++ b/_maps/RandomRuins/SpaceRuins/mechtransport.dmm
@@ -79,6 +79,9 @@
 /area/ruin/space/has_grav/powered/mechtransport)
 "u" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/gps{
+	gpstag = "Signal"
+	},
 /turf/open/floor/mineral/titanium/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
 "v" = (

--- a/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
@@ -905,6 +905,12 @@
 /obj/machinery/teleport/hub,
 /turf/open/floor/plating,
 /area/tcommsat/oldaisat)
+"ST" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plasteel/airless/dark,
+/area/tcommsat/oldaisat)
 
 (1,1,1) = {"
 aa
@@ -2646,7 +2652,7 @@ ac
 bU
 bZ
 ce
-bw
+ST
 ac
 ag
 cn

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -5194,6 +5194,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation)
+"Qc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/ancientstation/engi)
 "Ql" = (
 /obj/machinery/door/airlock,
 /turf/open/floor/plating,
@@ -6557,7 +6565,7 @@ em
 fF
 gl
 em
-em
+Qc
 hP
 em
 iw

--- a/_maps/RandomRuins/SpaceRuins/oldteleporter.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldteleporter.dmm
@@ -68,6 +68,12 @@
 	},
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/oldteleporter)
+"U" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/oldteleporter)
 
 (1,1,1) = {"
 a
@@ -203,7 +209,7 @@ b
 c
 d
 f
-e
+U
 j
 e
 e

--- a/_maps/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/RandomRuins/SpaceRuins/onehalf.dmm
@@ -329,6 +329,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/item/gps{
+	gpstag = "Signal"
+	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/onehalf/drone_bay)
 "aZ" = (

--- a/_maps/RandomRuins/SpaceRuins/originalcontent.dmm
+++ b/_maps/RandomRuins/SpaceRuins/originalcontent.dmm
@@ -914,6 +914,15 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/indestructible/paper,
 /area/ruin/powered)
+"Ky" = (
+/obj/structure/fluff/paper{
+	dir = 4
+	},
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/indestructible/paper,
+/area/ruin/powered)
 
 (1,1,1) = {"
 aa
@@ -2288,7 +2297,7 @@ az
 af
 af
 am
-aq
+Ky
 aq
 aT
 af

--- a/_maps/RandomRuins/SpaceRuins/power_puzzle.dmm
+++ b/_maps/RandomRuins/SpaceRuins/power_puzzle.dmm
@@ -879,6 +879,13 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/storage/power2)
+"kJ" = (
+/obj/effect/decal/cleanable/generic,
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/storage/central)
 "Ce" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1207,7 +1214,7 @@ bs
 bp
 bp
 bp
-cN
+kJ
 cO
 bp
 aY

--- a/_maps/RandomRuins/SpaceRuins/scav_mining.dmm
+++ b/_maps/RandomRuins/SpaceRuins/scav_mining.dmm
@@ -184,6 +184,12 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/powered)
+"O" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/powered)
 
 (1,1,1) = {"
 a
@@ -459,7 +465,7 @@ b
 b
 b
 o
-q
+O
 v
 q
 z

--- a/_maps/RandomRuins/SpaceRuins/shuttlerelic.dmm
+++ b/_maps/RandomRuins/SpaceRuins/shuttlerelic.dmm
@@ -97,6 +97,15 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/oldshuttle,
 /area/ruin/powered)
+"S" = (
+/obj/structure/chair/old{
+	dir = 1
+	},
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/oldshuttle,
+/area/ruin/powered)
 
 (1,1,1) = {"
 a
@@ -224,7 +233,7 @@ i
 i
 c
 m
-m
+S
 m
 o
 m

--- a/_maps/RandomRuins/SpaceRuins/spacearcade.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacearcade.dmm
@@ -105,6 +105,12 @@
 "s" = (
 /turf/closed/mineral,
 /area/ruin/space/has_grav/powered)
+"R" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/eighties,
+/area/ruin/space/has_grav/powered)
 
 (1,1,1) = {"
 a
@@ -310,7 +316,7 @@ s
 s
 s
 b
-c
+R
 c
 c
 h

--- a/_maps/RandomRuins/SpaceRuins/spacedock13.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacedock13.dmm
@@ -92,6 +92,12 @@
 /obj/structure/statue/gold/ce,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/powered)
+"F" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/powered)
 
 (1,1,1) = {"
 a
@@ -378,7 +384,7 @@ b
 d
 d
 d
-d
+F
 b
 k
 a

--- a/_maps/RandomRuins/SpaceRuins/spacehive.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehive.dmm
@@ -12,9 +12,6 @@
 "d" = (
 /turf/open/floor/wood/airless,
 /area/ruin/unpowered)
-"e" = (
-/turf/open/floor/wood/airless,
-/area/ruin/unpowered)
 "f" = (
 /obj/machinery/door/airlock/wood,
 /obj/structure/punji_sticks,
@@ -38,14 +35,13 @@
 /obj/machinery/hydroponics,
 /turf/open/floor/wood/airless,
 /area/ruin/unpowered)
-"l" = (
-/obj/machinery/hydroponics,
-/turf/open/floor/wood/airless,
-/area/ruin/unpowered)
 "m" = (
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 11
+	},
+/obj/item/gps{
+	gpstag = "Signal"
 	},
 /turf/open/floor/wood/airless,
 /area/ruin/unpowered)
@@ -390,8 +386,8 @@ g
 b
 c
 d
-e
-e
+d
+d
 f
 j
 g
@@ -424,8 +420,8 @@ h
 g
 g
 b
-l
-l
+k
+k
 m
 b
 g

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -5008,6 +5008,12 @@
 	},
 /turf/template_noop,
 /area/ruin/unpowered/no_grav)
+"sC" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/ruin/space/has_grav/hotel/bar)
 "sN" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/structure/cable{
@@ -6706,7 +6712,7 @@ gc
 gq
 gE
 gV
-fx
+sC
 hy
 hK
 gp

--- a/_maps/RandomRuins/SpaceRuins/swarmerstation13.dmm
+++ b/_maps/RandomRuins/SpaceRuins/swarmerstation13.dmm
@@ -71,6 +71,12 @@
 /obj/item/clothing/shoes/winterboots,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered)
+"T" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
 
 (1,1,1) = {"
 a
@@ -734,7 +740,7 @@ e
 e
 e
 e
-e
+T
 c
 b
 a

--- a/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
@@ -312,6 +312,9 @@
 "aU" = (
 /obj/structure/table/reinforced,
 /obj/item/pen/blue,
+/obj/item/gps{
+	gpstag = "Signal"
+	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/turretedoutpost)
 "aV" = (

--- a/_maps/RandomRuins/SpaceRuins/vaporwave.dmm
+++ b/_maps/RandomRuins/SpaceRuins/vaporwave.dmm
@@ -208,6 +208,12 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/vaporwave,
 /area/ruin/space/has_grav/powered/aesthetic)
+"Q" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/plasteel/vaporwave,
+/area/ruin/space/has_grav/powered/aesthetic)
 "R" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -360,7 +366,7 @@ a
 d
 d
 f
-k
+Q
 k
 k
 k

--- a/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
+++ b/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
@@ -210,6 +210,12 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/mineral/titanium/white,
 /area/ruin/space/has_grav/whiteship/box)
+"Jn" = (
+/obj/item/gps{
+	gpstag = "Signal"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/ruin/space/has_grav/whiteship/box)
 "Kq" = (
 /obj/structure/light_construct/small{
 	dir = 4
@@ -868,7 +874,7 @@ Bk
 Wt
 Bk
 Kq
-Bk
+Jn
 Yr
 iw
 Bk


### PR DESCRIPTION
simple change, adds GPS that gives a non-descript "signal" to all random small sites, hopefully getting people including myself to not use docking view as a way to scan the entire map for sites, but explore them more naturally, without looking for needles in a haystack.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
all space ruins should now have GPS, will make finding them easier.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
