### PR TITLE
Fixes mice losing their disease when they die

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -73,6 +73,7 @@
 			M.icon_state = icon_dead
 			M.name = name
 			M.reagents.add_reagent(/datum/reagent/blood, 2, data)
+			M.ratdisease = src.ratdisease
 			if(toast)
 				M.add_atom_colour("#3A3A3A", FIXED_COLOUR_PRIORITY)
 				M.desc = "It's toast."
@@ -177,6 +178,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 2)
 	foodtypes = GROSS | MEAT | RAW
 	w_class = WEIGHT_CLASS_TINY
+	var/list/ratdisease = list()
 	grind_results = list(/datum/reagent/blood = 20, /datum/reagent/liquidgibs = 5)
 
 
@@ -194,3 +196,12 @@
 /obj/item/food/deadmouse/on_grind()
 	.=..()
 	reagents.clear_reagents()
+
+/obj/item/food/deadmouse/extrapolator_act(mob/user, var/obj/item/extrapolator/E, scan = TRUE)
+	if(!ratdisease.len)
+		return FALSE
+	if(scan)
+		E.scan(src, ratdisease, user)
+	else
+		E.extrapolate(src, ratdisease, user)
+	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

When we updated food, dead mice were turned into food items and lost the diseases they had while living.  This makes them diseased again.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This is an integral component of virology

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:

fix: Dead mice can properly be extrapolated again for diseases.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
