### PR TITLE
Emergency Shuttle Emag Rebalance

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -1,5 +1,6 @@
 #define TIME_LEFT (SSshuttle.emergency.timeLeft())
 #define ENGINES_START_TIME 100
+#define EMAG_MULTIPLIER 2 //speed at which emag reduces time, increase to reduce time more.
 #define ENGINES_STARTED (SSshuttle.emergency.mode == SHUTTLE_IGNITING)
 #define IS_DOCKED (SSshuttle.emergency.mode == SHUTTLE_DOCKED || (ENGINES_STARTED))
 #define SHUTTLE_CONSOLE_ACTION_DELAY (5 SECONDS)
@@ -25,11 +26,16 @@
 	var/list/acted_recently = list()
 	var/hijack_last_stage_increase = 0 SECONDS
 	var/hijack_stage_time = 5 SECONDS
-	var/hijack_stage_cooldown = 5 SECONDS
+	var/hijack_stage_cooldown = 2 SECONDS
 	var/hijack_flight_time_increase = 30 SECONDS
 	var/hijack_completion_flight_time_set = 10 SECONDS	//How long in deciseconds to set shuttle's timer after hijack is done.
 	var/hijack_hacking = FALSE
 	var/hijack_announce = TRUE
+
+	var/emag_cooldown = 5 SECONDS
+	var/emag_last_used = 0 //no spamming the emag ya dingus
+	var/emag_attempts = 0
+	var/emag_required_attempts = 0
 
 /obj/machinery/computer/emergency_shuttle/examine(mob/user)
 	. = ..()
@@ -176,13 +182,24 @@
 		return .
 
 	// Check to see if we've reached criteria for early launch
-	if((authorized.len >= auth_need) || (obj_flags & EMAGGED))
-		// shuttle timers use 1/10th seconds internally
-		SSshuttle.emergency.setTimer(ENGINES_START_TIME)
-		var/system_error = obj_flags & EMAGGED ? "SYSTEM ERROR:" : null
+	if(obj_flags & EMAGGED) //Check for emagging first because we want the silly console authorizations
+		if(emag_attempts <= emag_required_attempts)
+			return
+		var/current_time = TIME_LEFT
+		SSshuttle.emergency.setTimer(current_time / EMAG_MULTIPLIER * 10)
 		minor_announce("The emergency shuttle will launch in \
-			[TIME_LEFT] seconds", system_error, alert=TRUE)
+			[TIME_LEFT] seconds", "SYSTEM ERROR:", alert=TRUE)
+		emag_required_attempts++
 		. = TRUE
+
+	else if(authorized.len >= auth_need)
+		SSshuttle.emergency.setTimer(ENGINES_START_TIME) //A proper authorization would give the okay to get the hell outta there
+		minor_announce("The emergency shuttle will launch in \
+			[TIME_LEFT] seconds", "Emergency timer authorized", alert=TRUE)
+		. = TRUE
+
+
+
 
 /obj/machinery/computer/emergency_shuttle/proc/increase_hijack_stage()
 	var/obj/docking_port/mobile/emergency/shuttle = SSshuttle.emergency
@@ -216,7 +233,7 @@
 	if(SSshuttle.emergency.hijack_status >= HIJACKED)
 		to_chat(user, "<span class='warning'>The emergency shuttle is already loaded with a corrupt navigational payload. What more do you want from it?</span>")
 		return
-	if(hijack_last_stage_increase >= world.time + hijack_stage_cooldown)
+	if(hijack_last_stage_increase <= world.time + hijack_stage_cooldown)
 		say("Error - Catastrophic software error detected. Input is currently on timeout.")
 		return
 	hijack_hacking = TRUE
@@ -255,15 +272,27 @@
 	minor_announce(scramble_message_replace_chars(msg, replaceprob = 10), "Emergency Shuttle", TRUE)
 
 /obj/machinery/computer/emergency_shuttle/emag_act(mob/user)
+	var/time = TIME_LEFT
 	// How did you even get on the shuttle before it go to the station?
 	if(!IS_DOCKED)
+		to_chat(user, "<span class='warning'>The shuttle is already in transit!</span>")
 		return
 
-	if((obj_flags & EMAGGED) || ENGINES_STARTED)	//SYSTEM ERROR: THE SHUTTLE WILL LA-SYSTEM ERROR: THE SHUTTLE WILL LA-SYSTEM ERROR: THE SHUTTLE WILL LAUNCH IN 10 SECONDS
+	if(ENGINES_STARTED)	//SYSTEM ERROR: THE SHUTTLE WILL LA-SYSTEM ERROR: THE SHUTTLE WILL LA-SYSTEM ERROR: THE SHUTTLE WILL LAUNCH IN 10 SECONDS
 		to_chat(user, "<span class='warning'>The shuttle is already launching!</span>")
 		return
 
-	var/time = TIME_LEFT
+	if((obj_flags & EMAGGED))
+		if(emag_last_used <= world.time + emag_cooldown) //if emagging is on cooldown
+			say("Error - Catastrophic software error detected. Input is currently on timeout.")
+			return
+
+		emag_attempts++
+		emag_last_used = world.time
+		message_admins("[ADMIN_LOOKUPFLW(user.client)] has emagged the emergency shuttle [emag_attempts] times, [time] seconds before launch.")
+		log_game("[key_name(user)] has emagged the emergency shuttle in [COORD(src)] [time] seconds before launch.  This has occurred [emag_attempts] times.")
+		return
+
 	message_admins("[ADMIN_LOOKUPFLW(user.client)] has emagged the emergency shuttle, [time] seconds before launch.")
 	log_game("[key_name(user)] has emagged the emergency shuttle in [COORD(src)] [time] seconds before launch.")
 
@@ -280,6 +309,8 @@
 
 		authorized += ID
 
+	emag_last_used = world.time
+	emag_attempts++
 	process(SSMACHINES_DT)
 
 /obj/machinery/computer/emergency_shuttle/Destroy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Reworks shuttle emagging so that instead of it reducing the time left to 10 seconds, it will halve the remaining time each usage.  You can keep halving the remaining time until it has reached 10 seconds, the emag effect has a 2 second cooldown.

While reworking this I also noticed that hijacking was not working as intended; there was supposed to be a cooldown between attempts at increasing hijack stages, but was not implemented correctly.  While this does fix that, I feel that 5 seconds may be too big of a nerf from being able to spam it, so as a slight compromise, it'll be 2 seconds, just like the emag.  

I'd be happy to adjust these numbers for balance reasons as well.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This was requested by Zanden a while ago, and while emags are a great and powerful traitor item, a single silly click of a button probably shouldn't have such a powerful effect on the emergency shuttle.  

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:

balance: Emagging the emergency shuttle now halves remaining timer.  You can further reduce the timer by using the emag again (every 2 seconds).
fix: Hijacking stage increases now properly have a cooldown (2 seconds).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
