### PR TITLE
The anime trait now warns you that your food preferences will change

### DIFF
--- a/monkestation/code/datums/traits/neutral.dm
+++ b/monkestation/code/datums/traits/neutral.dm
@@ -16,7 +16,7 @@
 
 /datum/quirk/anime
 	name = "Anime"
-	desc = "You are an anime enjoyer! Show your enthusiasm with some fashionable attire."
+	desc = "You are an anime enjoyer! These fashionable bodymods are extensive enough to even change your food preferences!"
 	mob_trait = TRAIT_ANIME
 	value = 0
 

--- a/monkestation/code/game/objects/items/anime.dm
+++ b/monkestation/code/game/objects/items/anime.dm
@@ -137,6 +137,7 @@
 		weeb.add_splatter_floor(location)
 		var/msg = "<span class=danger>You feel the power of God and Anime flow through you!</span>"
 		to_chat(weeb, msg)
+		to_chat(weeb, "<span class=danger>Through the power of Anime, your food preferences now match your new form!</span>")
 		playsound(location, 'sound/weapons/circsawhit.ogg', 50, 1)
 		weeb.update_body()
 		weeb.update_hair()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

A suggestion from Kumi!  A number of people have wound up confused by the fact that the anime implant changes your food preferences, often in a rather harsh manner.  This adds a couple warnings just to try to give people a heads up that something's going on.

Ideally there will eventually be a more robust system for telling if a food is good to eat or not, but that would be a PR with a much larger scope.

## Why It's Good For The Game

Fewer confused newbies, more clarity of mechanics.

## Changelog

:cl:
add: The anime trait now warns you that your food preferences will change
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
