### PR TITLE
Makes dusters available from secdrobes

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -35,11 +35,19 @@
 					/obj/item/clothing/under/rank/security/officer/blueshirt = 3,
 					/obj/item/clothing/under/rank/security/officer/mallcop = 3,
 					/obj/item/clothing/neck/tie/red = 6,
-					/obj/item/clothing/neck/tie/black = 6,)
+					/obj/item/clothing/neck/tie/black = 6,
+					/obj/item/clothing/suit/armor/secduster = 3,
+					/obj/item/clothing/head/helmet/hat/cowboy = 3)
 	contraband = list(/obj/item/clothing/suit/hooded/wintercoat/security/old = 3)
 	premium = list(/obj/item/clothing/under/rank/security/officer/formal = 3,
 					/obj/item/clothing/suit/security/officer = 3,
-					/obj/item/clothing/head/beret/sec/navyofficer = 3)
+					/obj/item/clothing/head/beret/sec/navyofficer = 3,
+					/obj/item/clothing/suit/armor/secduster/engineering = 2,
+					/obj/item/clothing/head/helmet/hat/cowboy/engineering = 2,
+					/obj/item/clothing/suit/armor/secduster/medical = 2,
+					/obj/item/clothing/head/helmet/hat/cowboy/medical = 2,
+					/obj/item/clothing/suit/armor/secduster/science = 2,
+					/obj/item/clothing/head/helmet/hat/cowboy/science = 2)
 	refill_canister = /obj/item/vending_refill/wardrobe/sec_wardrobe
 	payment_department = ACCOUNT_SEC
 	light_color = "#ff3300"

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -46,6 +46,9 @@
 					/obj/item/clothing/head/helmet/hat/cowboy/engineering = 2,
 					/obj/item/clothing/suit/armor/secduster/medical = 2,
 					/obj/item/clothing/head/helmet/hat/cowboy/medical = 2,
+					/obj/item/clothing/suit/armor/secduster/cargo = 2,
+					/obj/item/clothing/head/helmet/hat/cowboy/cargo = 2,
+
 					/obj/item/clothing/suit/armor/secduster/science = 2,
 					/obj/item/clothing/head/helmet/hat/cowboy/science = 2)
 	refill_canister = /obj/item/vending_refill/wardrobe/sec_wardrobe


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This adds the security dusters and cowboy hats to the secdrobes.  Department specific dusters are under premium.

## Why It's Good For The Game

We have these kickass dusters but they're only available roundstart.  This lets security and cargo supply us with more as needed!

## Changelog

:cl:
add: You can now acquire more security dusters through the secdrobe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
