### PR TITLE
Botany Rolling Papers, Please

### DIFF
--- a/monkestation/code/modules/research/designs/biogenerator_designs.dm
+++ b/monkestation/code/modules/research/designs/biogenerator_designs.dm
@@ -110,6 +110,14 @@
 	build_path = /obj/item/paper_bin/construction
 	category = list("initial","Organic Materials")
 
+/datum/design/rollingpapers // Why couldn't botanists make their own papers!?
+	name = "Rolling Paper Pack"
+	id = "rollingpapers"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 1000)
+	build_path = /obj/item/storage/fancy/rollingpapers
+	category = list("initial","Organic Materials")
+
 /datum/design/cloth
 	category = list("tier_three","Organic Materials")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds rolling papers to the initial biogenerator design list, simple. For a department capable of making paper in a multitude of forms AND weed, it's surprising this wasn't added sooner.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

Rolling papers are obtainable through cigarette vendors, but without the aid of cargo purchasing restocking kits, there is a finite amount available. For the intrepid botanist keen on getting ~~themselves~~ the crew as high as possible, having a renewable source of rolling papers is key. It also makes sense for them to have, seeing as they can already print paper bins, cardboard, and books.

## Changelog

:cl:
add: Added rolling papers to the initial biogen list
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
