### PR TITLE
RD's Randomized Roundstart Reactive Rmor

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -83,8 +83,8 @@
 	excludefromjob = list("Head of Security", "Warden")
 
 /datum/objective_item/steal/reactive
-	name = "the reactive teleport armor."
-	targetitem = /obj/item/clothing/suit/armor/reactive/teleport
+	name = "the reactive armor."
+	targetitem = /obj/item/clothing/suit/armor/reactive
 	difficulty = 5
 	excludefromjob = list("Research Director")
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -13,7 +13,7 @@
 	new /obj/item/tank/internals/air(src)
 	new /obj/item/megaphone/command(src)
 	new /obj/item/storage/lockbox/medal/sci(src)
-	new /obj/item/clothing/suit/armor/reactive/teleport(src)
+	new /obj/item/reactive_armour_shell/random(src)
 	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/laser_pointer(src)
 	new /obj/item/door_remote/research_director(src)

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -4,9 +4,6 @@
 	icon_state = "reactiveoff"
 	icon = 'icons/obj/clothing/suits.dmi'
 	w_class = WEIGHT_CLASS_BULKY
-
-/obj/item/reactive_armour_shell/attackby(obj/item/I, mob/user, params)
-	..()
 	var/static/list/anomaly_armour_types = list(
 		/obj/effect/anomaly/grav	                = /obj/item/clothing/suit/armor/reactive/repulse,
 		/obj/effect/anomaly/flux 	           		= /obj/item/clothing/suit/armor/reactive/tesla,
@@ -24,6 +21,9 @@
 		//MONKESTATION EDIT END
 		)
 
+/obj/item/reactive_armour_shell/attackby(obj/item/I, mob/user, params)
+	..()
+
 	if(istype(I, /obj/item/assembly/signaler/anomaly))
 		var/obj/item/assembly/signaler/anomaly/A = I
 		var/armour_path = anomaly_armour_types[A.anomaly_type]
@@ -33,6 +33,16 @@
 		new armour_path(get_turf(src))
 		qdel(src)
 		qdel(A)
+
+/obj/item/reactive_armour_shell/random
+	name = "randomized reactive armor"
+	desc = "Oddly reality breaking. must be a bug."
+
+/obj/item/reactive_armour_shell/random/Initialize(mapload)
+	. = ..()
+	var/armour_path = anomaly_armour_types[pick(anomaly_armour_types)]
+	new armour_path(loc)
+	qdel(src)
 
 //Reactive armor
 /obj/item/clothing/suit/armor/reactive


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

Gives the RD a random reactive armor on round start (except for stealth since that's the backup anomaly type)

I don't think its too busted since the teleporting armor is already a little stronger than like half of the ones you can get.

## Why It's Good For The Game

The teleport one is boring, everyone's seen it,  let them roll the primal one some time.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
add: The RD rolls a random reactive armor on round start instead of just getting the default teleport one
/:cl: