### PR TITLE
Adds a few more crates!

### DIFF
--- a/monkestation/code/modules/cargo/packs.dm
+++ b/monkestation/code/modules/cargo/packs.dm
@@ -1,4 +1,104 @@
 //////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Armory //////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/datum/supply_pack/security/armory/revolver
+	name = "Revolver Single-Pack"
+	desc = "Contains one revolver, of the sort detectives are known to habitually smuggle on board.  Ammo not included."
+	cost = 1000
+	contraband = TRUE
+	small_item = TRUE
+	contains = list(/obj/item/gun/ballistic/revolver/detective)
+	crate_name = "single revolver crate"
+
+//////////////////////////////////////////////////////////////////////////////
+/////////////////////// Canisters & Materials ////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/datum/supply_pack/materials/randommaterials
+	name = "Contracted Materials"
+	desc = "No miners? We'll contract the work and send you the materials! Contains random processed materials, good luck!"
+	cost = 3000
+	contains = list()
+	crate_name = "contracted materials crate"
+
+/datum/supply_pack/materials/randommaterials/fill(obj/structure/closet/crate/C)
+	for(var/i in 1 to 5)
+		var/item = pick(
+			prob(200);
+				/obj/item/stack/sheet/iron/fifty,
+			prob(100);
+				/obj/item/stack/sheet/glass/fifty,
+			prob(50);
+				/obj/item/stack/sheet/plastic/fifty,
+			prob(50);
+				/obj/item/stack/sheet/mineral/copper/twenty,
+			prob(50);
+				/obj/item/stack/sheet/mineral/plasma/twenty,
+			prob(20);
+				/obj/item/stack/sheet/plasteel/twenty,
+			prob(20);
+				/obj/item/stack/sheet/mineral/titanium/twenty,
+			prob(10);
+				/obj/item/stack/sheet/mineral/silver/twenty,
+			prob(10);
+				/obj/item/stack/sheet/mineral/gold/five,
+			prob(5);
+				/obj/item/stack/sheet/mineral/diamond/five,
+			prob(5);
+				/obj/item/stack/sheet/mineral/uranium/five,
+			prob(5);
+				/obj/item/stack/sheet/bluespace_crystal/five
+		)
+		new item(C)
+
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Medical /////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/datum/supply_pack/medical/cadaver
+	name = "Cadaver Crate"
+	desc = "We won't ask why you need it if you don't ask why it's contraband. Contents not guaranteed deceased."
+	cost = 700
+	contraband = TRUE
+	contains = list(/mob/living/carbon/human/)
+	crate_name = "cadaver freezer"
+	crate_type = /obj/structure/closet/crate/freezer
+
+/datum/supply_pack/medical/ass
+	name = "Ass Crate"
+	desc = "What's that smell? Why it's the ass crate of course! For when your coworkers have had prolific posterior pains. Contains abundant assorted asses."
+	cost = 800
+	contraband = TRUE
+	contains = list()
+	crate_name = "ass crate"
+	crate_type = /obj/structure/closet/crate/freezer
+
+/datum/supply_pack/medical/ass/fill(obj/structure/closet/crate/C)
+	for(var/i in 1 to 6)
+		var/item = pick(
+			prob(200);
+				/obj/item/organ/butt,
+			prob(20);
+				/obj/item/organ/butt/cyber,
+			prob(20);
+				/obj/item/organ/butt/iron,
+			prob(20);
+				/obj/item/organ/butt/skeletal,
+			prob(10);
+				/obj/item/organ/butt/clown,
+			prob(10);
+				/obj/item/organ/butt/plasma,
+			prob(5);
+				/obj/item/organ/butt/bluespace,
+			prob(5);
+				/obj/item/organ/butt/xeno,
+			prob(1);
+				/obj/item/organ/butt/atomic
+		)
+		new item(C)
+
+//////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Miscellaneous ///////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 /datum/supply_pack/misc/sticker_set
@@ -50,3 +150,14 @@
 	crate_name = "Experimental Cloner Crate"
 	crate_type = /obj/structure/closet/crate/medical
 	dangerous = TRUE
+
+/datum/supply_pack/misc/cratecrate
+	name = "Crate crate"
+	desc = "A crate full of crates. Why? How?"
+	cost = 2000
+	access = FALSE
+	contains = list(/obj/structure/closet/crate,
+					/obj/structure/closet/crate,
+					/obj/structure/closet/crate)
+	crate_name = "Crate Crate"
+	crate_type = /obj/structure/closet/crate


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

This adds a few new crates for cargo to play with:
Revolver (detective replacement, contraband)
Cadaver (a live braindead human, contraband)
Asses (6 random asses, with a very slim chance of special asses, contraband)
Crates (a crate full of crates, someone requested it and it's funny)
Random materials (a crate of random mining materials, heavily weighted against valuables)

## Why It's Good For The Game

More fun stuff for cargo.  A way to bypass mining for emergencies, but definitely not a good one.  A way for detectives to rearm.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

You can see a test run here of the random materials crate.  Only one crate contained anything you can't normally order.  Only 2 of them were profitable to re-sell.  I don't expect long-term balance issues and we can tweak the numbers easily.
![image](https://user-images.githubusercontent.com/31165061/224084559-f2228f13-769f-4ab8-9a8c-aa3e69f6346e.png)

</details>

## Changelog

:cl:
add: Added a few new cargo crates!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
