### PR TITLE
Removes Ghosts not being able to use OOC in preround

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -16,9 +16,6 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 		if(!GLOB.ooc_allowed)
 			to_chat(src, "<span class='danger'>OOC is globally muted.</span>")
 			return
-		if(SSticker.current_state < GAME_STATE_PLAYING && !istype(mob, /mob/dead/new_player))
-			to_chat(src, "<span class='danger'>Observers cannot use OOC pre-game.</span>")
-			return
 		if(mob.stat == DEAD && !GLOB.dooc_allowed)
 			to_chat(usr, "<span class='danger'>OOC for dead mobs has been turned off.</span>")
 			return


### PR DESCRIPTION
# About The Pull Request
Removes the ghosts inability to use OOC before a round starts

## Why It's Good For The Game
If someone is gonna ICK OCK, they're not doing it before the round starts, and if they wanted to ICK OCK about station status, they're just gonna do it after the round starts anyway.

## Testing Photographs and Procedure

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

## Changelog

:cl: bluecat
del: The Inability for ghosts to not be able to send messages in OOC before a round starts
/:cl:
